### PR TITLE
feat(adapter+firmware): CWD Pool — multi-project working directory selection

### DIFF
--- a/adapter/cmd/bbclaw-adapter/main.go
+++ b/adapter/cmd/bbclaw-adapter/main.go
@@ -160,6 +160,7 @@ func buildLocalServer(cfg config.Config, sink pipeline.Sink, cloudRelay *homeada
 			ASRTranscribeTimeout: cfg.ASRTranscribeTimeout,
 			SessionReuseWindow:   cfg.SessionReuseWindow,
 			SessionMaxAge:        cfg.SessionMaxAge,
+			CwdPool:              cfg.CwdPool,
 		},
 		streams, asrProvider, ttsProvider, sink, logger, metrics,
 	)

--- a/adapter/internal/config/config.go
+++ b/adapter/internal/config/config.go
@@ -10,6 +10,13 @@ import (
 	"time"
 )
 
+// CwdEntry is one entry in the CWD pool: a human-readable name and the
+// absolute filesystem path it maps to.
+type CwdEntry struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
 type Config struct {
 	// AdapterMode: "auto" (default, local HTTP always on + cloud relay when configured),
 	// "local" (force local only), or "cloud" (force cloud relay only).
@@ -57,6 +64,12 @@ type Config struct {
 	// Session management tunables.
 	SessionReuseWindow time.Duration // BBCLAW_SESSION_REUSE_WINDOW — reuse recent session within this window
 	SessionMaxAge      time.Duration // BBCLAW_SESSION_MAX_AGE — sweep sessions older than this
+
+	// CWD pool (issue #30 / T3).
+	// BBCLAW_CWD_POOL="name:path,name:path,..." — multi-project working directory selection.
+	// BBCLAW_DEFAULT_CWD is kept as a single-entry fallback when the pool is empty.
+	DefaultCwd string     // BBCLAW_DEFAULT_CWD
+	CwdPool    []CwdEntry // parsed from BBCLAW_CWD_POOL
 
 	// Cloud relay fields.
 	CloudWSURL     string
@@ -161,6 +174,8 @@ func LoadFromEnv() (Config, error) {
 		ReconnectDelay:       time.Duration(getEnvInt("CLOUD_RECONNECT_DELAY_SECONDS", 3)) * time.Second,
 		SessionReuseWindow:   getEnvDuration("BBCLAW_SESSION_REUSE_WINDOW", 5*time.Minute),
 		SessionMaxAge:        getEnvDuration("BBCLAW_SESSION_MAX_AGE", 7*24*time.Hour),
+		DefaultCwd:           strings.TrimSpace(os.Getenv("BBCLAW_DEFAULT_CWD")),
+		CwdPool:              parseCwdPool(os.Getenv("BBCLAW_CWD_POOL"), strings.TrimSpace(os.Getenv("BBCLAW_DEFAULT_CWD"))),
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -360,6 +375,39 @@ func getEnvBool(name string, fallback bool) bool {
 	default:
 		return fallback
 	}
+}
+
+// parseCwdPool parses BBCLAW_CWD_POOL="name:path,name:path,..." into a slice
+// of CwdEntry. Malformed entries (missing colon, empty name or path) are
+// silently skipped. When the pool string is empty and defaultCwd is non-empty,
+// a single synthetic entry named "default" is returned so callers always have
+// at least one entry to work with. When both are empty, nil is returned.
+func parseCwdPool(poolEnv, defaultCwd string) []CwdEntry {
+	poolEnv = strings.TrimSpace(poolEnv)
+	var entries []CwdEntry
+	if poolEnv != "" {
+		for _, part := range strings.Split(poolEnv, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			idx := strings.IndexByte(part, ':')
+			if idx <= 0 {
+				continue // no colon or empty name
+			}
+			name := strings.TrimSpace(part[:idx])
+			path := strings.TrimSpace(part[idx+1:])
+			if name == "" || path == "" {
+				continue
+			}
+			entries = append(entries, CwdEntry{Name: name, Path: path})
+		}
+	}
+	// Fall back to BBCLAW_DEFAULT_CWD as a single-entry pool when pool is empty.
+	if len(entries) == 0 && defaultCwd != "" {
+		entries = []CwdEntry{{Name: "default", Path: defaultCwd}}
+	}
+	return entries
 }
 
 // getEnvDuration parses a duration from an env var. Supports Go duration

--- a/adapter/internal/config/config_test.go
+++ b/adapter/internal/config/config_test.go
@@ -167,6 +167,136 @@ func TestLoadFromEnvCloudModeDisablesLocalIngress(t *testing.T) {
 	}
 }
 
+func TestParseCwdPool(t *testing.T) {
+	tests := []struct {
+		name       string
+		poolEnv    string
+		defaultCwd string
+		want       []CwdEntry
+	}{
+		{
+			name:       "empty pool and no default → nil",
+			poolEnv:    "",
+			defaultCwd: "",
+			want:       nil,
+		},
+		{
+			name:       "empty pool with default → single default entry",
+			poolEnv:    "",
+			defaultCwd: "/home/user/code",
+			want:       []CwdEntry{{Name: "default", Path: "/home/user/code"}},
+		},
+		{
+			name:       "single entry",
+			poolEnv:    "myproject:/Users/mikas/code/myproject",
+			defaultCwd: "",
+			want:       []CwdEntry{{Name: "myproject", Path: "/Users/mikas/code/myproject"}},
+		},
+		{
+			name:       "multiple entries",
+			poolEnv:    "myproject:/Users/mikas/code/myproject,side:/Users/mikas/code/side",
+			defaultCwd: "",
+			want: []CwdEntry{
+				{Name: "myproject", Path: "/Users/mikas/code/myproject"},
+				{Name: "side", Path: "/Users/mikas/code/side"},
+			},
+		},
+		{
+			name:       "pool present overrides default",
+			poolEnv:    "a:/path/a",
+			defaultCwd: "/fallback",
+			want:       []CwdEntry{{Name: "a", Path: "/path/a"}},
+		},
+		{
+			name:       "malformed entry (no colon) is skipped",
+			poolEnv:    "nocolon,good:/path/good",
+			defaultCwd: "",
+			want:       []CwdEntry{{Name: "good", Path: "/path/good"}},
+		},
+		{
+			name:       "empty name is skipped",
+			poolEnv:    ":/path/bad,ok:/path/ok",
+			defaultCwd: "",
+			want:       []CwdEntry{{Name: "ok", Path: "/path/ok"}},
+		},
+		{
+			name:       "empty path is skipped",
+			poolEnv:    "bad:,ok:/path/ok",
+			defaultCwd: "",
+			want:       []CwdEntry{{Name: "ok", Path: "/path/ok"}},
+		},
+		{
+			name:       "whitespace trimmed",
+			poolEnv:    "  proj : /path/proj , other : /path/other ",
+			defaultCwd: "",
+			want: []CwdEntry{
+				{Name: "proj", Path: "/path/proj"},
+				{Name: "other", Path: "/path/other"},
+			},
+		},
+		{
+			name:       "all malformed falls back to default",
+			poolEnv:    "nocolon,alsono",
+			defaultCwd: "/fallback",
+			want:       []CwdEntry{{Name: "default", Path: "/fallback"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCwdPool(tt.poolEnv, tt.defaultCwd)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseCwdPool() len=%d, want %d; got=%v", len(got), len(tt.want), got)
+			}
+			for i, e := range got {
+				if e.Name != tt.want[i].Name || e.Path != tt.want[i].Path {
+					t.Errorf("entry[%d] = {%q,%q}, want {%q,%q}", i, e.Name, e.Path, tt.want[i].Name, tt.want[i].Path)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadFromEnvCwdPool(t *testing.T) {
+	t.Setenv("ASR_LOCAL_BIN", "/bin/echo")
+	t.Setenv("OPENCLAW_RPC_URL", "https://gateway.example.com/rpc")
+	t.Setenv("TTS_WS_URL", "wss://openspeech.bytedance.com/api/v1/tts/ws_binary")
+	t.Setenv("TTS_APP_ID", "appid")
+	t.Setenv("TTS_TOKEN", "token")
+	t.Setenv("TTS_CLUSTER", "volcano_tts")
+	t.Setenv("TTS_VOICE", "zh-CN-XiaoxiaoNeural")
+
+	t.Run("pool parsed from env", func(t *testing.T) {
+		t.Setenv("BBCLAW_CWD_POOL", "a:/path/a,b:/path/b")
+		cfg, err := LoadFromEnv()
+		if err != nil {
+			t.Fatalf("LoadFromEnv() error = %v", err)
+		}
+		if len(cfg.CwdPool) != 2 {
+			t.Fatalf("CwdPool len=%d, want 2", len(cfg.CwdPool))
+		}
+		if cfg.CwdPool[0].Name != "a" || cfg.CwdPool[0].Path != "/path/a" {
+			t.Errorf("CwdPool[0] = %+v", cfg.CwdPool[0])
+		}
+		if cfg.CwdPool[1].Name != "b" || cfg.CwdPool[1].Path != "/path/b" {
+			t.Errorf("CwdPool[1] = %+v", cfg.CwdPool[1])
+		}
+	})
+
+	t.Run("default cwd becomes single pool entry when pool empty", func(t *testing.T) {
+		t.Setenv("BBCLAW_DEFAULT_CWD", "/home/user/work")
+		cfg, err := LoadFromEnv()
+		if err != nil {
+			t.Fatalf("LoadFromEnv() error = %v", err)
+		}
+		if len(cfg.CwdPool) != 1 {
+			t.Fatalf("CwdPool len=%d, want 1", len(cfg.CwdPool))
+		}
+		if cfg.CwdPool[0].Name != "default" || cfg.CwdPool[0].Path != "/home/user/work" {
+			t.Errorf("CwdPool[0] = %+v", cfg.CwdPool[0])
+		}
+	})
+}
+
 func TestGetEnvDuration(t *testing.T) {
 	tests := []struct {
 		envVal   string

--- a/adapter/internal/httpapi/agent.go
+++ b/adapter/internal/httpapi/agent.go
@@ -759,9 +759,10 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 // adapter's `BBCLAW_DEFAULT_CWD` (or, future: a named cwd pool selected by
 // the cloud admin console).
 type agentSessionCreateRequest struct {
-	Driver string `json:"driver,omitempty"`
-	Title  string `json:"title,omitempty"`
-	Cwd    string `json:"cwd,omitempty"` // optional override; defaults to manager's default
+	Driver  string `json:"driver,omitempty"`
+	Title   string `json:"title,omitempty"`
+	Cwd     string `json:"cwd,omitempty"`     // optional override; defaults to manager's default
+	CwdName string `json:"cwdName,omitempty"` // issue #30: select cwd by pool name
 }
 
 // handleAgentSessionCreate mints a new logical session (ADR-014).
@@ -803,7 +804,17 @@ func (s *Server) handleAgentSessionCreate(w http.ResponseWriter, r *http.Request
 	}
 
 	deviceID := strings.TrimSpace(r.URL.Query().Get("deviceId"))
-	sess, err := s.sessions.Create(deviceID, driver, strings.TrimSpace(req.Cwd), strings.TrimSpace(req.Title))
+	// Resolve cwd: cwdName takes priority over raw cwd field.
+	cwd := strings.TrimSpace(req.Cwd)
+	if cwdName := strings.TrimSpace(req.CwdName); cwdName != "" {
+		if resolved, ok := s.resolveCwdByName(cwdName); ok {
+			cwd = resolved
+		} else {
+			writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "UNKNOWN_CWD_NAME", Detail: cwdName})
+			return
+		}
+	}
+	sess, err := s.sessions.Create(deviceID, driver, cwd, strings.TrimSpace(req.Title))
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, response{OK: false, Error: "CREATE_SESSION_FAILED", Detail: err.Error()})
 		return
@@ -989,6 +1000,39 @@ func (s *Server) handleAgentDeleteSession(w http.ResponseWriter, r *http.Request
 	}
 	s.log.Infof("agent: deleted session=%s driver=%s", sessionID, entry.driverName)
 	writeJSON(w, http.StatusOK, response{OK: true})
+}
+
+// resolveCwdByName looks up a cwd path by name in the configured pool.
+// Returns ("", false) when the name is not found.
+func (s *Server) resolveCwdByName(name string) (string, bool) {
+	for _, entry := range s.cfg.CwdPool {
+		if entry.Name == name {
+			return entry.Path, true
+		}
+	}
+	return "", false
+}
+
+// handleAgentCwdPool returns the configured CWD pool entries.
+//
+//	GET /v1/agent/cwd-pool
+//	response: {"ok":true,"data":{"pool":[{"name":"myproject"},{"name":"side"}]}}
+//
+// Only the name is returned to the device — the full filesystem path is not
+// sent over the wire (it leaks host info and the device only needs the name
+// to pass back as cwdName in POST /v1/agent/sessions).
+func (s *Server) handleAgentCwdPool(w http.ResponseWriter, r *http.Request) {
+	type poolItem struct {
+		Name string `json:"name"`
+	}
+	items := make([]poolItem, 0, len(s.cfg.CwdPool))
+	for _, e := range s.cfg.CwdPool {
+		items = append(items, poolItem{Name: e.Name})
+	}
+	writeJSON(w, http.StatusOK, response{
+		OK:   true,
+		Data: map[string]any{"pool": items},
+	})
 }
 
 // broadcastSessionStateChange emits a session.state_change WebSocket event to

--- a/adapter/internal/httpapi/agent_cwd_pool_test.go
+++ b/adapter/internal/httpapi/agent_cwd_pool_test.go
@@ -1,0 +1,189 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/agent/logicalsession"
+	"github.com/daboluocc/bbclaw/adapter/internal/config"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
+)
+
+func TestHandleAgentCwdPool(t *testing.T) {
+	log := obs.NewLogger()
+	metrics := obs.NewMetrics()
+
+	t.Run("empty pool returns empty array", func(t *testing.T) {
+		srv := NewServer(AppConfig{}, nil, nil, nil, nil, log, metrics)
+		req := httptest.NewRequest("GET", "/v1/agent/cwd-pool", nil)
+		w := httptest.NewRecorder()
+		srv.handleAgentCwdPool(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp response
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if !resp.OK {
+			t.Fatal("expected ok=true")
+		}
+		data := resp.Data.(map[string]any)
+		pool := data["pool"].([]any)
+		if len(pool) != 0 {
+			t.Fatalf("expected empty pool, got %d entries", len(pool))
+		}
+	})
+
+	t.Run("pool entries returned by name only (no path)", func(t *testing.T) {
+		srv := NewServer(AppConfig{
+			CwdPool: []config.CwdEntry{
+				{Name: "myproject", Path: "/secret/path/myproject"},
+				{Name: "side", Path: "/secret/path/side"},
+			},
+		}, nil, nil, nil, nil, log, metrics)
+		req := httptest.NewRequest("GET", "/v1/agent/cwd-pool", nil)
+		w := httptest.NewRecorder()
+		srv.handleAgentCwdPool(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var resp response
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		data := resp.Data.(map[string]any)
+		poolRaw, _ := json.Marshal(data["pool"])
+		var pool []map[string]any
+		json.Unmarshal(poolRaw, &pool)
+
+		if len(pool) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(pool))
+		}
+		if pool[0]["name"] != "myproject" {
+			t.Errorf("pool[0].name = %v", pool[0]["name"])
+		}
+		if pool[1]["name"] != "side" {
+			t.Errorf("pool[1].name = %v", pool[1]["name"])
+		}
+		// path must NOT be present in the response
+		if _, hasPath := pool[0]["path"]; hasPath {
+			t.Error("pool[0] must not expose 'path' field to device")
+		}
+	})
+}
+
+func TestHandleAgentSessionCreateWithCwdName(t *testing.T) {
+	log := obs.NewLogger()
+	metrics := obs.NewMetrics()
+
+	// Build a minimal session manager backed by a temp file.
+	dir := t.TempDir()
+	mgr, err := logicalsession.NewManager(filepath.Join(dir, "sessions.json"), "", log)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	router := agent.NewRouter()
+	router.Register(&mockBasicDriver{name: "claude-code"}, log)
+
+	t.Run("cwdName resolves to path", func(t *testing.T) {
+		srv := NewServer(AppConfig{
+			CwdPool: []config.CwdEntry{
+				{Name: "myproject", Path: "/Users/mikas/code/myproject"},
+			},
+		}, nil, nil, nil, nil, log, metrics)
+		srv.SetAgentRouter(router)
+		srv.SetSessionManager(mgr)
+
+		body, _ := json.Marshal(map[string]string{
+			"driver":  "claude-code",
+			"cwdName": "myproject",
+		})
+		req := httptest.NewRequest("POST", "/v1/agent/sessions", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		srv.handleAgentSessionCreate(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		if !resp.OK {
+			t.Fatalf("expected ok=true, got error=%s", resp.Error)
+		}
+		data := resp.Data.(map[string]any)
+		sessRaw, _ := json.Marshal(data["session"])
+		var sess logicalsession.LogicalSession
+		json.Unmarshal(sessRaw, &sess)
+		if sess.Cwd != "/Users/mikas/code/myproject" {
+			t.Errorf("session.cwd = %q, want /Users/mikas/code/myproject", sess.Cwd)
+		}
+	})
+
+	t.Run("unknown cwdName returns 400", func(t *testing.T) {
+		srv := NewServer(AppConfig{
+			CwdPool: []config.CwdEntry{
+				{Name: "myproject", Path: "/Users/mikas/code/myproject"},
+			},
+		}, nil, nil, nil, nil, log, metrics)
+		srv.SetAgentRouter(router)
+		srv.SetSessionManager(mgr)
+
+		body, _ := json.Marshal(map[string]string{
+			"driver":  "claude-code",
+			"cwdName": "nonexistent",
+		})
+		req := httptest.NewRequest("POST", "/v1/agent/sessions", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		srv.handleAgentSessionCreate(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", w.Code)
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		if resp.Error != "UNKNOWN_CWD_NAME" {
+			t.Errorf("expected UNKNOWN_CWD_NAME, got %s", resp.Error)
+		}
+	})
+
+	t.Run("no cwdName falls back to default cwd", func(t *testing.T) {
+		mgr2, _ := logicalsession.NewManager(
+			filepath.Join(t.TempDir(), "sessions.json"), "/default/cwd", log)
+		srv := NewServer(AppConfig{
+			CwdPool: []config.CwdEntry{
+				{Name: "myproject", Path: "/Users/mikas/code/myproject"},
+			},
+		}, nil, nil, nil, nil, log, metrics)
+		srv.SetAgentRouter(router)
+		srv.SetSessionManager(mgr2)
+
+		body, _ := json.Marshal(map[string]string{"driver": "claude-code"})
+		req := httptest.NewRequest("POST", "/v1/agent/sessions", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		srv.handleAgentSessionCreate(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+		}
+		var resp response
+		json.NewDecoder(w.Body).Decode(&resp)
+		data := resp.Data.(map[string]any)
+		sessRaw, _ := json.Marshal(data["session"])
+		var sess logicalsession.LogicalSession
+		json.Unmarshal(sessRaw, &sess)
+		// No cwdName → manager uses its defaultCwd
+		if sess.Cwd != "/default/cwd" {
+			t.Errorf("session.cwd = %q, want /default/cwd", sess.Cwd)
+		}
+	})
+
+}

--- a/adapter/internal/httpapi/server.go
+++ b/adapter/internal/httpapi/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/daboluocc/bbclaw/adapter/internal/agent/logicalsession"
 	"github.com/daboluocc/bbclaw/adapter/internal/asr"
 	"github.com/daboluocc/bbclaw/adapter/internal/audio"
+	"github.com/daboluocc/bbclaw/adapter/internal/config"
 	"github.com/daboluocc/bbclaw/adapter/internal/obs"
 	"github.com/daboluocc/bbclaw/adapter/internal/openclaw"
 )
@@ -36,6 +37,7 @@ type AppConfig struct {
 	ASRTranscribeTimeout time.Duration
 	SessionReuseWindow   time.Duration // 0 disables reuse
 	SessionMaxAge        time.Duration // 0 disables sweep
+	CwdPool              []config.CwdEntry // populated from BBCLAW_CWD_POOL / BBCLAW_DEFAULT_CWD
 }
 
 type ASRProvider interface {
@@ -114,6 +116,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /v1/agent/message", s.withAuth(s.handleAgentMessage))
 	mux.HandleFunc("GET /v1/agent/drivers", s.withAuth(s.handleAgentDrivers))
 	mux.HandleFunc("GET /v1/agent/sessions", s.withAuth(s.handleAgentSessions))
+	mux.HandleFunc("GET /v1/agent/cwd-pool", s.withAuth(s.handleAgentCwdPool))
 	mux.HandleFunc("POST /v1/agent/sessions", s.withAuth(s.handleAgentSessionCreate))
 	mux.HandleFunc("GET /v1/agent/sessions/{id}", s.withAuth(s.handleAgentSessionGet))
 	mux.HandleFunc("PATCH /v1/agent/sessions/{id}", s.withAuth(s.handleAgentSessionUpdate))

--- a/firmware/include/bb_agent_client.h
+++ b/firmware/include/bb_agent_client.h
@@ -143,9 +143,28 @@ esp_err_t bb_agent_send_message(const char* text, const char* session_id, const 
  *
  * @param driver               Driver name (e.g. "claude-code"); NULL/"" → adapter picks default.
  * @param title                Human-friendly title; NULL/"" allowed (set later via control panel).
+ * @param cwd_name             CWD pool entry name (issue #30); NULL/"" → adapter uses default cwd.
  * @param out_session_id       Buffer to receive the id, NUL-terminated; empty string on failure.
  * @param out_session_id_len   Capacity of buffer (must be >= 40 to fit "ls-" + uuid).
  * @return ESP_OK on success; ESP_ERR_INVALID_ARG / ESP_ERR_NO_MEM / ESP_FAIL otherwise.
  */
-esp_err_t bb_agent_create_session(const char* driver, const char* title,
+esp_err_t bb_agent_create_session(const char* driver, const char* title, const char* cwd_name,
                                   char* out_session_id, size_t out_session_id_len);
+
+/**
+ * One entry in the CWD pool returned by GET /v1/agent/cwd-pool.
+ * Only the name is sent by the adapter (path is not exposed to the device).
+ */
+typedef struct {
+  char name[32];
+} bb_agent_cwd_entry_t;
+
+/**
+ * GET /v1/agent/cwd-pool — list available project working directories (issue #30).
+ *
+ * @param out_list   Caller-provided array; may be NULL (count-only query).
+ * @param cap        Capacity of out_list; ignored when out_list is NULL.
+ * @param out_count  Total entries available (not capped by cap).
+ * @return ESP_OK / error code.
+ */
+esp_err_t bb_agent_list_cwd_pool(bb_agent_cwd_entry_t* out_list, int cap, int* out_count);

--- a/firmware/include/bb_ui_agent_chat.h
+++ b/firmware/include/bb_ui_agent_chat.h
@@ -196,3 +196,31 @@ int bb_ui_agent_chat_session_picker_select(void);
  * Returns 1 if the session picker is currently visible (loading or shown).
  */
 int bb_ui_agent_chat_session_picker_is_visible(void);
+
+/* ── CWD Pool Picker (issue #30) ── */
+
+/**
+ * Returns 1 if the CWD project picker is currently visible (loading or shown).
+ * When visible, key events should be routed to the CWD picker instead of the
+ * session picker.
+ */
+int bb_ui_agent_chat_cwd_picker_is_visible(void);
+
+/**
+ * Move the CWD picker highlight. delta = -1 (up) / +1 (down), wraps.
+ * Must be called inside the LVGL lock.
+ */
+void bb_ui_agent_chat_cwd_picker_move(int delta);
+
+/**
+ * Confirm the currently highlighted CWD picker entry (OK key).
+ * Creates a new session with the selected project's cwd_name.
+ * Must be called inside the LVGL lock.
+ */
+void bb_ui_agent_chat_cwd_picker_confirm(void);
+
+/**
+ * Cancel the CWD picker (BACK key). Hides the picker without creating a session.
+ * Must be called inside the LVGL lock.
+ */
+void bb_ui_agent_chat_cwd_picker_cancel(void);

--- a/firmware/src/bb_agent_client.c
+++ b/firmware/src/bb_agent_client.c
@@ -643,7 +643,7 @@ esp_err_t bb_agent_load_messages(const char* session_id,
 
 /* ── public: create logical session (ADR-014) ── */
 
-esp_err_t bb_agent_create_session(const char* driver, const char* title,
+esp_err_t bb_agent_create_session(const char* driver, const char* title, const char* cwd_name,
                                   char* out_session_id, size_t out_session_id_len) {
   if (out_session_id == NULL || out_session_id_len < 40) {
     return ESP_ERR_INVALID_ARG;
@@ -659,6 +659,9 @@ esp_err_t bb_agent_create_session(const char* driver, const char* title,
   }
   if (title != NULL && title[0] != '\0') {
     cJSON_AddStringToObject(req, "title", title);
+  }
+  if (cwd_name != NULL && cwd_name[0] != '\0') {
+    cJSON_AddStringToObject(req, "cwdName", cwd_name);
   }
   char* body = cJSON_PrintUnformatted(req);
   cJSON_Delete(req);
@@ -683,9 +686,10 @@ esp_err_t bb_agent_create_session(const char* driver, const char* title,
   esp_http_client_set_header(client, "Content-Type", "application/json");
   esp_http_client_set_post_field(client, body, (int)strlen(body));
 
-  ESP_LOGI(TAG, "create_session url=%s driver=%s title=%s", url,
+  ESP_LOGI(TAG, "create_session url=%s driver=%s title=%s cwd_name=%s", url,
            (driver != NULL && driver[0] != '\0') ? driver : "(default)",
-           (title != NULL && title[0] != '\0') ? title : "(none)");
+           (title != NULL && title[0] != '\0') ? title : "(none)",
+           (cwd_name != NULL && cwd_name[0] != '\0') ? cwd_name : "(none)");
 
   esp_err_t err = esp_http_client_perform(client);
   int status = (err == ESP_OK) ? esp_http_client_get_status_code(client) : 0;
@@ -734,6 +738,81 @@ esp_err_t bb_agent_create_session(const char* driver, const char* title,
   strncpy(out_session_id, id->valuestring, out_session_id_len - 1);
   out_session_id[out_session_id_len - 1] = '\0';
   ESP_LOGI(TAG, "create_session ok sid=%s", out_session_id);
+  cJSON_Delete(root);
+  return ESP_OK;
+}
+
+/* ── public: list CWD pool (issue #30) ── */
+
+esp_err_t bb_agent_list_cwd_pool(bb_agent_cwd_entry_t* out_list, int cap, int* out_count) {
+  if (out_count != NULL) {
+    *out_count = 0;
+  }
+
+  char url[256] = {0};
+  agent_build_url(url, sizeof(url), "/v1/agent/cwd-pool");
+
+  bb_http_dyn_accum_t accum = {0};
+  esp_http_client_config_t cfg;
+  bb_http_cfg_init(&cfg, url, BBCLAW_HTTP_TIMEOUT_MS, HTTP_METHOD_GET, http_event_handler_dyn, &accum);
+
+  esp_http_client_handle_t client = esp_http_client_init(&cfg);
+  if (client == NULL) {
+    return ESP_ERR_NO_MEM;
+  }
+
+  esp_err_t err = esp_http_client_perform(client);
+  int status = (err == ESP_OK) ? esp_http_client_get_status_code(client) : 0;
+  esp_http_client_cleanup(client);
+
+  if (err != ESP_OK) {
+    free(accum.buf);
+    ESP_LOGE(TAG, "list_cwd_pool transport err=%s", esp_err_to_name(err));
+    return err;
+  }
+  if (status < 200 || status >= 300 || accum.buf == NULL) {
+    ESP_LOGE(TAG, "list_cwd_pool http status=%d body=%.120s", status,
+             accum.buf != NULL ? accum.buf : "(null)");
+    free(accum.buf);
+    return ESP_FAIL;
+  }
+
+  cJSON* root = cJSON_Parse(accum.buf);
+  free(accum.buf);
+  accum.buf = NULL;
+  if (root == NULL) {
+    ESP_LOGE(TAG, "list_cwd_pool parse failed");
+    return ESP_FAIL;
+  }
+
+  const cJSON* data = cJSON_GetObjectItemCaseSensitive(root, "data");
+  const cJSON* pool = cJSON_GetObjectItemCaseSensitive(data, "pool");
+  if (!cJSON_IsArray(pool)) {
+    ESP_LOGE(TAG, "list_cwd_pool missing data.pool[]");
+    cJSON_Delete(root);
+    return ESP_FAIL;
+  }
+
+  int total = cJSON_GetArraySize(pool);
+  if (out_count != NULL) {
+    *out_count = total;
+  }
+  if (out_list != NULL && cap > 0) {
+    int n = total < cap ? total : cap;
+    for (int i = 0; i < n; i++) {
+      const cJSON* item = cJSON_GetArrayItem(pool, i);
+      if (item == NULL) continue;
+      bb_agent_cwd_entry_t* slot = &out_list[i];
+      memset(slot, 0, sizeof(*slot));
+      const cJSON* name = cJSON_GetObjectItemCaseSensitive(item, "name");
+      if (cJSON_IsString(name) && name->valuestring != NULL) {
+        strncpy(slot->name, name->valuestring, sizeof(slot->name) - 1);
+        slot->name[sizeof(slot->name) - 1] = '\0';
+      }
+    }
+  }
+
+  ESP_LOGI(TAG, "list_cwd_pool ok total=%d", total);
   cJSON_Delete(root);
   return ESP_OK;
 }

--- a/firmware/src/bb_ui_agent_chat.c
+++ b/firmware/src/bb_ui_agent_chat.c
@@ -67,6 +67,12 @@ static const char* TAG = "bb_agent_ui";
 #define BB_HISTORY_PAGE_SIZE   50
 #define BB_HISTORY_MAX_LOADED  300
 
+/* CWD pool picker (issue #30) — shown when creating a new session and the
+ * adapter has more than one project configured. */
+#define BB_CWD_PICKER_MAX      8
+#define BB_CWD_PICKER_VISIBLE  5
+#define BB_CWD_PICKER_ROW_H    20
+
 /* Action codes returned by session_picker_select(). */
 #define BB_SESSION_PICKER_ACTION_SWITCH       0
 #define BB_SESSION_PICKER_ACTION_SETTINGS     1
@@ -157,6 +163,19 @@ typedef struct {
   int history_has_more;
   volatile int history_fetch_pending;
   volatile uint32_t history_fetch_generation;
+
+  /* CWD pool picker (issue #30) — shown when creating a new session and the
+   * adapter has more than one project configured. Fetched once per session-
+   * picker open; cached for the lifetime of the chat overlay. */
+  bb_agent_cwd_entry_t cwd_pool[BB_CWD_PICKER_MAX];
+  int cwd_pool_count;
+  volatile int cwd_pool_fetch_pending;
+  volatile uint32_t cwd_pool_fetch_generation;
+  /* CWD picker UI state (only active when cwd_picker_visible > 0). */
+  int cwd_picker_visible;   /* 0=hidden, 1=loading, 2=visible */
+  int cwd_picker_sel;
+  lv_obj_t* cwd_picker_root;
+  lv_obj_t* cwd_picker_items[BB_CWD_PICKER_MAX];
 
   /* Phase 4.5.1 — TTS reply toggle + per-turn accumulator.
    * Phase 4.5.2 — sentence-level streaming + cancel-and-replace.
@@ -1080,6 +1099,17 @@ void bb_ui_agent_chat_hide(void) {
   s_chat.picker_sel = 0;
   s_chat.mode = BB_CHAT_MODE_PICKER;
 
+  /* CWD picker cleanup (issue #30). */
+  if (s_chat.cwd_picker_root != NULL) {
+    lv_obj_del(s_chat.cwd_picker_root);
+    s_chat.cwd_picker_root = NULL;
+    memset(s_chat.cwd_picker_items, 0, sizeof(s_chat.cwd_picker_items));
+  }
+  s_chat.cwd_picker_visible = 0;
+  /* Invalidate the pool cache so it's re-fetched on next chat entry. */
+  s_chat.cwd_pool_count = 0;
+  s_chat.cwd_pool_fetch_generation++;
+
   const bb_agent_theme_t* theme = bb_agent_theme_get_active();
   if (theme != NULL && theme->on_exit != NULL) {
     theme->on_exit();
@@ -1896,6 +1926,7 @@ typedef struct {
 
 typedef struct {
   char driver_name[24];
+  char cwd_name[32]; /* issue #30: selected project name; "" = no selection */
 } new_session_args_t;
 
 static void on_new_session_done(void* user_data) {
@@ -1950,14 +1981,16 @@ static void new_session_task(void* arg) {
     vTaskDelay(pdMS_TO_TICKS(200));
   }
 
-  res->err = bb_agent_create_session(res->driver_name, NULL,
+  res->err = bb_agent_create_session(res->driver_name,
+                                     NULL,
+                                     args->cwd_name[0] != '\0' ? args->cwd_name : NULL,
                                      res->session_id, sizeof(res->session_id));
   free(args);
   lv_async_call(on_new_session_done, res);
   vTaskDelete(NULL);
 }
 
-static void spawn_new_session_task(void) {
+static void spawn_new_session_task(const char* cwd_name) {
   new_session_args_t* args = (new_session_args_t*)heap_caps_calloc(
       1, sizeof(*args), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
   if (args == NULL) {
@@ -1967,6 +2000,9 @@ static void spawn_new_session_task(void) {
   const char* drv = s_chat.driver_name[0] != '\0'
                       ? s_chat.driver_name : BB_CHAT_DRIVER_FALLBACK;
   strncpy(args->driver_name, drv, sizeof(args->driver_name) - 1);
+  if (cwd_name != NULL && cwd_name[0] != '\0') {
+    strncpy(args->cwd_name, cwd_name, sizeof(args->cwd_name) - 1);
+  }
 
   TaskHandle_t t = NULL;
   BaseType_t ok = xTaskCreateWithCaps(new_session_task, "new_session",
@@ -1979,6 +2015,262 @@ static void spawn_new_session_task(void) {
   }
 }
 
+/* ── CWD pool fetch + picker (issue #30) ──────────────────────────────────
+ *
+ * When the user selects "+ 新建 session" and the adapter has more than one
+ * project configured, we show a project-selection sub-menu before creating
+ * the session. If the pool has 0 or 1 entries we skip the picker entirely
+ * (backward-compatible with single-project setups).
+ *
+ * Lifecycle:
+ *   1. session_picker_select() detects the "+ 新建" row.
+ *   2. If cwd_pool_count > 1 (already cached) → show picker immediately.
+ *      If not yet fetched → spawn cwd_pool_fetch_task, show picker when done.
+ *      If pool has ≤ 1 entry → create session directly (existing behaviour).
+ *   3. User navigates with UP/DOWN, confirms with OK → spawn_new_session_task(name).
+ *   4. BACK → hide picker, return to session picker (or just close).
+ */
+
+#define BB_CWD_FETCH_TASK_STACK 4096
+#define BB_CWD_FETCH_TASK_PRIO  4
+
+typedef struct {
+  uint32_t gen;
+  esp_err_t err;
+  int total;
+  bb_agent_cwd_entry_t entries[BB_CWD_PICKER_MAX];
+} cwd_pool_fetch_result_t;
+
+static void cwd_picker_build_ui(void);
+
+static void on_cwd_pool_fetch_done(void* user_data) {
+  cwd_pool_fetch_result_t* res = (cwd_pool_fetch_result_t*)user_data;
+  if (res == NULL) return;
+  s_chat.cwd_pool_fetch_pending = 0;
+  if (!s_chat.active || res->gen != s_chat.cwd_pool_fetch_generation) {
+    free(res);
+    return;
+  }
+  if (res->err != ESP_OK || res->total <= 0) {
+    ESP_LOGW(TAG, "cwd_pool fetch failed (%s), creating session without cwd_name",
+             esp_err_to_name(res->err));
+    s_chat.cwd_pool_count = 0;
+    /* Fall back: create session directly without a cwd_name. */
+    if (s_chat.cwd_picker_visible) {
+      s_chat.cwd_picker_visible = 0;
+      spawn_new_session_task(NULL);
+    }
+    free(res);
+    return;
+  }
+  int total = res->total > BB_CWD_PICKER_MAX ? BB_CWD_PICKER_MAX : res->total;
+  memcpy(s_chat.cwd_pool, res->entries, sizeof(res->entries[0]) * (size_t)total);
+  s_chat.cwd_pool_count = total;
+  free(res);
+
+  if (total <= 1) {
+    /* Single entry or empty — skip picker, create directly. */
+    s_chat.cwd_picker_visible = 0;
+    const char* name = (total == 1) ? s_chat.cwd_pool[0].name : NULL;
+    spawn_new_session_task(name);
+    return;
+  }
+  /* Multiple entries — show the picker. */
+  s_chat.cwd_picker_visible = 2;
+  s_chat.cwd_picker_sel = 0;
+  cwd_picker_build_ui();
+}
+
+static void cwd_pool_fetch_task(void* arg) {
+  uint32_t my_gen = (uint32_t)(uintptr_t)arg;
+  cwd_pool_fetch_result_t* res = (cwd_pool_fetch_result_t*)calloc(1, sizeof(*res));
+  if (res == NULL) {
+    s_chat.cwd_pool_fetch_pending = 0;
+    vTaskDelete(NULL);
+    return;
+  }
+  res->gen = my_gen;
+  for (int i = 0; i < 50 && !bb_wifi_is_connected(); ++i) {
+    vTaskDelay(pdMS_TO_TICKS(200));
+  }
+  res->err = bb_agent_list_cwd_pool(res->entries, BB_CWD_PICKER_MAX, &res->total);
+  lv_async_call(on_cwd_pool_fetch_done, res);
+  vTaskDelete(NULL);
+}
+
+/* Fetch the CWD pool from the adapter. If already cached (count > 0), calls
+ * on_cwd_pool_fetch_done synchronously via lv_async_call with the cached data
+ * so the caller always gets a consistent callback-driven flow. */
+static void spawn_cwd_pool_fetch_or_use_cache(void) {
+  if (s_chat.cwd_pool_count > 0) {
+    /* Already have data — synthesise a result from cache. */
+    cwd_pool_fetch_result_t* res = (cwd_pool_fetch_result_t*)calloc(1, sizeof(*res));
+    if (res == NULL) {
+      spawn_new_session_task(NULL);
+      return;
+    }
+    res->gen = s_chat.cwd_pool_fetch_generation;
+    res->err = ESP_OK;
+    res->total = s_chat.cwd_pool_count;
+    memcpy(res->entries, s_chat.cwd_pool,
+           sizeof(res->entries[0]) * (size_t)s_chat.cwd_pool_count);
+    lv_async_call(on_cwd_pool_fetch_done, res);
+    return;
+  }
+  if (s_chat.cwd_pool_fetch_pending) return;
+  s_chat.cwd_pool_fetch_pending = 1;
+  uint32_t gen = ++s_chat.cwd_pool_fetch_generation;
+  TaskHandle_t t = NULL;
+  BaseType_t ok = xTaskCreate(cwd_pool_fetch_task, "cwd_fetch",
+                              BB_CWD_FETCH_TASK_STACK,
+                              (void*)(uintptr_t)gen,
+                              BB_CWD_FETCH_TASK_PRIO, &t);
+  if (ok != pdPASS) {
+    ESP_LOGE(TAG, "spawn_cwd_pool_fetch: xTaskCreate failed");
+    s_chat.cwd_pool_fetch_pending = 0;
+    spawn_new_session_task(NULL);
+  }
+}
+
+/* ── CWD picker UI ── */
+
+#define BB_CWDPICKER_BG      0x12211b
+#define BB_CWDPICKER_FG      0xc8e2d6
+#define BB_CWDPICKER_FG_DIM  0x6b8c80
+#define BB_CWDPICKER_SEL_BG  0x2ec4a0
+#define BB_CWDPICKER_SEL_FG  0x0a0e0c
+#define BB_CWDPICKER_TITLE_H 22
+
+static void cwd_picker_apply_styles(void) {
+  const int total = s_chat.cwd_pool_count;
+  if (total == 0) return;
+  int first = s_chat.cwd_picker_sel - BB_CWD_PICKER_VISIBLE / 2;
+  if (first < 0) first = 0;
+  if (first + BB_CWD_PICKER_VISIBLE > total) {
+    first = total - BB_CWD_PICKER_VISIBLE;
+    if (first < 0) first = 0;
+  }
+  for (int i = 0; i < total; ++i) {
+    lv_obj_t* row = s_chat.cwd_picker_items[i];
+    if (row == NULL) continue;
+    int visible = (i >= first && i < first + BB_CWD_PICKER_VISIBLE);
+    if (visible) {
+      lv_obj_clear_flag(row, LV_OBJ_FLAG_HIDDEN);
+    } else {
+      lv_obj_add_flag(row, LV_OBJ_FLAG_HIDDEN);
+    }
+    if (i == s_chat.cwd_picker_sel) {
+      lv_obj_set_style_bg_color(row, lv_color_hex(BB_CWDPICKER_SEL_BG), 0);
+      lv_obj_set_style_bg_opa(row, LV_OPA_COVER, 0);
+      lv_obj_set_style_text_color(row, lv_color_hex(BB_CWDPICKER_SEL_FG), 0);
+    } else {
+      lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
+      lv_obj_set_style_text_color(row, lv_color_hex(BB_CWDPICKER_FG_DIM), 0);
+    }
+  }
+}
+
+static void cwd_picker_build_ui(void) {
+  if (s_chat.parent == NULL) return;
+
+#ifdef BBCLAW_HAVE_CJK_FONT
+  extern const lv_font_t lv_font_bbclaw_cjk;
+  const lv_font_t* font = &lv_font_bbclaw_cjk;
+#else
+  const lv_font_t* font = lv_font_get_default();
+#endif
+
+  /* Tear down previous picker if any. */
+  if (s_chat.cwd_picker_root != NULL) {
+    lv_obj_del(s_chat.cwd_picker_root);
+    s_chat.cwd_picker_root = NULL;
+    memset(s_chat.cwd_picker_items, 0, sizeof(s_chat.cwd_picker_items));
+  }
+
+  const int n = s_chat.cwd_pool_count;
+
+  s_chat.cwd_picker_root = lv_obj_create(s_chat.parent);
+  lv_obj_remove_style_all(s_chat.cwd_picker_root);
+  lv_obj_set_size(s_chat.cwd_picker_root, lv_pct(100), lv_pct(100));
+  lv_obj_align(s_chat.cwd_picker_root, LV_ALIGN_TOP_LEFT, 0, 0);
+  lv_obj_set_style_bg_color(s_chat.cwd_picker_root, lv_color_hex(BB_CWDPICKER_BG), 0);
+  lv_obj_set_style_bg_opa(s_chat.cwd_picker_root, LV_OPA_COVER, 0);
+  lv_obj_set_style_pad_all(s_chat.cwd_picker_root, 2, 0);
+  lv_obj_set_flex_flow(s_chat.cwd_picker_root, LV_FLEX_FLOW_COLUMN);
+  lv_obj_clear_flag(s_chat.cwd_picker_root, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_move_foreground(s_chat.cwd_picker_root);
+
+  /* Title row. */
+  lv_obj_t* title = lv_label_create(s_chat.cwd_picker_root);
+  lv_obj_set_size(title, lv_pct(100), BB_CWDPICKER_TITLE_H);
+  lv_obj_set_style_text_color(title, lv_color_hex(BB_CWDPICKER_FG), 0);
+  lv_obj_set_style_text_font(title, font, 0);
+  lv_obj_set_style_pad_left(title, 2, 0);
+  lv_label_set_text(title, "新建 Session");
+
+  /* Project rows. */
+  for (int i = 0; i < n; ++i) {
+    lv_obj_t* row = lv_label_create(s_chat.cwd_picker_root);
+    lv_obj_set_size(row, lv_pct(100), BB_CWD_PICKER_ROW_H);
+    lv_obj_set_style_pad_left(row, 4, 0);
+    lv_obj_set_style_pad_right(row, 4, 0);
+    lv_obj_set_style_radius(row, 3, 0);
+    lv_obj_set_style_text_font(row, font, 0);
+    lv_label_set_long_mode(row, LV_LABEL_LONG_MODE_DOTS);
+    lv_label_set_text(row, s_chat.cwd_pool[i].name);
+    s_chat.cwd_picker_items[i] = row;
+  }
+
+  cwd_picker_apply_styles();
+  ESP_LOGI(TAG, "cwd_picker: built %d project entries", n);
+}
+
+/* Hide and destroy the CWD picker overlay. */
+static void cwd_picker_hide(void) {
+  if (s_chat.cwd_picker_root != NULL) {
+    lv_obj_del(s_chat.cwd_picker_root);
+    s_chat.cwd_picker_root = NULL;
+    memset(s_chat.cwd_picker_items, 0, sizeof(s_chat.cwd_picker_items));
+  }
+  s_chat.cwd_picker_visible = 0;
+}
+
+/* Move selection up/down in the CWD picker. */
+void bb_ui_agent_chat_cwd_picker_move(int delta) {
+  if (!s_chat.active || s_chat.cwd_picker_visible != 2) return;
+  const int total = s_chat.cwd_pool_count;
+  if (total == 0) return;
+  int sel = ((s_chat.cwd_picker_sel + delta) % total + total) % total;
+  if (sel == s_chat.cwd_picker_sel) return;
+  s_chat.cwd_picker_sel = sel;
+  cwd_picker_apply_styles();
+}
+
+/* Confirm selection in the CWD picker (OK key). Creates the session with the
+ * selected project name. */
+void bb_ui_agent_chat_cwd_picker_confirm(void) {
+  if (!s_chat.active || s_chat.cwd_picker_visible != 2) return;
+  const int sel = s_chat.cwd_picker_sel;
+  if (sel < 0 || sel >= s_chat.cwd_pool_count) return;
+  const char* name = s_chat.cwd_pool[sel].name;
+  ESP_LOGI(TAG, "cwd_picker: selected '%s'", name);
+  cwd_picker_hide();
+  spawn_new_session_task(name);
+}
+
+/* Cancel the CWD picker (BACK key). Returns to the session picker. */
+void bb_ui_agent_chat_cwd_picker_cancel(void) {
+  if (!s_chat.active || !s_chat.cwd_picker_visible) return;
+  ESP_LOGI(TAG, "cwd_picker: cancelled");
+  cwd_picker_hide();
+}
+
+/* Returns non-zero when the CWD picker is visible (so the key handler can
+ * route UP/DOWN/OK/BACK to it instead of the session picker). */
+int bb_ui_agent_chat_cwd_picker_is_visible(void) {
+  return (s_chat.active && s_chat.cwd_picker_visible > 0) ? 1 : 0;
+}
+
 int bb_ui_agent_chat_session_picker_select(void) {
   if (!s_chat.active || s_chat.session_picker_visible != 2) {
     return BB_SESSION_PICKER_ACTION_NONE;
@@ -1987,10 +2279,13 @@ int bb_ui_agent_chat_session_picker_select(void) {
   const int n = s_chat.session_list_count;
 
   if (sel == 0) {
-    /* "+ 新建 session" row — kick off async create then converge with switch flow. */
+    /* "+ 新建 session" row — fetch CWD pool; if > 1 entry show project picker,
+     * otherwise create directly (backward-compatible). */
     ESP_LOGI(TAG, "session_picker: new session requested");
     bb_ui_agent_chat_session_picker_hide();
-    spawn_new_session_task();
+    /* Mark cwd_picker as loading so key handler routes to it. */
+    s_chat.cwd_picker_visible = 1;
+    spawn_cwd_pool_fetch_or_use_cache();
     return BB_SESSION_PICKER_ACTION_NEW_SESSION;
   }
 


### PR DESCRIPTION
Fixes #30

## What changed

### Adapter (Go)

**Config**: New `CwdEntry{Name,Path}` type. `parseCwdPool()` parses `BBCLAW_CWD_POOL="name:path,..."` into `[]CwdEntry`, falling back to `BBCLAW_DEFAULT_CWD` as a single `default` entry when the pool is empty. Malformed entries are silently skipped.

**HTTP API**:
- `GET /v1/agent/cwd-pool` — new endpoint returning `[{"name":"..."}]`. Path is omitted from the device response to avoid leaking host filesystem paths.
- `POST /v1/agent/sessions` — new optional `cwdName` field. Resolves against the pool; returns `400 UNKNOWN_CWD_NAME` if not found. Falls through to manager defaultCwd when omitted (backward-compatible).
- `AppConfig.CwdPool` wired through `main.go` `buildLocalServer`.

**Tests**: `parseCwdPool` (10 table cases), `handleAgentCwdPool` (empty pool, name-only response, no path leak), `handleAgentSessionCreate` with cwdName / unknown name / no name.

### Firmware (C / ESP-IDF)

**bb_agent_client.h/.c**:
- `bb_agent_cwd_entry_t` struct (name only).
- `bb_agent_list_cwd_pool()` — GET /v1/agent/cwd-pool, same pattern as `bb_agent_list_drivers`.
- `bb_agent_create_session()` — new `cwd_name` parameter (NULL/"" = no selection, backward-compatible).

**bb_ui_agent_chat.c/.h**:
- CWD pool state added to `bb_chat_state_t` (pool cache + picker UI state).
- `spawn_cwd_pool_fetch_or_use_cache()` fetches pool from adapter (or uses cache).
- `on_cwd_pool_fetch_done`: pool <= 1 entry creates session directly (existing behaviour); pool > 1 shows project picker.
- Full LVGL picker UI: title row + scrollable project list, same visual style as session picker.
- Public API: `bb_ui_agent_chat_cwd_picker_{is_visible,move,confirm,cancel}`.
- Session picker "+ 新建 session" now triggers pool fetch instead of direct session creation.
- `bb_ui_agent_chat_hide` clears CWD picker state and invalidates pool cache.

## Tested

- All adapter unit tests pass (`go test ./...` — 21 packages, 0 failures).
- Firmware: ESP-IDF cross-compilation not available in this environment. The C changes follow the exact same patterns as the existing `bb_agent_list_drivers` / `bb_agent_list_sessions` implementations. Hardware verification needed before merge.