### PR TITLE
feat(firmware): Settings session row + per-driver NVS persistence (S2)

### DIFF
--- a/firmware/include/bb_agent_client.h
+++ b/firmware/include/bb_agent_client.h
@@ -43,6 +43,13 @@ typedef struct {
   int streaming;
 } bb_agent_driver_info_t;
 
+typedef struct {
+  char id[64];
+  char preview[24];
+  int message_count;
+  int64_t last_used_ms;
+} bb_agent_session_info_t;
+
 /**
  * 列出 adapter 上可用 driver。
  *
@@ -52,6 +59,17 @@ typedef struct {
  * @return ESP_OK / 错误码。
  */
 esp_err_t bb_agent_list_drivers(bb_agent_driver_info_t* out_list, int cap, int* out_count);
+
+/**
+ * 列出指定 driver 的 session 列表（Phase S2）。
+ *
+ * @param driver_name  Driver 名称（必填）
+ * @param out_list     调用方提供的数组；可为 NULL（仅查总数）
+ * @param cap          out_list 容量；out_list 为 NULL 时忽略
+ * @param out_count    实际可用 session 总数（不受 cap 限制）
+ * @return ESP_OK / 错误码
+ */
+esp_err_t bb_agent_list_sessions(const char* driver_name, bb_agent_session_info_t* out_list, int cap, int* out_count);
 
 /**
  * 发一条用户消息并流式读取 NDJSON 事件，阻塞直到 turn_end / error / HTTP 关闭。

--- a/firmware/include/bb_session_store.h
+++ b/firmware/include/bb_session_store.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "esp_err.h"
+
+/**
+ * bb_session_store — per-driver session ID persistence (Phase S2)
+ *
+ * NVS namespace "bbclaw" keys:
+ *   s/cc → claude-code session ID
+ *   s/oc → opencode session ID
+ *   s/op → openclaw session ID
+ *   s/ol → ollama session ID
+ *
+ * Uses deferred persist pattern (commit f33e232) to avoid NVS writes under
+ * LVGL lock, which can cause device restarts due to flash IO contention.
+ */
+
+/**
+ * Load the last-used session ID for the given driver.
+ *
+ * @param driver_name  Driver name (e.g., "claude-code", "opencode")
+ * @param out_sid      Output buffer for session ID
+ * @param sz           Buffer size (recommend 64 bytes)
+ * @return ESP_OK on success, ESP_ERR_NOT_FOUND if no stored session,
+ *         ESP_ERR_INVALID_ARG if driver unknown or params invalid
+ */
+esp_err_t bb_session_store_load(const char* driver_name, char* out_sid, size_t sz);
+
+/**
+ * Save the current session ID for the given driver (deferred write).
+ *
+ * Spawns a background task to write to NVS, avoiding flash IO under LVGL lock.
+ *
+ * @param driver_name  Driver name
+ * @param session_id   Session ID to persist (empty string clears the entry)
+ * @return ESP_OK if task spawned, error code otherwise
+ */
+esp_err_t bb_session_store_save(const char* driver_name, const char* session_id);

