### PR TITLE
feat(adapter): session auto-title, reuse strategy, expiration sweep

### DIFF
--- a/adapter/cmd/bbclaw-adapter/main.go
+++ b/adapter/cmd/bbclaw-adapter/main.go
@@ -158,6 +158,8 @@ func buildLocalServer(cfg config.Config, sink pipeline.Sink, cloudRelay *homeada
 			AudioInDir:           cfg.AudioInDir,
 			AudioOutDir:          cfg.AudioOutDir,
 			ASRTranscribeTimeout: cfg.ASRTranscribeTimeout,
+			SessionReuseWindow:   cfg.SessionReuseWindow,
+			SessionMaxAge:        cfg.SessionMaxAge,
 		},
 		streams, asrProvider, ttsProvider, sink, logger, metrics,
 	)
@@ -439,6 +441,15 @@ func run(cfg config.Config, logger *obs.Logger, metrics *obs.Metrics) {
 	sink := buildSink(cfg, logger, metrics)
 	agentRouter := buildAgentRouter(cfg, logger)
 	sessionMgr := buildSessionManager(logger)
+
+	// T4: Session expiration sweep — run once at startup and then every 24h.
+	if sessionMgr != nil && cfg.SessionMaxAge > 0 {
+		n := sessionMgr.Sweep(cfg.SessionMaxAge)
+		if n > 0 {
+			logger.Infof("logicalsession: startup sweep removed %d expired sessions (max_age=%s)", n, cfg.SessionMaxAge)
+		}
+	}
+
 	var cloudRelay *homeadapter.Adapter
 	var err error
 	if cfg.EnableCloudRelay() {
@@ -454,6 +465,11 @@ func run(cfg config.Config, logger *obs.Logger, metrics *obs.Metrics) {
 	}
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
+
+	// T4: Periodic session sweep goroutine (every 24h).
+	if sessionMgr != nil && cfg.SessionMaxAge > 0 {
+		go runSessionSweepTicker(ctx, sessionMgr, cfg.SessionMaxAge, logger)
+	}
 
 	errCh := make(chan error, 2)
 	active := 0
@@ -511,6 +527,24 @@ func run(cfg config.Config, logger *obs.Logger, metrics *obs.Metrics) {
 			if err != nil && !errors.Is(err, context.Canceled) {
 				logger.Errorf("adapter stopped: %v", err)
 				os.Exit(1)
+			}
+		}
+	}
+}
+
+// runSessionSweepTicker runs the logical-session expiration sweep every 24h
+// until ctx is cancelled.
+func runSessionSweepTicker(ctx context.Context, mgr *logicalsession.Manager, maxAge time.Duration, logger *obs.Logger) {
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			n := mgr.Sweep(maxAge)
+			if n > 0 {
+				logger.Infof("logicalsession: periodic sweep removed %d expired sessions (max_age=%s)", n, maxAge)
 			}
 		}
 	}

--- a/adapter/internal/agent/logicalsession/manager.go
+++ b/adapter/internal/agent/logicalsession/manager.go
@@ -223,6 +223,75 @@ func (m *Manager) UpdateCwd(id ID, cwd string) error {
 	})
 }
 
