### PR TITLE
fix(firmware): add missing cwd_name arg in bb_ui_settings.c

### DIFF
--- a/firmware/src/bb_ui_settings.c
+++ b/firmware/src/bb_ui_settings.c
@@ -382,7 +382,7 @@ void bb_ui_settings_handle_click(void) {
          * ADR-014: POST /v1/agent/sessions with current driver, no cwd. */
         const char* driver = bb_ui_agent_chat_get_current_driver();
         char new_sid[64] = {0};
-        esp_err_t create_err = bb_agent_create_session(driver, NULL, new_sid, sizeof(new_sid));
+        esp_err_t create_err = bb_agent_create_session(driver, NULL, NULL, new_sid, sizeof(new_sid));
         if (create_err == ESP_OK && new_sid[0] != '\0') {
           strncpy(s_st.selected_session, new_sid, sizeof(s_st.selected_session) - 1);
           s_st.selected_session[sizeof(s_st.selected_session) - 1] = '\0';


### PR DESCRIPTION
Fixes #35

## What changed

 was updated to 5 params in commit fb36993 (PR #33, CWD Pool), but the call site in  was not updated, causing a compile error on main.

Added the missing  for  as the third argument:

```c
// Before (broken):
esp_err_t create_err = bb_agent_create_session(driver, NULL, new_sid, sizeof(new_sid));

// After (fixed):
esp_err_t create_err = bb_agent_create_session(driver, NULL, NULL, new_sid, sizeof(new_sid));
```

## Testing

Build verification (`cd firmware && make build`) requires the ESP-IDF toolchain. No unit tests cover this call site. The fix is a mechanical one-line correction matching the 5-arg signature already used correctly in `bb_ui_agent_chat.c`.