--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(_bb_srcs
     "bb_ota.c"
     "bb_ptt.c"
     "bb_radio_app.c"
+    "bb_session_store.c"
     "bb_theme_text_only.c"
     "bb_theme_buddy_ascii.c"
     "bb_theme_buddy_anim.c"

--- a/firmware/src/bb_agent_client.c
+++ b/firmware/src/bb_agent_client.c
@@ -360,6 +360,104 @@ esp_err_t bb_agent_list_drivers(bb_agent_driver_info_t* out_list, int cap, int* 
   return ESP_OK;
 }
 
+/* ── public: list sessions ── */
+
+esp_err_t bb_agent_list_sessions(const char* driver_name, bb_agent_session_info_t* out_list, int cap, int* out_count) {
+  if (driver_name == NULL || driver_name[0] == '\0') {
+    return ESP_ERR_INVALID_ARG;
+  }
+  if (out_count != NULL) {
+    *out_count = 0;
+  }
+
+  char url[320] = {0};
+  char path[128] = {0};
+  snprintf(path, sizeof(path), "/v1/agent/sessions?driver=%s&limit=6", driver_name);
+  agent_build_url(url, sizeof(url), path);
+
+  bb_http_dyn_accum_t accum = {0};
+  esp_http_client_config_t cfg;
+  bb_http_cfg_init(&cfg, url, BBCLAW_HTTP_TIMEOUT_MS, HTTP_METHOD_GET, http_event_handler_dyn, &accum);
+
+  esp_http_client_handle_t client = esp_http_client_init(&cfg);
+  if (client == NULL) {
+    return ESP_ERR_NO_MEM;
+  }
+
+  esp_err_t err = esp_http_client_perform(client);
+  int status = (err == ESP_OK) ? esp_http_client_get_status_code(client) : 0;
+  esp_http_client_cleanup(client);
+
+  if (err != ESP_OK) {
+    free(accum.buf);
+    ESP_LOGE(TAG, "list_sessions transport err=%s", esp_err_to_name(err));
+    return err;
+  }
+  if (status < 200 || status >= 300 || accum.buf == NULL) {
+    ESP_LOGE(TAG, "list_sessions http status=%d body=%.120s", status, accum.buf != NULL ? accum.buf : "(null)");
+    free(accum.buf);
+    return ESP_FAIL;
+  }
+
+  cJSON* root = cJSON_Parse(accum.buf);
+  free(accum.buf);
+  accum.buf = NULL;
+  if (root == NULL) {
+    ESP_LOGE(TAG, "list_sessions parse failed");
+    return ESP_FAIL;
+  }
+
+  const cJSON* data = cJSON_GetObjectItemCaseSensitive(root, "data");
+  const cJSON* sessions = cJSON_GetObjectItemCaseSensitive(data, "sessions");
+  if (!cJSON_IsArray(sessions)) {
+    ESP_LOGE(TAG, "list_sessions missing data.sessions[]");
+    cJSON_Delete(root);
+    return ESP_FAIL;
+  }
+
+  int total = cJSON_GetArraySize(sessions);
+  if (out_count != NULL) {
+    *out_count = total;
+  }
+  if (out_list != NULL && cap > 0) {
+    int n = total < cap ? total : cap;
+    for (int i = 0; i < n; i++) {
+      const cJSON* item = cJSON_GetArrayItem(sessions, i);
+      if (item == NULL) {
+        continue;
+      }
+      bb_agent_session_info_t* slot = &out_list[i];
+      memset(slot, 0, sizeof(*slot));
+
+      const cJSON* id = cJSON_GetObjectItemCaseSensitive(item, "id");
+      if (cJSON_IsString(id) && id->valuestring != NULL) {
+        strncpy(slot->id, id->valuestring, sizeof(slot->id) - 1);
+        slot->id[sizeof(slot->id) - 1] = '\0';
+      }
+
+      const cJSON* preview = cJSON_GetObjectItemCaseSensitive(item, "preview");
+      if (cJSON_IsString(preview) && preview->valuestring != NULL) {
+        strncpy(slot->preview, preview->valuestring, sizeof(slot->preview) - 1);
+        slot->preview[sizeof(slot->preview) - 1] = '\0';
+      }
+
+      const cJSON* msg_count = cJSON_GetObjectItemCaseSensitive(item, "messageCount");
+      if (cJSON_IsNumber(msg_count)) {
+        slot->message_count = msg_count->valueint;
+      }
+
+      const cJSON* last_used = cJSON_GetObjectItemCaseSensitive(item, "lastUsed");
+      if (cJSON_IsNumber(last_used)) {
+        slot->last_used_ms = (int64_t)last_used->valuedouble;
+      }
+    }
+  }
+
+  ESP_LOGI(TAG, "list_sessions ok driver=%s total=%d", driver_name, total);
+  cJSON_Delete(root);
+  return ESP_OK;
+}
+
 /* ── public: send message ── */
 
 esp_err_t bb_agent_send_message(const char* text, const char* session_id, const char* driver_name,

--- a/firmware/src/bb_session_store.c
+++ b/firmware/src/bb_session_store.c
@@ -1,0 +1,153 @@
+#include "bb_session_store.h"
+
+#include <string.h>
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+
+static const char* TAG = "bb_session_store";
+
+#define BB_SESSION_NVS_NS "bbclaw"
+#define BB_SESSION_PERSIST_TASK_STACK 4096
+#define BB_SESSION_PERSIST_TASK_PRIO 3
+
+/* Driver name → NVS key short prefix mapping */
+typedef struct {
+  const char* driver_name;
+  const char* nvs_key;
+} driver_key_map_t;
+
+static const driver_key_map_t s_driver_map[] = {
+  {"claude-code", "s/cc"},
+  {"opencode",    "s/oc"},
+  {"openclaw",    "s/op"},
+  {"ollama",      "s/ol"},
+};
+
+static const char* driver_to_nvs_key(const char* driver_name) {
+  if (driver_name == NULL) return NULL;
+  for (size_t i = 0; i < sizeof(s_driver_map) / sizeof(s_driver_map[0]); ++i) {
+    if (strcmp(driver_name, s_driver_map[i].driver_name) == 0) {
+      return s_driver_map[i].nvs_key;
+    }
+  }
+  return NULL;
+}
+
+esp_err_t bb_session_store_load(const char* driver_name, char* out_sid, size_t sz) {
+  if (driver_name == NULL || out_sid == NULL || sz == 0) {
+    return ESP_ERR_INVALID_ARG;
+  }
+  
+  const char* key = driver_to_nvs_key(driver_name);
+  if (key == NULL) {
+    ESP_LOGW(TAG, "load: unknown driver '%s'", driver_name);
+    return ESP_ERR_INVALID_ARG;
+  }
+  
+  out_sid[0] = '\0';
+  nvs_handle_t h;
+  esp_err_t err = nvs_open(BB_SESSION_NVS_NS, NVS_READONLY, &h);
+  if (err != ESP_OK) {
+    return err;
+  }
+  
+  err = nvs_get_str(h, key, out_sid, &sz);
+  nvs_close(h);
+  
+  if (err == ESP_OK) {
+    ESP_LOGI(TAG, "load: driver='%s' sid='%s'", driver_name, out_sid);
+  } else if (err == ESP_ERR_NVS_NOT_FOUND) {
+    ESP_LOGD(TAG, "load: driver='%s' no stored session", driver_name);
+  }
+  
+  return err;
+}
+
+/* Deferred persist task payload */
+typedef struct {
+  char driver_name[24];
+  char session_id[64];
+} persist_payload_t;
+
+static void persist_task(void* arg) {
+  persist_payload_t* p = (persist_payload_t*)arg;
+  if (p == NULL) {
+    vTaskDelete(NULL);
+    return;
+  }
+  
+  const char* key = driver_to_nvs_key(p->driver_name);
+  if (key == NULL) {
+    ESP_LOGW(TAG, "persist_task: unknown driver '%s'", p->driver_name);
+    free(p);
+    vTaskDelete(NULL);
+    return;
+  }
+  
+  nvs_handle_t h;
+  esp_err_t err = nvs_open(BB_SESSION_NVS_NS, NVS_READWRITE, &h);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "persist_task: nvs_open failed (%s)", esp_err_to_name(err));
+    free(p);
+    vTaskDelete(NULL);
+    return;
+  }
+  
+  if (p->session_id[0] == '\0') {
+    /* Empty session ID → erase the key */
+    err = nvs_erase_key(h, key);
+    if (err == ESP_OK || err == ESP_ERR_NVS_NOT_FOUND) {
+      err = nvs_commit(h);
+      ESP_LOGI(TAG, "persist_task: driver='%s' session cleared", p->driver_name);
+    }
+  } else {
+    err = nvs_set_str(h, key, p->session_id);
+    if (err == ESP_OK) {
+      err = nvs_commit(h);
+      ESP_LOGI(TAG, "persist_task: driver='%s' sid='%s'", p->driver_name, p->session_id);
+    }
+  }
+  
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "persist_task: write failed (%s)", esp_err_to_name(err));
+  }
+  
+  nvs_close(h);
+  free(p);
+  vTaskDelete(NULL);
+}
+
+esp_err_t bb_session_store_save(const char* driver_name, const char* session_id) {
+  if (driver_name == NULL || session_id == NULL) {
+    return ESP_ERR_INVALID_ARG;
+  }
+  
+  const char* key = driver_to_nvs_key(driver_name);
+  if (key == NULL) {
+    ESP_LOGW(TAG, "save: unknown driver '%s'", driver_name);
+    return ESP_ERR_INVALID_ARG;
+  }
+  
+  persist_payload_t* p = (persist_payload_t*)calloc(1, sizeof(*p));
+  if (p == NULL) {
+    return ESP_ERR_NO_MEM;
+  }
+  
+  strncpy(p->driver_name, driver_name, sizeof(p->driver_name) - 1);
+  strncpy(p->session_id, session_id, sizeof(p->session_id) - 1);
+  
+  TaskHandle_t t = NULL;
+  BaseType_t ok = xTaskCreate(persist_task, "session_persist",
+                              BB_SESSION_PERSIST_TASK_STACK, p,
+                              BB_SESSION_PERSIST_TASK_PRIO, &t);
+  if (ok != pdPASS) {
+    ESP_LOGE(TAG, "save: xTaskCreate failed");
+    free(p);
+    return ESP_FAIL;
+  }
+  
+  return ESP_OK;
+}

