### PR TITLE
feat: expose approve endpoint + session detail for Web Chat

### DIFF
--- a/adapter/internal/httpapi/agent.go
+++ b/adapter/internal/httpapi/agent.go
@@ -632,6 +632,11 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 					errorCount++
 					lastError = ev.Text
 					s.agentSessions.setState(string(sid), "error")
+					broadcastSID := string(sid)
+					if usingLogical && logicalID != "" {
+						broadcastSID = string(logicalID)
+					}
+					s.broadcastSessionStateChange(broadcastSID, "error", ev.Text)
 					if strings.HasPrefix(ev.Text, "SESSION_NOT_FOUND") {
 						sessionNotFound = true
 					}
@@ -671,6 +676,11 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 		// Final attempt: finalize state and notification, then return.
 		if !channelClosed {
 			s.agentSessions.setState(string(sid), "completed")
+			completedSID := string(sid)
+			if usingLogical && logicalID != "" {
+				completedSID = string(logicalID)
+			}
+			s.broadcastSessionStateChange(completedSID, "completed", lastText)
 		}
 		// Bump LastUsedAt on the logical session so the picker can sort by
 		// recency. Done after the turn settles (post-retry) so a transient
@@ -932,6 +942,28 @@ func (s *Server) handleAgentDeleteSession(w http.ResponseWriter, r *http.Request
 	}
 	s.log.Infof("agent: deleted session=%s driver=%s", sessionID, entry.driverName)
 	writeJSON(w, http.StatusOK, response{OK: true})
+}
+
+// broadcastSessionStateChange emits a session.state_change WebSocket event to
+// all connected clients. It is a no-op when the hub is nil (no WS clients).
+//
+// Payload shape:
+//
+//	{"type":"event","kind":"session.state_change",
+//	 "payload":{"sessionId":"ls-xxx","state":"completed","preview":"..."}}
+func (s *Server) broadcastSessionStateChange(sessionID, state, preview string) {
+	if s.wsHub == nil {
+		return
+	}
+	s.wsHub.Broadcast(map[string]any{
+		"type": "event",
+		"kind": "session.state_change",
+		"payload": map[string]any{
+			"sessionId": sessionID,
+			"state":     state,
+			"preview":   truncatePreview(preview, 48),
+		},
+	})
 }
 
 // writeAgentEvent serialises an agent.Event to the NDJSON stream.

