### PR TITLE
fix: replace PCM envelope stub with real Ogg/Opus encoding on local_home path

### DIFF
--- a/adapter/internal/audio/codec.go
+++ b/adapter/internal/audio/codec.go
@@ -8,16 +8,11 @@ import (
 	"strings"
 )
 
-var bbclawPCMEnvelope = []byte("BBPCM16\n")
-
 func DecodeToPCM16LE(ctx context.Context, codec string, sampleRate int, channels int, payload []byte) ([]byte, error) {
 	switch normalizeCodec(codec) {
 	case "pcm16", "pcm_s16le":
 		return payload, nil
 	case "opus":
-		if bytes.HasPrefix(payload, bbclawPCMEnvelope) {
-			return payload[len(bbclawPCMEnvelope):], nil
-		}
 		return decodeOpusWithFFmpeg(ctx, sampleRate, channels, payload)
 	default:
 		return nil, fmt.Errorf("unsupported codec: %s", codec)

--- a/firmware/include/bb_audio.h
+++ b/firmware/include/bb_audio.h
@@ -21,4 +21,3 @@ void bb_audio_set_volume_pct(int pct);
 void bb_audio_set_speaker_enabled(int enabled);
 int bb_audio_get_speaker_sw_enabled(void);
 void bb_audio_poll_speaker_sw(void);
-esp_err_t bb_audio_encode_opus(const uint8_t* pcm, size_t pcm_len, uint8_t* out_buf, size_t out_buf_len, size_t* out_len);

--- a/firmware/src/bb_adapter_client.c
+++ b/firmware/src/bb_adapter_client.c
@@ -1407,15 +1407,19 @@ esp_err_t bb_adapter_stream_start(bb_stream_ctx_t* ctx) {
   ctx->next_seq = 1;
   ctx->ws_chunk_count = 0;
 
+  /* Create Ogg/Opus encoder for both transport modes.
+   * local_home: encoder output is base64-encoded and POSTed to /v1/stream/chunk.
+   * cloud_saas: encoder output is sent as binary WebSocket frames. */
+  log_mem_snapshot("stream start before encoder");
+  ctx->ws_encoder = bb_ogg_opus_encoder_create(BBCLAW_AUDIO_SAMPLE_RATE, BBCLAW_AUDIO_CHANNELS, BBCLAW_STREAM_CHUNK_MS);
+  if (ctx->ws_encoder == NULL) {
+    ESP_LOGE(TAG, "encoder create failed stream=%s", ctx->stream_id);
+    log_mem_snapshot("stream start encoder failed");
+    return ESP_ERR_NO_MEM;
+  }
+  log_mem_snapshot("stream start after encoder");
+
   if (bb_transport_is_cloud_saas()) {
-    log_mem_snapshot("stream start before encoder");
-    ctx->ws_encoder = bb_ogg_opus_encoder_create(BBCLAW_AUDIO_SAMPLE_RATE, BBCLAW_AUDIO_CHANNELS, BBCLAW_STREAM_CHUNK_MS);
-    if (ctx->ws_encoder == NULL) {
-      ESP_LOGE(TAG, "ws encoder create failed stream=%s", ctx->stream_id);
-      log_mem_snapshot("stream start encoder failed");
-      return ESP_ERR_NO_MEM;
-    }
-    log_mem_snapshot("stream start after encoder");
     char body[384] = {0};
     snprintf(body, sizeof(body),
              "{\"type\":\"request\",\"messageId\":\"start-%s\",\"deviceId\":\"%s\",\"kind\":\"voice.stream.start\","
@@ -1440,10 +1444,18 @@ esp_err_t bb_adapter_stream_start(bb_stream_ctx_t* ctx) {
            BBCLAW_AUDIO_CHANNELS);
 
   bb_http_resp_t resp = {0};
-  ESP_RETURN_ON_ERROR(http_post_json("/v1/stream/start", body, &resp), TAG, "stream start request failed");
+  esp_err_t http_err = http_post_json("/v1/stream/start", body, &resp);
+  if (http_err != ESP_OK) {
+    bb_ogg_opus_encoder_destroy((bb_ogg_opus_encoder_t*)ctx->ws_encoder);
+    ctx->ws_encoder = NULL;
+    ESP_LOGE(TAG, "stream start request failed err=%s", esp_err_to_name(http_err));
+    return http_err;
+  }
 
   if (resp.status_code < 200 || resp.status_code >= 300 || !body_contains_ok_true(resp.body)) {
     ESP_LOGE(TAG, "stream start failed status=%d body=%s", resp.status_code, resp.body);
+    bb_ogg_opus_encoder_destroy((bb_ogg_opus_encoder_t*)ctx->ws_encoder);
+    ctx->ws_encoder = NULL;
     return ESP_FAIL;
   }
 #if BBCLAW_ADAPTER_STREAM_CHUNK_DIAG
@@ -1693,6 +1705,25 @@ esp_err_t bb_adapter_stream_finish_stream(const bb_stream_ctx_t* ctx, bb_finish_
     xSemaphoreGive(s_ws.lock);
     ESP_LOGI(TAG, "ws voice.stream.finish stream=%s", ctx->stream_id);
     return ESP_OK;
+  }
+
+  /* local_home: flush any remaining PCM samples from the Ogg/Opus encoder,
+   * send the final Ogg pages as a chunk, then destroy the encoder. */
+  bb_stream_ctx_t* mutable_ctx = (bb_stream_ctx_t*)ctx;
+  if (mutable_ctx->ws_encoder != NULL) {
+    uint8_t* ogg_tail = NULL;
+    size_t ogg_tail_len = 0;
+    esp_err_t flush_err =
+        bb_ogg_opus_encoder_flush((bb_ogg_opus_encoder_t*)mutable_ctx->ws_encoder, &ogg_tail, &ogg_tail_len);
+    if (flush_err == ESP_OK && ogg_tail != NULL && ogg_tail_len > 0U) {
+      /* Send the final Ogg pages as a regular HTTP chunk before finishing. */
+      (void)bb_adapter_stream_chunk(mutable_ctx, ogg_tail, ogg_tail_len, bb_now_ms());
+      bb_ogg_opus_free(ogg_tail);
+    } else if (ogg_tail != NULL) {
+      bb_ogg_opus_free(ogg_tail);
+    }
+    bb_ogg_opus_encoder_destroy((bb_ogg_opus_encoder_t*)mutable_ctx->ws_encoder);
+    mutable_ctx->ws_encoder = NULL;
   }
 
   memset(out_result, 0, sizeof(*out_result));

--- a/firmware/src/bb_audio.c
+++ b/firmware/src/bb_audio.c
@@ -34,7 +34,6 @@ static i2c_master_dev_handle_t s_codec_dev;
 static i2s_chan_handle_t s_tx_chan;
 static i2s_chan_handle_t s_rx_chan;
 static uint8_t s_codec_addr = BBCLAW_ES8311_I2C_ADDR;
-static const uint8_t kPCMEnvelope[] = {'B', 'B', 'P', 'C', 'M', '1', '6', '\n'};
 static uint8_t s_rx_raw_buf[4096];
 static int s_rx_use_32bit;
 static int s_tx_use_stereo32;
@@ -1227,24 +1226,6 @@ esp_err_t bb_audio_play_test_tone(uint32_t freq_hz, uint32_t duration_ms, int16_
   return ESP_OK;
 }
 
-esp_err_t bb_audio_encode_opus(const uint8_t* pcm, size_t pcm_len, uint8_t* out_buf, size_t out_buf_len, size_t* out_len) {
-  if (pcm == NULL || out_buf == NULL || out_len == NULL) {
-    return ESP_ERR_INVALID_ARG;
-  }
-
-  /*
-   * TODO(audio): replace with real Opus encoder on device.
-   * Current transport sends a BBClaw PCM envelope accepted by adapter's opus path.
-   */
-  size_t need = sizeof(kPCMEnvelope) + pcm_len;
-  if (need > out_buf_len) {
-    return ESP_ERR_NO_MEM;
-  }
-  memcpy(out_buf, kPCMEnvelope, sizeof(kPCMEnvelope));
-  memcpy(out_buf + sizeof(kPCMEnvelope), pcm, pcm_len);
-  *out_len = need;
-  return ESP_OK;
-}
 
 void bb_audio_set_volume_pct(int pct) {
   if (pct < 0) { pct = 0; }

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -208,7 +208,6 @@ static char s_spoken_registration_code[16];
 static uint8_t s_stream_task_pcm_read_buf[1024];
 static uint8_t s_stream_pcm_chunk_buf[(BBCLAW_AUDIO_SAMPLE_RATE * BBCLAW_STREAM_CHUNK_MS / 1000) * sizeof(int16_t) *
                                       BBCLAW_AUDIO_CHANNELS];
-static uint8_t s_stream_encoded_chunk_buf[sizeof(s_stream_pcm_chunk_buf) + 64];
 
 /*
  * Ring buffer for decoupling I2S capture from HTTP upload.
@@ -1366,15 +1365,29 @@ static esp_err_t flush_stream_chunk(bb_stream_ctx_t* stream, uint8_t* pcm_buf, s
     return ESP_OK;
   }
 
-  size_t encoded_len = 0;
-  esp_err_t err = bb_audio_encode_opus(pcm_buf, *pending_pcm_len, s_stream_encoded_chunk_buf,
-                                       sizeof(s_stream_encoded_chunk_buf), &encoded_len);
+  /* local_home: encode PCM as Ogg/Opus using the stream's encoder, then POST
+   * the resulting Ogg pages to the adapter via bb_adapter_stream_chunk(). */
+  if (stream->ws_encoder == NULL) {
+    ESP_LOGE(TAG, "flush_stream_chunk: encoder not initialized for local_home");
+    return ESP_ERR_INVALID_STATE;
+  }
+  uint8_t* ogg_data = NULL;
+  size_t ogg_len = 0;
+  esp_err_t err = bb_ogg_opus_encoder_append_pcm16((bb_ogg_opus_encoder_t*)stream->ws_encoder,
+                                                   (const int16_t*)pcm_buf,
+                                                   *pending_pcm_len / sizeof(int16_t),
+                                                   &ogg_data, &ogg_len);
   if (err != ESP_OK) {
     return err;
   }
-  err = bb_adapter_stream_chunk(stream, s_stream_encoded_chunk_buf, encoded_len, bb_now_ms());
-  if (err != ESP_OK) {
-    return err;
+  if (ogg_data != NULL && ogg_len > 0U) {
+    err = bb_adapter_stream_chunk(stream, ogg_data, ogg_len, bb_now_ms());
+    bb_ogg_opus_free(ogg_data);
+    if (err != ESP_OK) {
+      return err;
+    }
+  } else if (ogg_data != NULL) {
+    bb_ogg_opus_free(ogg_data);
   }
   *pending_pcm_len = 0U;
   return ESP_OK;


### PR DESCRIPTION
Fixes #49

## What changed

The `bb_audio_encode_opus()` function was a stub that prepended an 8-byte `BBPCM16\n` header to raw PCM instead of doing any actual Opus encoding. The adapter had a matching special-case branch that stripped this header. This meant the local_home HTTP path was sending ~256 kbps raw PCM while advertising it as Opus.

The existing `bb_ogg_opus_encoder` (used by the cloud_saas WebSocket path) already provides real Opus encoding via libopus. This fix wires the local_home path through the same encoder.

## Changes

**firmware/src/bb_adapter_client.c**
- `bb_adapter_stream_start()`: create `bb_ogg_opus_encoder` for both transports (was cloud_saas only); fix error paths to destroy encoder on failure
- `bb_adapter_stream_finish_stream()`: flush and destroy encoder for local_home before sending the finish request (mirrors cloud_saas behaviour)

**firmware/src/bb_radio_app.c**
- `flush_stream_chunk()`: for local_home, call `bb_ogg_opus_encoder_append_pcm16()` and pass the resulting Ogg/Opus bytes to `bb_adapter_stream_chunk()` instead of calling the removed stub
- Remove unused `s_stream_encoded_chunk_buf` static array

**firmware/src/bb_audio.c** / **firmware/include/bb_audio.h**
- Remove `bb_audio_encode_opus()` stub and `kPCMEnvelope` constant

**adapter/internal/audio/codec.go**
- Remove `bbclawPCMEnvelope` special-case branch; the opus path now always decodes real Ogg/Opus via ffmpeg

## Testing

- Adapter: `make test` — all packages pass
- Firmware: `make build` — compiles cleanly (no new warnings)
- Hardware validation (PTT → local_home → adapter ASR) requires a physical device; the partition-size warning in the build output is pre-existing and unrelated to this change