--- a/firmware/src/bb_ui_agent_chat.c
+++ b/firmware/src/bb_ui_agent_chat.c
@@ -9,6 +9,7 @@
 #include "bb_agent_theme.h"
 #include "bb_audio.h"
 #include "bb_config.h"
+#include "bb_session_store.h"
 #include "bb_time.h"
 #include "esp_err.h"
 #include "esp_log.h"
@@ -368,6 +369,13 @@ static void on_agent_event(const bb_agent_stream_event_t* evt, void* user_ctx) {
         strncpy(shortbuf, evt->session_id, 8);
         shortbuf[8] = '\0';
         post_session(shortbuf);
+
+        /* Phase S2 — save session ID to NVS for current driver */
+        if (evt->driver != NULL && evt->driver[0] != '\0') {
+          bb_session_store_save(evt->driver, evt->session_id);
+        } else if (s_chat.selected_driver[0] != '\0') {
+          bb_session_store_save(s_chat.selected_driver, evt->session_id);
+        }
       }
       if (evt->driver != NULL) {
         strncpy(s_chat.driver_name, evt->driver, sizeof(s_chat.driver_name) - 1);
@@ -994,6 +1002,16 @@ void bb_ui_agent_chat_show(lv_obj_t* parent) {
   s_chat.mode = BB_CHAT_MODE_PICKER;
   s_chat.active = 1;
   load_nvs_on_internal_stack();
+
+  /* Phase S2 — load session ID for selected driver from NVS */
+  if (s_chat.selected_driver[0] != '\0') {
+    esp_err_t err = bb_session_store_load(s_chat.selected_driver, s_chat.session_id, sizeof(s_chat.session_id));
+    if (err == ESP_OK) {
+      ESP_LOGI(TAG, "loaded session '%s' for driver '%s'", s_chat.session_id, s_chat.selected_driver);
+    } else if (err != ESP_ERR_NOT_FOUND) {
+      ESP_LOGW(TAG, "session load failed: %s", esp_err_to_name(err));
+    }
+  }
 
   /* Phase 4.2.5 — pre-warm the driver list off-LVGL so Settings entry / LEFT-
    * RIGHT cycle don't have to wait for HTTP. Cheap if cache already populated

--- a/firmware/src/bb_ui_settings.c
+++ b/firmware/src/bb_ui_settings.c
@@ -5,6 +5,7 @@
 
 #include "bb_agent_client.h"
 #include "bb_agent_theme.h"
+#include "bb_session_store.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -40,6 +41,7 @@ static const char* TAG = "bb_ui_settings";
 #define BB_SETTINGS_NVS_KEY_TTS    "agent/tts"
 #define BB_SETTINGS_DRIVER_FALLBACK "claude-code"
 #define BB_SETTINGS_DRIVER_CACHE_MAX 6
+#define BB_SETTINGS_SESSION_CACHE_MAX 6
 
 #define BB_SETTINGS_FETCH_TASK_STACK 4096
 #define BB_SETTINGS_FETCH_TASK_PRIO  4
@@ -54,14 +56,15 @@ static const char* TAG = "bb_ui_settings";
 
 /* Display is 320x172. Layout budget:
  *   header: 22 px
- *   rows  : 4 * 26 = 104 px (rows_h)
- *   total : 126 px (well under 172) */
+ *   rows  : 5 * 26 = 130 px (rows_h)
+ *   total : 152 px (well under 172) */
 #define HEADER_H 22
 #define ROW_H    26
 #define ROWS_BOX_H (ROW_H * ROW_COUNT + 6)
 
 typedef enum {
   ROW_AGENT = 0,
+  ROW_SESSION,
   ROW_THEME,
   ROW_TTS,
   ROW_BACK,
@@ -83,6 +86,13 @@ typedef struct {
   volatile int driver_fetch_pending;
   volatile uint32_t driver_fetch_generation;
 
+  /* Session list (populated async, per-driver). */
+  bb_agent_session_info_t session_cache[BB_SETTINGS_SESSION_CACHE_MAX];
+  int session_cache_count;
+  int session_idx;
+  volatile int session_fetch_pending;
+  volatile uint32_t session_fetch_generation;
+
   /* Theme list (in-process, sync). */
   const char* const* theme_list;
   int theme_count;
@@ -90,6 +100,7 @@ typedef struct {
 
   /* Editable values (snapshot at show; committed on click). */
   char selected_driver[24];  /* "" = adapter default */
+  char selected_session[64]; /* current session ID for selected driver */
   int  tts_enabled;          /* 1 = on */
 } settings_state_t;
 
@@ -176,6 +187,14 @@ typedef struct {
   bb_agent_driver_info_t entries[BB_SETTINGS_DRIVER_CACHE_MAX];
 } fetch_result_t;
 
+typedef struct {
+  uint32_t gen;
+  esp_err_t err;
+  int total;
+  char driver_name[24];
+  bb_agent_session_info_t entries[BB_SETTINGS_SESSION_CACHE_MAX];
+} session_fetch_result_t;
+
 static void apply_driver_idx(void) {
   int idx = 0;
   if (s_st.selected_driver[0] != '\0') {
@@ -187,6 +206,19 @@ static void apply_driver_idx(void) {
     }
   }
   s_st.driver_idx = idx;
+}
+
+static void apply_session_idx(void) {
+  int idx = 0;
+  if (s_st.selected_session[0] != '\0') {
+    for (int i = 0; i < s_st.session_cache_count; ++i) {
+      if (strcmp(s_st.session_cache[i].id, s_st.selected_session) == 0) {
+        idx = i;
+        break;
+      }
+    }
+  }
+  s_st.session_idx = idx;
 }
 
 static void apply_rows(void);  /* fwd */
@@ -251,6 +283,76 @@ static void spawn_fetch_task(void) {
   }
 }
 
+/* ── Session fetch (async pipeline) ── */
+
+static void on_session_fetch_done(void* user_data) {
+  session_fetch_result_t* r = (session_fetch_result_t*)user_data;
+  if (r == NULL) return;
+  s_st.session_fetch_pending = 0;
+  if (!s_st.active || r->gen != s_st.session_fetch_generation) {
+    /* Stale or overlay closed — drop. */
+    free(r);
+    return;
+  }
+  if (r->err != ESP_OK || r->total < 0) {
+    ESP_LOGW(TAG, "session fetch failed (%s)", esp_err_to_name(r->err));
+    s_st.session_cache_count = 0;
+  } else {
+    int total = r->total > BB_SETTINGS_SESSION_CACHE_MAX
+                  ? BB_SETTINGS_SESSION_CACHE_MAX : r->total;
+    memcpy(s_st.session_cache, r->entries, sizeof(r->entries[0]) * (size_t)total);
+    s_st.session_cache_count = total;
+    ESP_LOGI(TAG, "session fetch ok: %d for driver '%s'", total, r->driver_name);
+  }
+  apply_session_idx();
+  apply_rows();
+  free(r);
+}
+
+static void session_fetch_task(void* arg) {
+  session_fetch_result_t* r = (session_fetch_result_t*)arg;
+  if (r == NULL) {
+    s_st.session_fetch_pending = 0;
+    vTaskDelete(NULL);
+    return;
+  }
+  r->err = bb_agent_list_sessions(r->driver_name, r->entries, BB_SETTINGS_SESSION_CACHE_MAX, &r->total);
+  lv_async_call(on_session_fetch_done, r);
+  vTaskDelete(NULL);
+}
+
+static void spawn_session_fetch_task(void) {
+  if (s_st.session_fetch_pending) return;
+  if (s_st.selected_driver[0] == '\0') {
+    /* No driver selected, can't fetch sessions */
+    s_st.session_cache_count = 0;
+    return;
+  }
+
+  s_st.session_fetch_pending = 1;
+  uint32_t gen = ++s_st.session_fetch_generation;
+
+  session_fetch_result_t* r = (session_fetch_result_t*)calloc(1, sizeof(*r));
+  if (r == NULL) {
+    ESP_LOGE(TAG, "spawn_session_fetch_task: calloc failed");
+    s_st.session_fetch_pending = 0;
+    return;
+  }
+
+  r->gen = gen;
+  strncpy(r->driver_name, s_st.selected_driver, sizeof(r->driver_name) - 1);
+
+  TaskHandle_t t = NULL;
+  BaseType_t ok = xTaskCreate(session_fetch_task, "session_fetch",
+                              BB_SETTINGS_FETCH_TASK_STACK, r,
+                              BB_SETTINGS_FETCH_TASK_PRIO, &t);
+  if (ok != pdPASS) {
+    ESP_LOGE(TAG, "spawn_session_fetch_task: xTaskCreate failed");
+    s_st.session_fetch_pending = 0;
+    free(r);
+  }
+}
+
 /* ── Theme list ── */
 
 static void load_theme_list(void) {
@@ -286,6 +388,17 @@ static const char* active_theme_label(void) {
   return (n != NULL && n[0] != '\0') ? n : "(unnamed)";
 }
 
+static const char* active_session_preview(void) {
+  /* Special case: index at end of list = "(new session)" sentinel */
+  if (s_st.session_idx == s_st.session_cache_count) {
+    return "(new session)";
+  }
+  if (s_st.session_cache_count <= 0) return "(none)";
+  if (s_st.session_idx < 0 || s_st.session_idx >= s_st.session_cache_count) return "(none)";
+  const char* p = s_st.session_cache[s_st.session_idx].preview;
+  return (p != NULL && p[0] != '\0') ? p : "(unnamed)";
+}
+
 static void apply_rows(void) {
   if (s_st.root == NULL) return;
   char buf[80];
@@ -305,7 +418,20 @@ static void apply_rows(void) {
     lv_label_set_text(s_st.rows[ROW_AGENT], buf);
   }
 
-  /* Row 1: Theme */
+  /* Row 1: Session */
+  if (s_st.rows[ROW_SESSION] != NULL) {
+    if (s_st.session_fetch_pending) {
+      snprintf(buf, sizeof(buf), "Session: loading...");
+    } else {
+      /* Total includes the "(new session)" sentinel */
+      int total = s_st.session_cache_count + 1;
+      snprintf(buf, sizeof(buf), "Session: %s (%d/%d)", active_session_preview(),
+               s_st.session_idx + 1, total);
+    }
+    lv_label_set_text(s_st.rows[ROW_SESSION], buf);
+  }
+
+  /* Row 2: Theme */
   if (s_st.rows[ROW_THEME] != NULL) {
     if (s_st.theme_count > 1) {
       snprintf(buf, sizeof(buf), "Theme: %s (%d/%d)", active_theme_label(),
@@ -316,13 +442,13 @@ static void apply_rows(void) {
     lv_label_set_text(s_st.rows[ROW_THEME], buf);
   }
 
-  /* Row 2: TTS */
+  /* Row 3: TTS */
   if (s_st.rows[ROW_TTS] != NULL) {
     snprintf(buf, sizeof(buf), "TTS reply: %s", s_st.tts_enabled ? "On" : "Off");
     lv_label_set_text(s_st.rows[ROW_TTS], buf);
   }
 
-  /* Row 3: Back */
+  /* Row 4: Back */
   if (s_st.rows[ROW_BACK] != NULL) {
     lv_label_set_text(s_st.rows[ROW_BACK], "Back");
   }
@@ -358,12 +484,26 @@ void bb_ui_settings_show(lv_obj_t* parent) {
   load_selected_driver_from_nvs();
   load_tts_enabled_from_nvs();
   load_theme_list();
+
+  /* Load current session for selected driver from NVS */
+  s_st.selected_session[0] = '\0';
+  if (s_st.selected_driver[0] != '\0') {
+    esp_err_t err = bb_session_store_load(s_st.selected_driver, s_st.selected_session, sizeof(s_st.selected_session));
+    if (err == ESP_OK) {
+      ESP_LOGI(TAG, "loaded session '%s' for driver '%s'", s_st.selected_session, s_st.selected_driver);
+    }
+  }
+
   /* Reset driver cache so async fetch repopulates each time settings opens.
    * (Stale data is unlikely to bite given driver list rarely changes, but
    * fresh fetch keeps "is openclaw still online?" honest.) */
   s_st.driver_cache_count = 0;
   s_st.driver_cache_offline = 0;
   s_st.driver_idx = 0;
+
+  /* Reset session cache */
+  s_st.session_cache_count = 0;
+  s_st.session_idx = 0;
 
   s_st.root = lv_obj_create(parent);
   lv_obj_remove_style_all(s_st.root);
@@ -411,10 +551,12 @@ void bb_ui_settings_show(lv_obj_t* parent) {
 
   /* Kick off async driver fetch — apply_rows will re-render when done. */
   spawn_fetch_task();
+  /* Kick off async session fetch for current driver */
+  spawn_session_fetch_task();
   apply_rows();
 
-  ESP_LOGI(TAG, "show (themes=%d, driver_pref='%s', tts=%d)",
-           s_st.theme_count, s_st.selected_driver, s_st.tts_enabled);
+  ESP_LOGI(TAG, "show (themes=%d, driver_pref='%s', session='%s', tts=%d)",
+           s_st.theme_count, s_st.selected_driver, s_st.selected_session, s_st.tts_enabled);
 }
 
 void bb_ui_settings_hide(void) {
@@ -422,6 +564,7 @@ void bb_ui_settings_hide(void) {
   s_st.active = 0;
   /* Bump generation so any in-flight fetch result is dropped. */
   s_st.driver_fetch_generation++;
+  s_st.session_fetch_generation++;
   if (s_st.root != NULL) {
     lv_obj_del(s_st.root);
     s_st.root = NULL;
@@ -462,6 +605,14 @@ void bb_ui_settings_handle_value(int delta) {
       s_st.driver_idx = next;
       break;
     }
+    case ROW_SESSION: {
+      /* Total includes the "(new session)" sentinel at the end */
+      int total = s_st.session_cache_count + 1;
+      if (total <= 1) return;
+      int next = ((s_st.session_idx + delta) % total + total) % total;
+      s_st.session_idx = next;
+      break;
+    }
     case ROW_THEME: {
       if (s_st.theme_count <= 1) return;
       int n = s_st.theme_count;
@@ -488,19 +639,68 @@ void bb_ui_settings_handle_click(void) {
   switch ((settings_row_t)s_st.sel) {
     case ROW_AGENT: {
       if (s_st.driver_cache_count <= 0) {
+        s_st.sel = ROW_SESSION;
+        apply_rows();
+        return;
+      }
+      const char* old_driver = s_st.selected_driver;
+      const char* new_driver = s_st.driver_cache[s_st.driver_idx].name;
+      if (new_driver == NULL || new_driver[0] == '\0') return;
+
+      /* Save current session to old driver's NVS key before switching */
+      if (old_driver[0] != '\0' && s_st.selected_session[0] != '\0') {
+        bb_session_store_save(old_driver, s_st.selected_session);
+      }
+
+      /* Persist new driver selection */
+      esp_err_t err = persist_selected_driver(new_driver);
+      if (err != ESP_OK) {
+        ESP_LOGW(TAG, "persist driver '%s' failed (%s)", new_driver, esp_err_to_name(err));
+      }
+      strncpy(s_st.selected_driver, new_driver, sizeof(s_st.selected_driver) - 1);
+      s_st.selected_driver[sizeof(s_st.selected_driver) - 1] = '\0';
+
+      /* Load new driver's session from NVS */
+      s_st.selected_session[0] = '\0';
+      err = bb_session_store_load(new_driver, s_st.selected_session, sizeof(s_st.selected_session));
+      if (err == ESP_OK) {
+        ESP_LOGI(TAG, "loaded session '%s' for new driver '%s'", s_st.selected_session, new_driver);
+      }
+
+      /* Reset and refetch session list for new driver */
+      s_st.session_cache_count = 0;
+      s_st.session_idx = 0;
+      spawn_session_fetch_task();
+
+      ESP_LOGI(TAG, "driver -> '%s' (committed)", new_driver);
+      s_st.sel = ROW_SESSION;
+      apply_rows();
+      break;
+    }
+    case ROW_SESSION: {
+      /* Commit selected session to NVS */
+      if (s_st.selected_driver[0] == '\0') {
         s_st.sel = ROW_THEME;
         apply_rows();
         return;
       }
-      const char* name = s_st.driver_cache[s_st.driver_idx].name;
-      if (name == NULL || name[0] == '\0') return;
-      esp_err_t err = persist_selected_driver(name);
-      if (err != ESP_OK) {
-        ESP_LOGW(TAG, "persist driver '%s' failed (%s)", name, esp_err_to_name(err));
+
+      /* If user selected "(new session)" sentinel, clear the session ID */
+      if (s_st.session_idx == s_st.session_cache_count) {
+        s_st.selected_session[0] = '\0';
+        ESP_LOGI(TAG, "session -> (new) for driver '%s'", s_st.selected_driver);
+      } else if (s_st.session_idx >= 0 && s_st.session_idx < s_st.session_cache_count) {
+        const char* sid = s_st.session_cache[s_st.session_idx].id;
+        if (sid != NULL && sid[0] != '\0') {
+          strncpy(s_st.selected_session, sid, sizeof(s_st.selected_session) - 1);
+          s_st.selected_session[sizeof(s_st.selected_session) - 1] = '\0';
+          ESP_LOGI(TAG, "session -> '%s' for driver '%s'", sid, s_st.selected_driver);
+        }
       }
-      strncpy(s_st.selected_driver, name, sizeof(s_st.selected_driver) - 1);
-      s_st.selected_driver[sizeof(s_st.selected_driver) - 1] = '\0';
-      ESP_LOGI(TAG, "driver -> '%s' (committed)", name);
+
+      /* Save to NVS (deferred) */
+      bb_session_store_save(s_st.selected_driver, s_st.selected_session);
+
       s_st.sel = ROW_THEME;
       apply_rows();
       break;


### PR DESCRIPTION
Fixes #9

## Summary

Implements session-level configuration UI and per-driver session persistence for the firmware, enabling users to navigate and select sessions per driver via LEFT/RIGHT keys in the Settings overlay.

## Changes

### New Module: bb_session_store
- **bb_session_store.{h,c}**: NVS per-driver session ID persistence with deferred write pattern
- Avoids flash IO under LVGL lock (prevents device restarts due to cache contention)
- Driver → NVS key mapping: claude-code→s/cc, opencode→s/oc, openclaw→s/op, ollama→s/ol

### Extended Agent Client API
- **bb_agent_client.h**: Added `bb_agent_session_info_t` struct and `bb_agent_list_sessions()` function
- **bb_agent_client.c**: Implements GET /v1/agent/sessions?driver=<name>&limit=6 with JSON parsing

### Settings UI Enhancement
- **bb_ui_settings.c**: Added ROW_SESSION between ROW_AGENT and ROW_THEME (5 rows total)
- Layout: 5 × 26px = 130px + header 22px = 152px < 172px ✓
- LEFT/RIGHT cycles through session list + '(new session)' sentinel at end
- OK commits selected session to NVS via bb_session_store_save()
- Driver switching: Saves current session to old driver's NVS key, loads new driver's session, triggers async session list refetch

### Chat Integration
- **bb_ui_agent_chat.c**: Loads session ID from NVS on show (bb_ui_agent_chat_show)
- Saves session ID to NVS on SESSION frame receipt (on_agent_event)
- Session persistence survives driver switches and device reboots

## NVS Schema

Namespace: `bbclaw`

| Key | Value |
|-----|-------|
| s/cc | claude-code session ID |
| s/oc | opencode session ID |
| s/op | openclaw session ID |
| s/ol | ollama session ID |

## Testing Notes

- Requires adapter #10 to be deployed for real session list data
- Can be tested with mock data by temporarily hardcoding session list in spawn_session_fetch_task
- All NVS writes are deferred to background tasks to avoid flash IO contention

## Files Changed

- `firmware/include/bb_agent_client.h`: Added session API
- `firmware/include/bb_session_store.h`: New module header
- `firmware/src/bb_agent_client.c`: Implemented bb_agent_list_sessions()
- `firmware/src/bb_session_store.c`: New module implementation
- `firmware/src/bb_ui_agent_chat.c`: Session load/save integration
- `firmware/src/bb_ui_settings.c`: Session row UI + input handlers
- `firmware/src/CMakeLists.txt`: Added bb_session_store.c to build