### PR TITLE
fix(firmware): send notification ACK in cloud_saas mode

### DIFF
--- a/firmware/include/bb_adapter_client.h
+++ b/firmware/include/bb_adapter_client.h
@@ -91,3 +91,6 @@ void bb_adapter_tts_audio_free(bb_tts_audio_t* audio);
 void bb_adapter_tts_chunks_free(bb_tts_chunk_t* head);
 esp_err_t bb_adapter_display_pull(bb_display_task_t* out_task);
 esp_err_t bb_adapter_display_ack(const char* task_id, const char* action_id);
+
+/* Send a raw text frame over the adapter client WebSocket (cloud_saas mode). */
+esp_err_t bb_adapter_client_send_text(const char* payload);

--- a/firmware/src/bb_adapter_client.c
+++ b/firmware/src/bb_adapter_client.c
@@ -638,6 +638,10 @@ static esp_err_t ws_send_text_message(const char* payload) {
   return sent >= 0 ? ESP_OK : ESP_FAIL;
 }
 
+esp_err_t bb_adapter_client_send_text(const char* payload) {
+  return ws_send_text_message(payload);
+}
+
 static esp_err_t ws_send_binary_message(const uint8_t* data, size_t len) {
   if (data == NULL || len == 0U) {
     return ESP_ERR_INVALID_ARG;

--- a/firmware/src/bb_notification.c
+++ b/firmware/src/bb_notification.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "bb_adapter_client.h"
 #include "bb_agent_theme.h"
 #include "bb_config.h"
 #include "bb_transport.h"
@@ -203,9 +204,17 @@ static void send_ws_ack(const char* session_id) {
     if (session_id == NULL || session_id[0] == '\0') return;
 
     if (bb_transport_is_cloud_saas()) {
-        /* cloud_saas: ACK goes through the existing cloud WS in bb_adapter_client.
-         * TODO: wire bb_adapter_client_ws_send() for ACK envelopes. */
-        ESP_LOGI(TAG, "ack via cloud WS session=%s (TODO: wire adapter_client)", session_id);
+        /* cloud_saas: send ACK through the adapter client's WS connection. */
+        char msg[192];
+        snprintf(msg, sizeof(msg),
+            "{\"type\":\"request\",\"kind\":\"session.notification.ack\","
+            "\"payload\":{\"sessionId\":\"%s\"}}", session_id);
+        esp_err_t err = bb_adapter_client_send_text(msg);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "ack: cloud WS send failed session=%s err=%d", session_id, (int)err);
+        } else {
+            ESP_LOGI(TAG, "ack: sent via cloud WS session=%s", session_id);
+        }
         return;
     }
 


### PR DESCRIPTION
Fixes #25

## What changed

In `cloud_saas` mode, `send_ws_ack()` in `bb_notification.c` was logging a TODO and returning without actually sending the notification ACK. The adapter never received ACKs, causing potential notification queue buildup.

This PR:

1. **Exposes `bb_adapter_client_send_text()`** — a public wrapper around the existing static `ws_send_text_message()` in `bb_adapter_client.c`, allowing other firmware modules to send text frames over the cloud WS connection.

2. **Wires the cloud_saas ACK path** — `send_ws_ack()` now constructs the `session.notification.ack` JSON envelope and sends it via `bb_adapter_client_send_text()` instead of early-returning.

No adapter or cloud changes needed — the protocol handler at `ws.go:162` already processes `session.notification.ack` messages correctly.

## Verification

- Adapter unit tests: all pass
- Firmware build: compiles cleanly (ESP-IDF, esp32s3 target)
- Hardware runtime test: requires physical device in cloud_saas mode (not available in CI)