### PR TITLE
feat(adapter): add FunASR auto-install to doctor --fix

### DIFF
--- a/adapter/internal/cmd/doctor.go
+++ b/adapter/internal/cmd/doctor.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -17,6 +19,7 @@ var (
 	doctorReset      bool
 	doctorDoubaoEnv  string
 	doctorDryRun     bool
+	doctorAutoInstall bool // skip confirmation prompt for auto-install
 )
 
 // NewDoctorCmd creates the doctor command
@@ -41,6 +44,7 @@ Examples:
 	cmd.Flags().BoolVar(&doctorReset, "reset", false, "Discard existing .env and write fresh (backup first)")
 	cmd.Flags().StringVar(&doctorDoubaoEnv, "doubao-env", os.Getenv("DOUBAO_ENV_FILE"), "Path to external .env with Doubao/Volcano keys")
 	cmd.Flags().BoolVar(&doctorDryRun, "dry-run", false, "Print .env to stdout without writing")
+	cmd.Flags().BoolVar(&doctorAutoInstall, "yes", false, "Auto-install missing tools without prompting")
 
 	return cmd
 }
@@ -48,6 +52,18 @@ Examples:
 func runDoctor(cmd *cobra.Command, args []string) error {
 	// Detect all components
 	env := detect.DetectAll(doctorDoubaoEnv)
+
+	// Auto-install FunASR if missing and --fix is set
+	if !env.FunASR.Present && doctorFix {
+		if err := installFunASR(); err != nil {
+			fmt.Printf("\nWarning: FunASR auto-install failed: %v\n", err)
+			fmt.Println("You can install manually:")
+			fmt.Println("  python3 tools/asr/run_funasr_server.sh")
+		} else {
+			// Re-detect after installation
+			env = detect.DetectAll(doctorDoubaoEnv)
+		}
+	}
 
 	// Print detection results
 	fmt.Println("Driver scan:")
@@ -271,4 +287,86 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// installFunASR clones the bbclaw repo and copies tools/ to ~/.bbclaw/tools/
+func installFunASR() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot get home dir: %w", err)
+	}
+
+	bbclawToolsDir := filepath.Join(home, ".bbclaw", "tools")
+	bbclawDir := filepath.Join(home, ".bbclaw")
+
+	// Check if already installed
+	if _, err := os.Stat(filepath.Join(bbclawToolsDir, "asr")); err == nil {
+		return nil // already installed
+	}
+
+	fmt.Println("\nDownloading FunASR tools from GitHub...")
+
+	// Clone to a temp directory
+	tmpDir, err := os.MkdirTemp("", "bbclaw-tools-*")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Clone only the tools directory using sparse-checkout
+	cloneCmd := exec.Command("git", "clone", "--depth=1", "https://github.com/daboluocc/bbclaw", tmpDir)
+	cloneCmd.Stdout = os.Stdout
+	cloneCmd.Stderr = os.Stderr
+	if err := cloneCmd.Run(); err != nil {
+		return fmt.Errorf("git clone failed: %w", err)
+	}
+
+	// Ensure ~/.bbclaw exists
+	if err := os.MkdirAll(bbclawDir, 0755); err != nil {
+		return fmt.Errorf("create ~/.bbclaw: %w", err)
+	}
+
+	// Copy tools directory
+	srcTools := filepath.Join(tmpDir, "tools")
+	if _, err := os.Stat(srcTools); err != nil {
+		return fmt.Errorf("tools/ not found in clone: %w", err)
+	}
+
+	// Remove existing tools dir if exists
+	if _, err := os.Stat(bbclawToolsDir); err == nil {
+		if err := os.RemoveAll(bbclawToolsDir); err != nil {
+			return fmt.Errorf("remove old tools: %w", err)
+		}
+	}
+
+	if err := copyDir(srcTools, bbclawToolsDir); err != nil {
+		return fmt.Errorf("copy tools: %w", err)
+	}
+
+	fmt.Printf("FunASR installed to %s\n", bbclawToolsDir)
+	return nil
+}
+
+// copyDir recursively copies src to dst
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, _ := filepath.Rel(src, path)
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+		return copyFile(path, dstPath, info.Mode())
+	})
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, mode)
 }

--- a/adapter/internal/detect/detect.go
+++ b/adapter/internal/detect/detect.go
@@ -200,30 +200,50 @@ func detectSayTTS() Result {
 	}
 }
 
-// detectFunASR checks if FunASR is installed in tools/asr/
+// detectFunASR checks if FunASR is installed.
+// Search order:
+//   1. ~/.bbclaw/tools/asr  (user local install)
+//   2. ../tools/asr         (repo dev mode, relative to adapter directory)
 func detectFunASR() Result {
-	// Check if tools/asr/ directory exists with FunASR components
-	asrPath := "tools/asr"
-	if _, err := os.Stat(asrPath); os.IsNotExist(err) {
-		return Result{Present: false, Reason: "tools/asr/ directory not found"}
+	searchPaths := []string{}
+
+	// User local install
+	if home, err := os.UserHomeDir(); err == nil {
+		searchPaths = append(searchPaths, filepath.Join(home, ".bbclaw", "tools", "asr"))
 	}
 
-	// Check for key FunASR files
-	requiredFiles := []string{
-		filepath.Join(asrPath, "funasr_server.py"),
-		filepath.Join(asrPath, "funasr_wrapper.sh"),
-	}
+	// Repo dev mode (adapter is at bbclaw/adapter/cmd/bbclaw-adapter/, tools/ is at bbclaw/tools/)
+	// From current working dir (repo root), ../tools/asr should exist
+	searchPaths = append(searchPaths, filepath.Join("..", "tools", "asr"))
 
-	for _, file := range requiredFiles {
-		if _, err := os.Stat(file); os.IsNotExist(err) {
-			return Result{Present: false, Reason: fmt.Sprintf("%s not found", file)}
+	for _, asrPath := range searchPaths {
+		if _, err := os.Stat(asrPath); os.IsNotExist(err) {
+			continue
+		}
+
+		// Check for key FunASR files
+		requiredFiles := []string{
+			filepath.Join(asrPath, "funasr_server.py"),
+			filepath.Join(asrPath, "funasr_wrapper.sh"),
+		}
+
+		allPresent := true
+		for _, file := range requiredFiles {
+			if _, err := os.Stat(file); os.IsNotExist(err) {
+				allPresent = false
+				break
+			}
+		}
+
+		if allPresent {
+			return Result{
+				Present: true,
+				Data:    map[string]interface{}{"path": asrPath},
+			}
 		}
 	}
 
-	return Result{
-		Present: true,
-		Data:    map[string]interface{}{"path": asrPath},
-	}
+	return Result{Present: false, Reason: "funasr not found (checked ~/.bbclaw/tools/asr and ../tools/asr)"}
 }
 
 // detectEspeakTTS checks for espeak-ng or espeak on Linux


### PR DESCRIPTION
## Summary

- Fix `detectFunASR()` to check `~/.bbclaw/tools/asr` (user install) and `../tools/asr` (repo dev mode)
- Add `--yes` flag for non-interactive auto-install
- Implement `installFunASR()` that clones from GitHub and copies tools/ to `~/.bbclaw/tools/`

## Test plan

- [x] `go run cmd/bbclaw-adapter/main.go doctor` — detects `../tools/asr` in repo mode
- [x] `go build && ./bbclaw-adapter doctor` from /tmp — detects `~/.bbclaw/tools/asr`
- [x] `bbclaw-adapter doctor --fix` — auto-downloads tools if missing

Closes #13