### PR TITLE
fix: cycle_driver 切换后加载新 driver 历史记录

### DIFF
--- a/firmware/src/bb_ui_agent_chat.c
+++ b/firmware/src/bb_ui_agent_chat.c
@@ -2505,11 +2505,26 @@ esp_err_t bb_ui_agent_chat_cycle_driver(int delta) {
 
   s_chat.session_id[0] = '\0';
 
+  /* ── Restore new driver's last session + history (issue #41) ── */
+  /* 1. Load the new driver's last-used session_id from NVS (per-driver store). */
+  load_nvs_on_internal_stack();
+
+  /* 2. Rebuild transcript UI: clear stale content, re-init theme for new session. */
+  apply_session_switch_ui(s_chat.session_id);
+
+  /* 3. Fetch history for the restored session (or just reset state if none). */
+  if (s_chat.session_id[0] != '\0') {
+    history_state_reset();
+    spawn_history_fetch_task(-1, /*is_initial=*/1);
+  } else {
+    history_state_reset();
+  }
+
   const bb_agent_theme_t* theme = bb_agent_theme_get_active();
   if (theme != NULL && theme->set_driver != NULL) {
     theme->set_driver(name);
   }
-  ESP_LOGI(TAG, "cycle_driver: '%s' (delta=%+d, idx=%d/%d) session reset",
+  ESP_LOGI(TAG, "cycle_driver: '%s' (delta=%+d, idx=%d/%d) session restored",
            name, delta, next, n);
   return ESP_OK;
 }


### PR DESCRIPTION
Fixes #41

## 问题

LEFT/RIGHT 切换 driver 后，屏幕显示空白或残留旧 driver 的 transcript，因为 `cycle_driver` 缺少 session 恢复和历史加载流程。

## 修改内容

在 `bb_ui_agent_chat_cycle_driver()` 的 `s_chat.session_id[0] = '\0'` 之后，补上与 `bb_ui_agent_chat_show()` 和 `session_picker_select()` 一致的三步恢复流程：

1. `load_nvs_on_internal_stack()` — 从 NVS 加载新 driver 的 last-used session_id（per-driver 存储）
2. `apply_session_switch_ui()` — 清空旧 transcript，重建主题
3. `history_state_reset()` + `spawn_history_fetch_task(-1, is_initial=1)` — 拉取新 session 历史（若有 session）

## 测试说明

此为纯固件 C 代码变更，无单元测试覆盖。需要硬件验证：
- 至少 2 个 driver 可用（如 claude-code + ollama）
- 烧录 local_home profile，Adapter 已启动
- 进入 CHAT，发送消息建立 session，LEFT/RIGHT 切换 driver，确认新 driver 历史正确加载
- 切回原 driver，确认原 session 历史也正确恢复