### PR TITLE
fix: skip doomed --resume when CLI session JSONL is missing on disk

### DIFF
--- a/adapter/internal/agent/claudecode/driver.go
+++ b/adapter/internal/agent/claudecode/driver.go
@@ -228,6 +228,19 @@ func (d *Driver) Approve(sid agent.SessionID, tid agent.ToolID, decision agent.D
 	return agent.ErrUnsupported
 }
 
+// CLISessionExists reports whether the on-disk JSONL transcript for the given
+// CLI session id can be found under ~/.claude/projects/. Used by the agent
+// proxy to skip a doomed --resume attempt when the conversation file has been
+// deleted or GC'd by the CLI, avoiding the 4-7s cold-start penalty of
+// spawning a process that will immediately fail with SESSION_NOT_FOUND.
+func (d *Driver) CLISessionExists(cliSessionID string) bool {
+	if strings.TrimSpace(cliSessionID) == "" {
+		return false
+	}
+	path, err := d.findHistoryPath(cliSessionID)
+	return err == nil && path != ""
+}
+
 // Stop terminates any in-flight subprocess and closes the session.
 func (d *Driver) Stop(sid agent.SessionID) error {
 	d.mu.Lock()

--- a/adapter/internal/agent/claudecode/driver_test.go
+++ b/adapter/internal/agent/claudecode/driver_test.go
@@ -2,6 +2,8 @@ package claudecode
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -187,5 +189,44 @@ func TestDriverName(t *testing.T) {
 	d := New(Options{}, obs.NewLogger())
 	if d.Name() != "claude-code" {
 		t.Errorf("Name: want 'claude-code', got %q", d.Name())
+	}
+}
+
+// TestCLISessionExists verifies the filesystem check used by the agent proxy
+// to skip doomed --resume attempts. The driver should return false when no
+// matching JSONL exists and true when one is present.
+func TestCLISessionExists(t *testing.T) {
+	d := New(Options{}, obs.NewLogger())
+
+	// Point CLAUDE_SESSIONS_DIR at a temp dir so we don't touch ~/.claude.
+	// The driver derives projectsDir as filepath.Join(filepath.Dir(sessionsDir), "projects").
+	sessionsDir := t.TempDir()
+	t.Setenv("CLAUDE_SESSIONS_DIR", sessionsDir)
+
+	// No projects dir yet → false, no panic.
+	if d.CLISessionExists("abc-123") {
+		t.Error("CLISessionExists: want false when projects dir is absent")
+	}
+	if d.CLISessionExists("") {
+		t.Error("CLISessionExists: want false for empty id")
+	}
+
+	// Create a fake JSONL transcript under projects/<project>/abc-123.jsonl.
+	projectsDir := filepath.Join(filepath.Dir(sessionsDir), "projects")
+	projectSubdir := filepath.Join(projectsDir, "-tmp-myproject")
+	if err := os.MkdirAll(projectSubdir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	jsonlPath := filepath.Join(projectSubdir, "abc-123.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(`{"type":"user"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if !d.CLISessionExists("abc-123") {
+		t.Error("CLISessionExists: want true when JSONL file exists")
+	}
+	// A different id in the same project dir should still return false.
+	if d.CLISessionExists("xyz-999") {
+		t.Error("CLISessionExists: want false for id with no matching file")
 	}
 }

--- a/adapter/internal/agent/driver.go
+++ b/adapter/internal/agent/driver.go
@@ -134,3 +134,13 @@ type MessagesPage struct {
 type MessageLoader interface {
 	LoadMessages(ctx context.Context, sid string, before, limit int) (MessagesPage, error)
 }
+
+// CLISessionChecker is an optional capability for drivers that store
+// conversation history on disk. When implemented, the agent proxy uses it to
+// validate a resume target before spawning a subprocess — if the on-disk
+// transcript is missing the resume attempt is skipped entirely, avoiding the
+// 4-7s cold-start penalty of a process that would immediately fail with
+// SESSION_NOT_FOUND.
+type CLISessionChecker interface {
+	CLISessionExists(cliSessionID string) bool
+}

--- a/adapter/internal/homeadapter/agent_proxy.go
+++ b/adapter/internal/homeadapter/agent_proxy.go
@@ -708,6 +708,23 @@ func (a *Adapter) handleAgentMessageRequest(ctx context.Context, write func(Clou
 	a.metrics.Inc("agent_proxy_message_start")
 	routeStart := time.Now()
 
+	// Proactive resume validation: if the driver can check whether a CLI
+	// conversation still exists on disk, do so before the attempt loop.
+	// A missing transcript means --resume would immediately fail with
+	// SESSION_NOT_FOUND, wasting 4-7s on a doomed cold-start. Clearing
+	// resumeFromLogical here lets the first attempt go straight to a fresh
+	// session instead of triggering the retry cascade.
+	if resumeFromLogical != "" {
+		if checker, ok := drv.(agent.CLISessionChecker); ok {
+			if !checker.CLISessionExists(resumeFromLogical) {
+				a.log.Infof("agent_proxy: resume target missing on disk, skipping resume cli=%s logical=%s",
+					resumeFromLogical, logicalID)
+				a.metrics.Inc("agent_proxy_resume_skipped_missing")
+				resumeFromLogical = ""
+			}
+		}
+	}
+
 	// Outer loop wraps one or two attempts. Attempt 0 is the normal path
 	// (start with ResumeID if the device asked to resume); attempt 1 fires
 	// only when the driver emitted SESSION_NOT_FOUND on attempt 0 — see

--- a/adapter/internal/homeadapter/agent_proxy_logical_test.go
+++ b/adapter/internal/homeadapter/agent_proxy_logical_test.go
@@ -367,6 +367,88 @@ func TestAgentProxySessionsListLogical(t *testing.T) {
 	mu.Unlock()
 }
 
+// checkingProxyDriver wraps recordingProxyDriver and additionally implements
+// agent.CLISessionChecker so we can test the proactive resume-skip path.
+type checkingProxyDriver struct {
+	*recordingProxyDriver
+	existingIDs map[string]bool
+}
+
+func newCheckingProxyDriver(mintedSid agent.SessionID, existingIDs ...string) *checkingProxyDriver {
+	m := make(map[string]bool, len(existingIDs))
+	for _, id := range existingIDs {
+		m[id] = true
+	}
+	return &checkingProxyDriver{
+		recordingProxyDriver: newRecordingProxyDriver(mintedSid),
+		existingIDs:          m,
+	}
+}
+
+func (d *checkingProxyDriver) CLISessionExists(cliSessionID string) bool {
+	return d.existingIDs[cliSessionID]
+}
+
+// TestAgentProxySkipsResumeWhenCLISessionMissing verifies that when the driver
+// implements CLISessionChecker and reports the stored CLI session id is absent
+// on disk, the proxy clears resumeFromLogical before the attempt loop — so the
+// driver is started with an empty ResumeID (fresh session) rather than a stale
+// one that would immediately fail with SESSION_NOT_FOUND and trigger a costly
+// retry.
+func TestAgentProxySkipsResumeWhenCLISessionMissing(t *testing.T) {
+	// Driver reports "cc-stale" does NOT exist on disk.
+	drv := newCheckingProxyDriver("cc-fresh-after-skip")
+	a, mgr := newProxyTestAdapterWithMgr(t, drv)
+
+	ls, err := mgr.Create("device-skip", "claude-code", "/tmp/wd", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Store a stale CLI session id that the checker will report as missing.
+	if err := mgr.UpdateCLISessionID(ls.ID, "cc-stale"); err != nil {
+		t.Fatalf("UpdateCLISessionID: %v", err)
+	}
+
+	var (
+		mu  sync.Mutex
+		got []CloudEnvelope
+	)
+	write := func(env CloudEnvelope) error {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, env)
+		return nil
+	}
+	err = a.handleRequest(context.Background(), write, CloudEnvelope{
+		Type: "request", MessageID: "m-skip", DeviceID: "device-skip", Kind: "agent.message",
+		Payload: map[string]any{"text": "hello", "sessionId": string(ls.ID)},
+	})
+	if err != nil {
+		t.Fatalf("handleRequest: %v", err)
+	}
+
+	// Driver must have been started exactly once (no retry) with an empty
+	// ResumeID — the stale id was discarded before the attempt loop.
+	if drv.startCount() != 1 {
+		t.Errorf("driver Start count=%d want 1 (no retry)", drv.startCount())
+	}
+	resumeIDs := drv.resumeIDsCopy()
+	if len(resumeIDs) != 1 || resumeIDs[0] != "" {
+		t.Errorf("driver ResumeIDs=%v want [\"\"] (stale id should have been skipped)", resumeIDs)
+	}
+
+	// The logical session's CLISessionID should be updated to the new minted id.
+	mu.Lock()
+	defer mu.Unlock()
+	updated, ok := mgr.Get(ls.ID)
+	if !ok {
+		t.Fatalf("logical session not found after turn")
+	}
+	if updated.CLISessionID != "cc-fresh-after-skip" {
+		t.Errorf("CLISessionID=%q want cc-fresh-after-skip", updated.CLISessionID)
+	}
+}
+
 func TestAgentProxyUnknownLogicalSession(t *testing.T) {
 	drv := newRecordingProxyDriver("never-used")
 	a, mgr := newProxyTestAdapterWithMgr(t, drv)


### PR DESCRIPTION
Fixes #43

## What changed and why

When a logical session's stored `CLISessionID` points to a conversation that no longer exists on disk (deleted, GC'd by the CLI, or adapter restarted), the agent proxy was spawning a `claude-code` process that immediately failed with `SESSION_NOT_FOUND`, then retrying with a second fresh spawn — doubling the 4-7s cold-start cost and producing transient error frames on the device.

This PR addresses root cause #2 from the issue (session resume failure cascade).

### Changes

- **`agent/driver.go`** — adds `CLISessionChecker` interface: an optional capability for drivers that can validate a resume target before spawning a subprocess.
- **`claudecode/driver.go`** — implements `Driver.CLISessionExists` by reusing the existing `findHistoryPath` scan (O(N) stat over project subdirs, same as `LoadMessages`).
- **`homeadapter/agent_proxy.go`** — before the attempt loop in `handleAgentMessageRequest`, type-asserts the driver to `CLISessionChecker`; if the stored CLI session id is absent on disk, clears `resumeFromLogical` so attempt 0 goes straight to a fresh session instead of triggering the retry cascade. Emits a new `agent_proxy_resume_skipped_missing` metric counter for observability.

### What this does NOT fix

- Root cause #1 (no process reuse / warm-start pool): the `claude` CLI's `-p` flag is inherently one-shot, so true process reuse requires a more significant architectural change (pre-spawn pool). That is out of scope for this PR.
- Tool-use latency: inherent to Claude's reasoning, not addressable in adapter code.

### Testing

- `TestCLISessionExists` (claudecode package): verifies false when projects dir absent, false for unknown id, true when JSONL file present.
- `TestAgentProxySkipsResumeWhenCLISessionMissing` (homeadapter package): end-to-end — driver started exactly once with empty ResumeID (no retry), logical session CLISessionID updated to the new minted id.
- Full adapter test suite: all pass (`go test ./...`).

### Runtime verification

Requires hardware (ESP32-S3 + cloud_saas profile) to fully verify the latency improvement. The fix is exercised by: restarting the adapter (which clears in-memory sessions), then sending a PTT message on a logical session whose CLI conversation was previously active — the adapter log should show `phase=agent_proxy: resume target missing on disk, skipping resume` instead of `WARN phase=agent_proxy_retry attempt=1 reason=SESSION_NOT_FOUND`.