--- a/adapter/internal/httpapi/agent_approve.go
+++ b/adapter/internal/httpapi/agent_approve.go
@@ -1,0 +1,187 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/agent/logicalsession"
+)
+
+// approveRequest is the body for POST /v1/agent/sessions/{id}/approve.
+type approveRequest struct {
+	ToolID   string `json:"toolId"`
+	Decision string `json:"decision"`
+}
+
+// handleAgentSessionApprove forwards a tool-approval decision to the driver
+// that owns the session.
+//
+//	POST /v1/agent/sessions/{id}/approve
+//	{"toolId":"<from tool_call event>","decision":"once"|"deny"}
+//	→ {"ok":true}
+//
+// Error codes:
+//   - SESSION_ID_REQUIRED  — path param missing
+//   - SESSION_NOT_FOUND    — logical or CLI session unknown
+//   - INVALID_REQUEST      — bad JSON or missing fields
+//   - TOOL_APPROVAL_NOT_SUPPORTED — driver's Capabilities.ToolApproval is false
+//   - AGENT_NOT_CONFIGURED — router not set
+func (s *Server) handleAgentSessionApprove(w http.ResponseWriter, r *http.Request) {
+	if s.router == nil || s.agentSessions == nil {
+		writeJSON(w, http.StatusNotImplemented, response{OK: false, Error: "AGENT_NOT_CONFIGURED"})
+		return
+	}
+
+	sessionID := strings.TrimSpace(r.PathValue("id"))
+	if sessionID == "" {
+		writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "SESSION_ID_REQUIRED"})
+		return
+	}
+
+	var req approveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "INVALID_REQUEST"})
+		return
+	}
+	req.ToolID = strings.TrimSpace(req.ToolID)
+	req.Decision = strings.TrimSpace(req.Decision)
+	if req.ToolID == "" || req.Decision == "" {
+		writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "INVALID_REQUEST", Detail: "toolId and decision are required"})
+		return
+	}
+
+	// Resolve logical session id → CLI session id + driver name.
+	cliSessionID := sessionID
+	driverName := ""
+
+	if s.sessions != nil && strings.HasPrefix(sessionID, "ls-") {
+		ls, ok := s.sessions.Get(logicalsession.ID(sessionID))
+		if !ok {
+			writeJSON(w, http.StatusNotFound, response{OK: false, Error: "SESSION_NOT_FOUND"})
+			return
+		}
+		if ls.CLISessionID == "" {
+			// Logical session exists but no CLI turn has happened yet — nothing
+			// to approve.
+			writeJSON(w, http.StatusNotFound, response{OK: false, Error: "SESSION_NOT_FOUND", Detail: "no active CLI session for this logical session"})
+			return
+		}
+		cliSessionID = ls.CLISessionID
+		driverName = ls.Driver
+	}
+
+	// Look up the runtime entry to confirm the session is live and to get the
+	// driver name when we didn't get it from the logical table.
+	entry, found := s.agentSessions.get(cliSessionID)
+	if !found {
+		writeJSON(w, http.StatusNotFound, response{OK: false, Error: "SESSION_NOT_FOUND"})
+		return
+	}
+	if driverName == "" {
+		driverName = entry.driverName
+	}
+
+	drv, ok := s.router.Get(driverName)
+	if !ok {
+		writeJSON(w, http.StatusInternalServerError, response{OK: false, Error: "UNKNOWN_DRIVER", Detail: driverName})
+		return
+	}
+
+	// Reject early if the driver doesn't advertise tool approval support.
+	if !drv.Capabilities().ToolApproval {
+		writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "TOOL_APPROVAL_NOT_SUPPORTED"})
+		return
+	}
+
+	decision := agent.Decision(req.Decision)
+	if decision != agent.DecisionOnce && decision != agent.DecisionDeny {
+		writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "INVALID_REQUEST", Detail: "decision must be 'once' or 'deny'"})
+		return
+	}
+
+	if err := drv.Approve(entry.sid, agent.ToolID(req.ToolID), decision); err != nil {
+		if errors.Is(err, agent.ErrUnsupported) {
+			writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "TOOL_APPROVAL_NOT_SUPPORTED"})
+			return
+		}
+		if errors.Is(err, agent.ErrUnknownSession) {
+			writeJSON(w, http.StatusNotFound, response{OK: false, Error: "SESSION_NOT_FOUND"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, response{OK: false, Error: "APPROVE_FAILED", Detail: err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response{OK: true})
+}
+
+// handleAgentSessionGet returns metadata for a single logical session.
+//
+//	GET /v1/agent/sessions/{id}
+//	→ {"ok":true,"data":{"session":{...,"state":"idle"|"running"|"completed"|"error"}}}
+//
+// The `state` field is sourced from the runtime registry (agentSessions). If
+// the adapter has restarted and the session is no longer in the registry,
+// state defaults to "idle".
+//
+// Error codes:
+//   - SESSION_ID_REQUIRED       — path param missing
+//   - NOT_LOGICAL               — id does not have ls- prefix
+//   - SESSION_NOT_FOUND         — logical session unknown
+//   - LOGICAL_SESSIONS_DISABLED — session manager not configured
+//   - AGENT_NOT_CONFIGURED      — router not set
+func (s *Server) handleAgentSessionGet(w http.ResponseWriter, r *http.Request) {
+	if s.router == nil {
+		writeJSON(w, http.StatusNotImplemented, response{OK: false, Error: "AGENT_NOT_CONFIGURED"})
+		return
+	}
+	if s.sessions == nil {
+		writeJSON(w, http.StatusNotImplemented, response{OK: false, Error: "LOGICAL_SESSIONS_DISABLED"})
+		return
+	}
+
+	sessionID := strings.TrimSpace(r.PathValue("id"))
+	if sessionID == "" {
+		writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "SESSION_ID_REQUIRED"})
+		return
+	}
+	if !strings.HasPrefix(sessionID, "ls-") {
+		writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "NOT_LOGICAL", Detail: "id must have ls- prefix"})
+		return
+	}
+
+	ls, ok := s.sessions.Get(logicalsession.ID(sessionID))
+	if !ok {
+		writeJSON(w, http.StatusNotFound, response{OK: false, Error: "SESSION_NOT_FOUND"})
+		return
+	}
+
+	// Derive runtime state from the registry. Fall back to "idle" when the
+	// adapter has restarted and the CLI session is no longer tracked.
+	state := "idle"
+	if s.agentSessions != nil && ls.CLISessionID != "" {
+		if entry, found := s.agentSessions.get(ls.CLISessionID); found {
+			state = entry.state
+		}
+	}
+
+	writeJSON(w, http.StatusOK, response{
+		OK: true,
+		Data: map[string]any{
+			"session": map[string]any{
+				"id":           string(ls.ID),
+				"deviceId":     ls.DeviceID,
+				"driver":       ls.Driver,
+				"cwd":          ls.Cwd,
+				"title":        ls.Title,
+				"createdAt":    ls.CreatedAt,
+				"lastUsedAt":   ls.LastUsedAt,
+				"cliSessionId": ls.CLISessionID,
+				"state":        state,
+			},
+		},
+	})
+}