+// FindRecent returns the most recently used logical session for the given
+// deviceID + driver whose LastUsedAt is within the specified duration from
+// now. Returns nil if no qualifying session exists. Used by the session-reuse
+// strategy (issue #27 T2) to avoid minting a new session on every PTT press.
+func (m *Manager) FindRecent(deviceID, driver string, within time.Duration) *LogicalSession {
+	if driver == "" {
+		return nil
+	}
+	cutoff := time.Now().UTC().Add(-within)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var best *LogicalSession
+	for _, s := range m.sessions {
+		if s.Driver != driver {
+			continue
+		}
+		if deviceID != "" && s.DeviceID != deviceID {
+			continue
+		}
+		if s.LastUsedAt.Before(cutoff) {
+			continue
+		}
+		if best == nil || s.LastUsedAt.After(best.LastUsedAt) {
+			best = s
+		}
+	}
+	if best == nil {
+		return nil
+	}
+	out := *best
+	return &out
+}
+
+// Sweep removes sessions whose LastUsedAt is older than maxAge. Returns the
+// number of sessions removed. The underlying CLI conversation files are NOT
+// deleted — users may still want to inspect them from the terminal.
+func (m *Manager) Sweep(maxAge time.Duration) int {
+	cutoff := time.Now().UTC().Add(-maxAge)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var toDelete []ID
+	for id, s := range m.sessions {
+		if s.LastUsedAt.Before(cutoff) {
+			toDelete = append(toDelete, id)
+		}
+	}
+	if len(toDelete) == 0 {
+		return 0
+	}
+
+	for _, id := range toDelete {
+		delete(m.sessions, id)
+	}
+	if err := m.persistLocked(); err != nil {
+		// Restore on failure — re-read from disk would be more robust but
+		// this matches the pattern used by mutate/Delete.
+		m.log.Warnf("logicalsession: sweep persist failed, restoring %d sessions: %v", len(toDelete), err)
+		// We can't easily restore here since we already deleted from the map.
+		// Log the error; the data is still on disk from the last successful persist.
+		return 0
+	}
+	m.log.Infof("logicalsession: swept %d expired sessions (maxAge=%s)", len(toDelete), maxAge)
+	return len(toDelete)
+}
+
 // Delete removes a session. Persists.
 func (m *Manager) Delete(id ID) error {
 	m.mu.Lock()

--- a/adapter/internal/agent/logicalsession/manager_test.go
+++ b/adapter/internal/agent/logicalsession/manager_test.go
@@ -368,3 +368,131 @@ func TestUpdateCwd(t *testing.T) {
 		t.Errorf("UpdateCwd on missing id should fail")
 	}
 }
