### PR TITLE
fix: LVGL 长文本自动滚动到底后停止，不再跳回顶部

### DIFF
--- a/firmware/src/bb_lvgl_display.c
+++ b/firmware/src/bb_lvgl_display.c
@@ -628,7 +628,11 @@ static void auto_scroll_step_ctx(ui_auto_scroll_ctx_t* ctx) {
       if (y < max_y) lv_obj_scroll_to_y(ctx->cont, max_y, LV_ANIM_OFF);
       if (ctx->wait_ticks > 0) ctx->wait_ticks--;
       else if (s_tts_playing) ctx->wait_ticks = UI_AUTO_SCROLL_BOTTOM_HOLD_TICKS;
-      else auto_scroll_ctx_reset(ctx);
+      else {
+        // 不重置回顶部，保持在底部
+        ctx->phase = UI_AUTO_SCROLL_HOLD_BOTTOM;
+        ctx->wait_ticks = UI_AUTO_SCROLL_BOTTOM_HOLD_TICKS;
+      }
       break;
     case UI_AUTO_SCROLL_RUNNING:
     default:


### PR DESCRIPTION
## Summary

修复 LVGL 长文本显示跳动问题：自动滚动到底部后保持停留，不再重置回顶部。

## Changes

- `firmware/src/bb_lvgl_display.c`: 修改 `auto_scroll_step_ctx()` 中 `UI_AUTO_SCROLL_HOLD_BOTTOM` case 的逻辑，wait_ticks 耗尽后不再调用 `auto_scroll_ctx_reset()`，改为保持在底部状态

## Test plan

- [ ] 在搭载 ST7789 屏的设备上测试长文本滚动
- [ ] 确认滚动到底部后文本保持稳定，不再跳回顶部
- [ ] 确认 TTS 播放期间滚动行为正常

Fixes #6

---
🤖 Created by [ClawFlow](https://github.com/zhoushoujianwork/clawflow) — automated issue → fix → PR pipeline