--- a/adapter/internal/httpapi/agent_approve_test.go
+++ b/adapter/internal/httpapi/agent_approve_test.go
@@ -1,0 +1,373 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/agent/logicalsession"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
+)
+
+// mockApproveDriver is a driver that supports tool approval.
+type mockApproveDriver struct {
+	name         string
+	approveErr   error
+	approveCalls []struct {
+		sid      agent.SessionID
+		tid      agent.ToolID
+		decision agent.Decision
+	}
+}
+
+func (m *mockApproveDriver) Name() string { return m.name }
+func (m *mockApproveDriver) Capabilities() agent.Capabilities {
+	return agent.Capabilities{ToolApproval: true}
+}
+func (m *mockApproveDriver) Start(ctx context.Context, opts agent.StartOpts) (agent.SessionID, error) {
+	return agent.SessionID("cli-" + m.name), nil
+}
+func (m *mockApproveDriver) Send(sid agent.SessionID, text string) error { return nil }
+func (m *mockApproveDriver) Events(sid agent.SessionID) <-chan agent.Event {
+	ch := make(chan agent.Event)
+	close(ch)
+	return ch
+}
+func (m *mockApproveDriver) Approve(sid agent.SessionID, tid agent.ToolID, decision agent.Decision) error {
+	m.approveCalls = append(m.approveCalls, struct {
+		sid      agent.SessionID
+		tid      agent.ToolID
+		decision agent.Decision
+	}{sid, tid, decision})
+	return m.approveErr
+}
+func (m *mockApproveDriver) Stop(sid agent.SessionID) error { return nil }
+
+// mockNoApproveDriver is a driver that does NOT support tool approval.
+type mockNoApproveDriver struct{ name string }
+
+func (m *mockNoApproveDriver) Name() string { return m.name }
+func (m *mockNoApproveDriver) Capabilities() agent.Capabilities {
+	return agent.Capabilities{ToolApproval: false}
+}
+func (m *mockNoApproveDriver) Start(ctx context.Context, opts agent.StartOpts) (agent.SessionID, error) {
+	return "", nil
+}
+func (m *mockNoApproveDriver) Send(sid agent.SessionID, text string) error { return nil }
+func (m *mockNoApproveDriver) Events(sid agent.SessionID) <-chan agent.Event {
+	ch := make(chan agent.Event)
+	close(ch)
+	return ch
+}
+func (m *mockNoApproveDriver) Approve(sid agent.SessionID, tid agent.ToolID, decision agent.Decision) error {
+	return agent.ErrUnsupported
+}
+func (m *mockNoApproveDriver) Stop(sid agent.SessionID) error { return nil }
+
+// newApproveTestServer builds a server with a session registry entry ready for
+// approve tests. Returns the server, the CLI session id, and the logical session id.
+func newApproveTestServer(t *testing.T, drv agent.Driver) (*Server, string, string) {
+	t.Helper()
+	log := obs.NewLogger()
+	metrics := obs.NewMetrics()
+
+	router := agent.NewRouter()
+	router.Register(drv, log)
+
+	srv := NewServer(AppConfig{}, nil, nil, nil, nil, log, metrics)
+	srv.SetAgentRouter(router)
+
+	// Manually inject a CLI session entry into the registry.
+	cliSID := "cli-test-session"
+	srv.agentSessions.put(cliSID, &sessionEntry{
+		sid:        agent.SessionID(cliSID),
+		driverName: drv.Name(),
+		lastUsed:   time.Now(),
+		state:      "running",
+	})
+
+	// Create a logical session pointing at the CLI session.
+	dir := t.TempDir()
+	mgr, err := logicalsession.NewManager(dir+"/sessions.json", "/tmp", log)
+	if err != nil {
+		t.Fatalf("create manager: %v", err)
+	}
+	srv.SetSessionManager(mgr)
+	ls, err := mgr.Create("dev-1", drv.Name(), "/tmp", "test session")
+	if err != nil {
+		t.Fatalf("create logical session: %v", err)
+	}
+	if err := mgr.UpdateCLISessionID(ls.ID, cliSID); err != nil {
+		t.Fatalf("update cli session id: %v", err)
+	}
+
+	return srv, cliSID, string(ls.ID)
+}
+
+func postApprove(srv *Server, sessionID, toolID, decision string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(map[string]string{"toolId": toolID, "decision": decision})
+	req := httptest.NewRequest(http.MethodPost,
+		"/v1/agent/sessions/"+sessionID+"/approve",
+		bytes.NewReader(body))
+	req.SetPathValue("id", sessionID)
+	w := httptest.NewRecorder()
+	srv.handleAgentSessionApprove(w, req)
+	return w
+}
+
+func TestHandleAgentSessionApprove(t *testing.T) {
+	t.Run("success via logical session id", func(t *testing.T) {
+		drv := &mockApproveDriver{name: "approve-drv"}
+		srv, _, lsID := newApproveTestServer(t, drv)
+
+		w := postApprove(srv, lsID, "t-123", "once")
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		if !resp.OK {
+			t.Errorf("expected ok=true")
+		}
+		if len(drv.approveCalls) != 1 {
+			t.Fatalf("expected 1 approve call, got %d", len(drv.approveCalls))
+		}
+		if drv.approveCalls[0].tid != "t-123" {
+			t.Errorf("expected toolId t-123, got %s", drv.approveCalls[0].tid)
+		}
+		if drv.approveCalls[0].decision != agent.DecisionOnce {
+			t.Errorf("expected decision once, got %s", drv.approveCalls[0].decision)
+		}
+	})
+
+	t.Run("deny decision", func(t *testing.T) {
+		drv := &mockApproveDriver{name: "approve-drv2"}
+		srv, _, lsID := newApproveTestServer(t, drv)
+
+		w := postApprove(srv, lsID, "t-456", "deny")
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		if drv.approveCalls[0].decision != agent.DecisionDeny {
+			t.Errorf("expected decision deny, got %s", drv.approveCalls[0].decision)
+		}
+	})
+
+	t.Run("driver does not support tool approval", func(t *testing.T) {
+		drv := &mockNoApproveDriver{name: "no-approve-drv"}
+		srv, _, lsID := newApproveTestServer(t, drv)
+
+		w := postApprove(srv, lsID, "t-789", "once")
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		if resp.Error != "TOOL_APPROVAL_NOT_SUPPORTED" {
+			t.Errorf("expected TOOL_APPROVAL_NOT_SUPPORTED, got %s", resp.Error)
+		}
+	})
+
+	t.Run("unknown logical session returns 404", func(t *testing.T) {
+		drv := &mockApproveDriver{name: "approve-drv3"}
+		srv, _, _ := newApproveTestServer(t, drv)
+
+		w := postApprove(srv, "ls-doesnotexist", "t-1", "once")
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		if resp.Error != "SESSION_NOT_FOUND" {
+			t.Errorf("expected SESSION_NOT_FOUND, got %s", resp.Error)
+		}
+	})
+
+	t.Run("missing toolId returns 400", func(t *testing.T) {
+		drv := &mockApproveDriver{name: "approve-drv4"}
+		srv, _, lsID := newApproveTestServer(t, drv)
+
+		body := strings.NewReader(`{"decision":"once"}`)
+		req := httptest.NewRequest(http.MethodPost, "/v1/agent/sessions/"+lsID+"/approve", body)
+		req.SetPathValue("id", lsID)
+		w := httptest.NewRecorder()
+		srv.handleAgentSessionApprove(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("invalid decision value returns 400", func(t *testing.T) {
+		drv := &mockApproveDriver{name: "approve-drv5"}
+		srv, _, lsID := newApproveTestServer(t, drv)
+
+		w := postApprove(srv, lsID, "t-1", "always")
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("router not configured returns 501", func(t *testing.T) {
+		log := obs.NewLogger()
+		metrics := obs.NewMetrics()
+		srv := NewServer(AppConfig{}, nil, nil, nil, nil, log, metrics)
+
+		w := postApprove(srv, "ls-abc", "t-1", "once")
+
+		if w.Code != http.StatusNotImplemented {
+			t.Fatalf("expected 501, got %d", w.Code)
+		}
+	})
+}
+
+func TestHandleAgentSessionGet(t *testing.T) {
+	newGetTestServer := func(t *testing.T) (*Server, string) {
+		t.Helper()
+		log := obs.NewLogger()
+		metrics := obs.NewMetrics()
+		router := agent.NewRouter()
+		router.Register(&mockBasicDriver{name: "test-drv"}, log)
+		srv := NewServer(AppConfig{}, nil, nil, nil, nil, log, metrics)
+		srv.SetAgentRouter(router)
+
+		dir := t.TempDir()
+		mgr, err := logicalsession.NewManager(dir+"/sessions.json", "/tmp", log)
+		if err != nil {
+			t.Fatalf("create manager: %v", err)
+		}
+		srv.SetSessionManager(mgr)
+		ls, err := mgr.Create("dev-1", "test-drv", "/home/user/project", "My Session")
+		if err != nil {
+			t.Fatalf("create logical session: %v", err)
+		}
+		return srv, string(ls.ID)
+	}
+
+	getSession := func(srv *Server, sessionID string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/v1/agent/sessions/"+sessionID, nil)
+		req.SetPathValue("id", sessionID)
+		w := httptest.NewRecorder()
+		srv.handleAgentSessionGet(w, req)
+		return w
+	}
+
+	t.Run("returns session metadata with idle state when not in registry", func(t *testing.T) {
+		srv, lsID := newGetTestServer(t)
+
+		w := getSession(srv, lsID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		if !resp.OK {
+			t.Errorf("expected ok=true")
+		}
+		data := resp.Data.(map[string]any)
+		sess := data["session"].(map[string]any)
+		if sess["id"] != lsID {
+			t.Errorf("expected id=%s, got %v", lsID, sess["id"])
+		}
+		if sess["driver"] != "test-drv" {
+			t.Errorf("expected driver=test-drv, got %v", sess["driver"])
+		}
+		if sess["state"] != "idle" {
+			t.Errorf("expected state=idle (not in registry), got %v", sess["state"])
+		}
+		if sess["cwd"] != "/home/user/project" {
+			t.Errorf("expected cwd=/home/user/project, got %v", sess["cwd"])
+		}
+		if sess["title"] != "My Session" {
+			t.Errorf("expected title=My Session, got %v", sess["title"])
+		}
+	})
+
+	t.Run("returns running state when session is in registry", func(t *testing.T) {
+		srv, lsID := newGetTestServer(t)
+
+		// Inject a CLI session entry and link it to the logical session.
+		cliSID := "cli-running-123"
+		srv.agentSessions.put(cliSID, &sessionEntry{
+			sid:        agent.SessionID(cliSID),
+			driverName: "test-drv",
+			lastUsed:   time.Now(),
+			state:      "running",
+		})
+		srv.sessions.UpdateCLISessionID(logicalsession.ID(lsID), cliSID)
+
+		w := getSession(srv, lsID)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		data := resp.Data.(map[string]any)
+		sess := data["session"].(map[string]any)
+		if sess["state"] != "running" {
+			t.Errorf("expected state=running, got %v", sess["state"])
+		}
+		if sess["cliSessionId"] != cliSID {
+			t.Errorf("expected cliSessionId=%s, got %v", cliSID, sess["cliSessionId"])
+		}
+	})
+
+	t.Run("unknown session returns 404", func(t *testing.T) {
+		srv, _ := newGetTestServer(t)
+
+		w := getSession(srv, "ls-doesnotexist")
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d", w.Code)
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		if resp.Error != "SESSION_NOT_FOUND" {
+			t.Errorf("expected SESSION_NOT_FOUND, got %s", resp.Error)
+		}
+	})
+
+	t.Run("non-logical id returns 400", func(t *testing.T) {
+		srv, _ := newGetTestServer(t)
+
+		w := getSession(srv, "raw-cli-id")
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		if resp.Error != "NOT_LOGICAL" {
+			t.Errorf("expected NOT_LOGICAL, got %s", resp.Error)
+		}
+	})
+
+	t.Run("session manager not configured returns 501", func(t *testing.T) {
+		log := obs.NewLogger()
+		metrics := obs.NewMetrics()
+		router := agent.NewRouter()
+		router.Register(&mockBasicDriver{name: "test-drv"}, log)
+		srv := NewServer(AppConfig{}, nil, nil, nil, nil, log, metrics)
+		srv.SetAgentRouter(router)
+		// No SetSessionManager call
+
+		w := getSession(srv, "ls-abc")
+
+		if w.Code != http.StatusNotImplemented {
+			t.Fatalf("expected 501, got %d", w.Code)
+		}
+	})
+}

--- a/adapter/internal/httpapi/server.go
+++ b/adapter/internal/httpapi/server.go
@@ -113,8 +113,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/agent/drivers", s.withAuth(s.handleAgentDrivers))
 	mux.HandleFunc("GET /v1/agent/sessions", s.withAuth(s.handleAgentSessions))
 	mux.HandleFunc("POST /v1/agent/sessions", s.withAuth(s.handleAgentSessionCreate))
+	mux.HandleFunc("GET /v1/agent/sessions/{id}", s.withAuth(s.handleAgentSessionGet))
 	mux.HandleFunc("PATCH /v1/agent/sessions/{id}", s.withAuth(s.handleAgentSessionUpdate))
 	mux.HandleFunc("GET /v1/agent/sessions/{id}/messages", s.withAuth(s.handleAgentSessionMessages))
+	mux.HandleFunc("POST /v1/agent/sessions/{id}/approve", s.withAuth(s.handleAgentSessionApprove))
 	mux.HandleFunc("DELETE /v1/agent/sessions/{id}", s.withAuth(s.handleAgentDeleteSession))
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
 	// Playground is unauthenticated on purpose — it's a dev-only single-page


### PR DESCRIPTION
Fixes #28

## What changed

Three additions to the Adapter HTTP/WS API, all in `adapter/internal/httpapi/`:

### 1. `POST /v1/agent/sessions/{id}/approve`
Forwards a tool-approval decision (`once` | `deny`) to the driver that owns the session.
- Resolves `ls-` logical session ids → CLI session id via the logical session manager
- Guards on `Capabilities.ToolApproval` before calling `drv.Approve` — returns `400 TOOL_APPROVAL_NOT_SUPPORTED` for drivers that don't support it (all current drivers except future Phase 2 claude-code)
- Maps `ErrUnsupported` → 400, `ErrUnknownSession` → 404

### 2. `GET /v1/agent/sessions/{id}`
Returns single logical session metadata for the Web Chat session picker.
- Reads base data from the logical session manager
- Augments with runtime `state` (`idle` | `running` | `completed` | `error`) from `agentSessions` registry; falls back to `idle` when the adapter has restarted and the session is no longer tracked

### 3. `session.state_change` WebSocket broadcast
Added `broadcastSessionStateChange` helper that emits `{kind:"session.state_change", payload:{sessionId, state, preview}}` via the existing `wsHub.Broadcast` at two points in `handleAgentMessage`:
- On `EvError` (state → `error`)
- After turn settles (state → `completed`)

Uses the logical id (`ls-`) when available so Web Chat sees the stable id.

## Files changed
- `adapter/internal/httpapi/agent_approve.go` — new handlers for approve + session GET
- `adapter/internal/httpapi/agent_approve_test.go` — 12 new tests
- `adapter/internal/httpapi/agent.go` — `broadcastSessionStateChange` helper + broadcast call sites
- `adapter/internal/httpapi/server.go` — route registration for the two new endpoints

## Testing
- `go test ./...` passes (all packages green)
- Hardware/device verification not applicable — these are pure HTTP/WS adapter endpoints with no firmware changes
- Note: `Capabilities.ToolApproval` remains `false` on all current drivers (claude-code Phase 2 approval round-trip is a separate task); the approve endpoint is wired and tested but will return `TOOL_APPROVAL_NOT_SUPPORTED` until a driver sets the capability to `true`