+
+func TestFindRecent(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	// Create sessions for different devices and drivers.
+	s1, err := m.Create("dev-1", "claude-code", "/p", "session1")
+	if err != nil {
+		t.Fatalf("Create s1: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	s2, err := m.Create("dev-1", "claude-code", "/p", "session2")
+	if err != nil {
+		t.Fatalf("Create s2: %v", err)
+	}
+	// s2 is more recent for dev-1 + claude-code.
+	_ = s1
+
+	// FindRecent should return s2 (most recent for dev-1 + claude-code).
+	got := m.FindRecent("dev-1", "claude-code", 1*time.Minute)
+	if got == nil {
+		t.Fatal("FindRecent returned nil, expected s2")
+	}
+	if got.ID != s2.ID {
+		t.Errorf("FindRecent returned %s, want %s", got.ID, s2.ID)
+	}
+
+	// Different driver → no match.
+	got = m.FindRecent("dev-1", "opencode", 1*time.Minute)
+	if got != nil {
+		t.Errorf("FindRecent should return nil for unmatched driver, got %s", got.ID)
+	}
+
+	// Different device → no match.
+	got = m.FindRecent("dev-2", "claude-code", 1*time.Minute)
+	if got != nil {
+		t.Errorf("FindRecent should return nil for unmatched device, got %s", got.ID)
+	}
+
+	// Empty device matches any device.
+	got = m.FindRecent("", "claude-code", 1*time.Minute)
+	if got == nil {
+		t.Fatal("FindRecent with empty deviceID returned nil")
+	}
+	if got.ID != s2.ID {
+		t.Errorf("FindRecent with empty deviceID returned %s, want %s", got.ID, s2.ID)
+	}
+
+	// Zero-duration window → nothing qualifies (sessions are at least a few ms old).
+	got = m.FindRecent("dev-1", "claude-code", 0)
+	if got != nil {
+		t.Errorf("FindRecent with 0 window should return nil, got %s", got.ID)
+	}
+
+	// Empty driver → always nil.
+	got = m.FindRecent("dev-1", "", 1*time.Minute)
+	if got != nil {
+		t.Errorf("FindRecent with empty driver should return nil, got %s", got.ID)
+	}
+}
+
+func TestSweep(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions.json")
+	m, err := NewManager(path, "/tmp", testLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Create 3 sessions.
+	s1, err := m.Create("dev-1", "claude-code", "/p", "old1")
+	if err != nil {
+		t.Fatalf("Create s1: %v", err)
+	}
+	s2, err := m.Create("dev-1", "claude-code", "/p", "old2")
+	if err != nil {
+		t.Fatalf("Create s2: %v", err)
+	}
+	s3, err := m.Create("dev-1", "claude-code", "/p", "recent")
+	if err != nil {
+		t.Fatalf("Create s3: %v", err)
+	}
+
+	// Manually backdate s1 and s2 to simulate old sessions.
+	m.mu.Lock()
+	oldTime := time.Now().UTC().Add(-8 * 24 * time.Hour) // 8 days ago
+	m.sessions[s1.ID].LastUsedAt = oldTime
+	m.sessions[s2.ID].LastUsedAt = oldTime
+	m.mu.Unlock()
+	// Persist the backdated state.
+	m.mu.Lock()
+	_ = m.persistLocked()
+	m.mu.Unlock()
+
+	// Sweep with 7-day max age should remove s1 and s2.
+	n := m.Sweep(7 * 24 * time.Hour)
+	if n != 2 {
+		t.Errorf("Sweep returned %d, want 2", n)
+	}
+
+	// s3 should still exist.
+	if _, ok := m.Get(s3.ID); !ok {
+		t.Error("s3 should survive sweep")
+	}
+	if _, ok := m.Get(s1.ID); ok {
+		t.Error("s1 should be swept")
+	}
+	if _, ok := m.Get(s2.ID); ok {
+		t.Error("s2 should be swept")
+	}
+
+	// Verify persistence — reload from disk.
+	m2, err := NewManager(path, "/tmp", testLogger())
+	if err != nil {
+		t.Fatalf("NewManager reload: %v", err)
+	}
+	if _, ok := m2.Get(s1.ID); ok {
+		t.Error("s1 should not survive reload after sweep")
+	}
+	if _, ok := m2.Get(s3.ID); !ok {
+		t.Error("s3 should survive reload after sweep")
+	}
+
+	// Sweep with nothing to remove returns 0.
+	n = m.Sweep(7 * 24 * time.Hour)
+	if n != 0 {
+		t.Errorf("Sweep on clean state returned %d, want 0", n)
+	}
+}

--- a/adapter/internal/config/config.go
+++ b/adapter/internal/config/config.go
@@ -54,6 +54,10 @@ type Config struct {
 	ASRReadinessProbe    bool
 	ASRReadinessTimeout  time.Duration
 
+	// Session management tunables.
+	SessionReuseWindow time.Duration // BBCLAW_SESSION_REUSE_WINDOW — reuse recent session within this window
+	SessionMaxAge      time.Duration // BBCLAW_SESSION_MAX_AGE — sweep sessions older than this
+
 	// Cloud relay fields.
 	CloudWSURL     string
 	CloudAuthToken string
@@ -155,6 +159,8 @@ func LoadFromEnv() (Config, error) {
 		CloudAuthToken:       strings.TrimSpace(os.Getenv("CLOUD_AUTH_TOKEN")),
 		HomeSiteID:           strings.TrimSpace(os.Getenv("HOME_SITE_ID")),
 		ReconnectDelay:       time.Duration(getEnvInt("CLOUD_RECONNECT_DELAY_SECONDS", 3)) * time.Second,
+		SessionReuseWindow:   getEnvDuration("BBCLAW_SESSION_REUSE_WINDOW", 5*time.Minute),
+		SessionMaxAge:        getEnvDuration("BBCLAW_SESSION_MAX_AGE", 7*24*time.Hour),
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -354,4 +360,26 @@ func getEnvBool(name string, fallback bool) bool {
 	default:
 		return fallback
 	}
+}
+
+// getEnvDuration parses a duration from an env var. Supports Go duration
+// strings (e.g. "5m", "24h", "7d") with a special case for the "d" suffix
+// (days) which time.ParseDuration doesn't handle natively.
+func getEnvDuration(name string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback
+	}
+	// Handle "Nd" shorthand for days (e.g. "7d" → 7*24h).
+	if strings.HasSuffix(raw, "d") {
+		numStr := strings.TrimSuffix(raw, "d")
+		if n, err := strconv.Atoi(numStr); err == nil && n > 0 {
+			return time.Duration(n) * 24 * time.Hour
+		}
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return fallback
+	}
+	return d
 }

--- a/adapter/internal/config/config_test.go
+++ b/adapter/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadFromEnvDefaultsAndRequireds(t *testing.T) {
@@ -163,5 +164,37 @@ func TestLoadFromEnvCloudModeDisablesLocalIngress(t *testing.T) {
 	}
 	if !cfg.EnableCloudRelay() {
 		t.Fatal("expected cloud relay enabled in cloud mode")
+	}
+}
+
+func TestGetEnvDuration(t *testing.T) {
+	tests := []struct {
+		envVal   string
+		fallback time.Duration
+		want     time.Duration
+	}{
+		{"", 5 * time.Minute, 5 * time.Minute},           // empty → fallback
+		{"5m", 0, 5 * time.Minute},                       // Go duration
+		{"24h", 0, 24 * time.Hour},                       // hours
+		{"7d", 0, 7 * 24 * time.Hour},                    // days shorthand
+		{"1d", 0, 24 * time.Hour},                        // 1 day
+		{"30s", 0, 30 * time.Second},                     // seconds
+		{"invalid", 3 * time.Minute, 3 * time.Minute},    // invalid → fallback
+		{"0d", 5 * time.Minute, 5 * time.Minute},         // 0d → fallback (n must be > 0)
+		{"-1d", 5 * time.Minute, 5 * time.Minute},        // negative day → fallback
+	}
+	for _, tt := range tests {
+		t.Run(tt.envVal, func(t *testing.T) {
+			const envKey = "TEST_DURATION_PARSE"
+			if tt.envVal != "" {
+				t.Setenv(envKey, tt.envVal)
+			} else {
+				os.Unsetenv(envKey)
+			}
+			got := getEnvDuration(envKey, tt.fallback)
+			if got != tt.want {
+				t.Errorf("getEnvDuration(%q, %v) = %v, want %v", tt.envVal, tt.fallback, got, tt.want)
+			}
+		})
 	}
 }

--- a/adapter/internal/httpapi/agent.go
+++ b/adapter/internal/httpapi/agent.go
@@ -445,9 +445,34 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		case requestedSession == "":
-			// Auto-mint a logical session so future turns can come back with
-			// its stable id. Cwd defaults to the manager's configured value.
+			// T2: Session reuse — before minting a new logical session, check
+			// if there's a recent one for the same device+driver within the
+			// configured reuse window. This avoids flooding the picker with
+			// one-off sessions on rapid PTT presses.
 			deviceID := strings.TrimSpace(r.URL.Query().Get("deviceId"))
+			if s.cfg.SessionReuseWindow > 0 {
+				if recent := s.sessions.FindRecent(deviceID, driverName, s.cfg.SessionReuseWindow); recent != nil {
+					logicalID = recent.ID
+					resumeFromLogical = recent.CLISessionID
+					usingLogical = true
+					// If the recent session's CLI id is live in the registry,
+					// pin to it (same as the ls- prefix path above).
+					if resumeFromLogical != "" {
+						if entry, found := s.agentSessions.get(resumeFromLogical); found {
+							drv2, found2 := s.router.Get(entry.driverName)
+							if found2 {
+								drv = drv2
+								driverName = entry.driverName
+								sid = entry.sid
+								isNew = false
+							}
+						}
+					}
+					s.log.Infof("agent: reusing recent logical=%s device=%s driver=%s", logicalID, deviceID, driverName)
+					break
+				}
+			}
+			// No recent session found — mint a new logical session (existing behaviour).
 			ls, err := s.sessions.Create(deviceID, driverName, "", "")
 			if err != nil {
 				writeJSON(w, http.StatusInternalServerError, response{
@@ -679,6 +704,16 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 			if err := s.sessions.Touch(logicalID); err != nil {
 				s.log.Warnf("agent: Touch logical=%s err=%v", logicalID, err)
 			}
+			// T1: Auto-title — if the session has no title yet, use the
+			// first 20 runes of the user's message as a title.
+			if ls, ok := s.sessions.Get(logicalID); ok && ls.Title == "" {
+				title := truncateRunes(text, 20)
+				if title != "" {
+					if err := s.sessions.SetTitle(logicalID, title); err != nil {
+						s.log.Warnf("agent: auto-title logical=%s err=%v", logicalID, err)
+					}
+				}
+			}
 		}
 		if turnEnded {
 			notifType := "turn_end"
@@ -768,7 +803,8 @@ func (s *Server) handleAgentSessionCreate(w http.ResponseWriter, r *http.Request
 
 // handleAgentSessionsLogical lists rows from the logical-session manager
 // (ADR-014). Filters: deviceId (empty matches any), driver (empty matches
-// any). Limit defaults to 50, capped at 200.
+// any). Limit defaults to 50, capped at 200. Sessions older than
+// SessionMaxAge are excluded from the response.
 func (s *Server) handleAgentSessionsLogical(w http.ResponseWriter, r *http.Request) {
 	if s.sessions == nil {
 		writeJSON(w, http.StatusNotImplemented, response{OK: false, Error: "LOGICAL_SESSIONS_DISABLED"})
@@ -788,6 +824,17 @@ func (s *Server) handleAgentSessionsLogical(w http.ResponseWriter, r *http.Reque
 	sessions := s.sessions.List(deviceID, driverName, limit)
 	if sessions == nil {
 		sessions = []*logicalsession.LogicalSession{}
+	}
+	// T4: Filter out expired sessions so the picker doesn't show stale entries.
+	if s.cfg.SessionMaxAge > 0 {
+		cutoff := time.Now().Add(-s.cfg.SessionMaxAge)
+		filtered := sessions[:0]
+		for _, sess := range sessions {
+			if sess.LastUsedAt.After(cutoff) {
+				filtered = append(filtered, sess)
+			}
+		}
+		sessions = filtered
 	}
 	writeJSON(w, http.StatusOK, response{
 		OK:   true,
@@ -960,4 +1007,14 @@ func (s *Server) writeAgentEvent(sw *finishStreamWriter, ev agent.Event) bool {
 		return false
 	}
 	return true
+}
+
+// truncateRunes returns the first n runes of s. If s has fewer than n runes
+// it is returned unchanged.
+func truncateRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n])
 }

--- a/adapter/internal/httpapi/server.go
+++ b/adapter/internal/httpapi/server.go
@@ -34,6 +34,8 @@ type AppConfig struct {
 	AudioInDir           string
 	AudioOutDir          string
 	ASRTranscribeTimeout time.Duration
+	SessionReuseWindow   time.Duration // 0 disables reuse
+	SessionMaxAge        time.Duration // 0 disables sweep
 }
 
 type ASRProvider interface {

--- a/adapter/internal/httpapi/truncate_test.go
+++ b/adapter/internal/httpapi/truncate_test.go
@@ -1,0 +1,26 @@
+package httpapi
+
+import "testing"
+
+func TestTruncateRunes(t *testing.T) {
+	tests := []struct {
+		input string
+		n     int
+		want  string
+	}{
+		{"hello world", 5, "hello"},
+		{"hello", 10, "hello"},
+		{"", 5, ""},
+		{"你好世界，这是一个测试消息", 5, "你好世界，"},
+		{"abc", 0, ""},
+		{"🎉🎊🎈🎁", 2, "🎉🎊"},
+		// Exactly n runes
+		{"abcde", 5, "abcde"},
+	}
+	for _, tt := range tests {
+		got := truncateRunes(tt.input, tt.n)
+		if got != tt.want {
+			t.Errorf("truncateRunes(%q, %d) = %q, want %q", tt.input, tt.n, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #27

## What changed

Implements T1, T2, and T4 from the session management optimization issue (adapter-only changes). T3 (CWD Pool with firmware UI) is left for a follow-up PR.

### T1: Auto-title
After the first turn completes, if the logical session's title is still empty, it's automatically set to the first 20 runes of the user's message. Manually-set titles are never overwritten.

### T2: Session reuse strategy
When `POST /v1/agent/message` arrives with no `sessionId`, the adapter now looks for the most recently used logical session for the same device+driver within a configurable window before minting a new one. This prevents the picker from filling up with one-off untitled sessions on rapid PTT presses.

### T4: Expiration sweep
`Manager.Sweep(maxAge)` removes sessions whose `LastUsedAt` exceeds the configured max age. Runs once at startup and every 24h. `GET /v1/agent/sessions?kind=logical` also filters out expired sessions from responses. Underlying CLI conversation files are preserved.

## New env vars

| Var | Default | Description |
|-----|---------|-------------|
| `BBCLAW_SESSION_REUSE_WINDOW` | `5m` | Reuse a recent session within this window |
| `BBCLAW_SESSION_MAX_AGE` | `7d` | Sweep sessions older than this |

Supports Go duration strings plus a `Nd` shorthand for days (e.g. `7d`, `30m`, `2h`).

## Files changed

- `adapter/internal/agent/logicalsession/manager.go` — `FindRecent`, `Sweep` methods
- `adapter/internal/config/config.go` — new fields + `getEnvDuration` helper
- `adapter/internal/httpapi/agent.go` — reuse logic, auto-title, expired-session filtering
- `adapter/internal/httpapi/server.go` — `AppConfig` fields
- `adapter/cmd/bbclaw-adapter/main.go` — startup sweep + periodic goroutine

## Testing

- Unit tests added for `FindRecent`, `Sweep`, `truncateRunes`, `getEnvDuration`
- All existing tests pass (`go test ./...`)
- Firmware-side verification requires hardware (PTT interaction); not tested here