### PR TITLE
fix(adapter): voice commands no longer silently dropped for Agent Bus drivers

### DIFF
--- a/adapter/internal/agent/router.go
+++ b/adapter/internal/agent/router.go
@@ -8,6 +8,8 @@
 package agent
 
 import (
+	"context"
+	"fmt"
 	"sync"
 
 	"github.com/daboluocc/bbclaw/adapter/internal/obs"
@@ -23,9 +25,10 @@ type DriverInfo struct {
 // Router keeps a name -> Driver map plus a pointer to the default driver
 // (the first one registered). Drivers are looked up by their Name().
 type Router struct {
-	mu          sync.RWMutex
-	drivers     map[string]Driver
-	defaultName string
+	mu              sync.RWMutex
+	drivers         map[string]Driver
+	defaultName     string
+	sessionResolver SessionResolver
 }
 
 // NewRouter returns an empty Router. Call Register for each driver you want
@@ -104,4 +107,85 @@ func (r *Router) SetDefault(name string) bool {
 	}
 	r.defaultName = name
 	return true
+}
+
+// SessionResolver resolves a device-visible session key (logical id or raw
+// CLI id) to the driver name and SessionID that are currently live. It is
+// implemented by the HTTP layer's sessionRegistry + logicalsession.Manager
+// and injected into the Router so SendSlashCommand can stop the right session
+// without creating a circular import.
+type SessionResolver interface {
+	// ResolveSession returns the driver name and SessionID for the given key,
+	// or ("", "", false) when the key is not found.
+	ResolveSession(sessionKey string) (driverName string, sid SessionID, ok bool)
+	// ResetSession clears the live session binding for sessionKey so the next
+	// agent turn starts a fresh CLI conversation.
+	ResetSession(sessionKey string)
+}
+
+// SetSessionResolver attaches a resolver used by SendSlashCommand. When nil
+// (the default), /stop and /new fall back to operating on the default driver
+// without a specific session.
+func (r *Router) SetSessionResolver(sr SessionResolver) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sessionResolver = sr
+}
+
+// SendSlashCommand implements the commandSender interface expected by
+// pipeline.Wrap. It handles /stop, /new, and /status for Agent Bus drivers
+// (claudecode, opencode, ollama, aider) so voice commands are not silently
+// dropped when the openclaw driver is not active.
+//
+// sessionKey is the device-visible session id (logical "ls-" id or raw CLI
+// id). The resolver, when set, maps it to the live (driver, SessionID) pair.
+func (r *Router) SendSlashCommand(ctx context.Context, command, sessionKey string) (string, error) {
+	r.mu.RLock()
+	defaultName := r.defaultName
+	resolver := r.sessionResolver
+	r.mu.RUnlock()
+
+	switch command {
+	case "/stop":
+		if resolver != nil {
+			driverName, sid, ok := resolver.ResolveSession(sessionKey)
+			if ok {
+				drv, found := r.Get(driverName)
+				if !found {
+					return "", fmt.Errorf("agent router: driver %q not registered", driverName)
+				}
+				if err := drv.Stop(sid); err != nil {
+					return "", fmt.Errorf("agent router: stop sid=%s driver=%s: %w", sid, driverName, err)
+				}
+				return "", nil
+			}
+		}
+		// No live session found — stop on the default driver is a no-op but
+		// not an error (nothing was running).
+		return "", nil
+
+	case "/new":
+		if resolver != nil {
+			resolver.ResetSession(sessionKey)
+		}
+		return "", nil
+
+	case "/status":
+		r.mu.RLock()
+		name := defaultName
+		r.mu.RUnlock()
+		if resolver != nil {
+			if driverName, sid, ok := resolver.ResolveSession(sessionKey); ok {
+				name = driverName
+				return fmt.Sprintf("driver: %s  session: %s", name, sid), nil
+			}
+		}
+		if name == "" {
+			return "no driver configured", nil
+		}
+		return fmt.Sprintf("driver: %s", name), nil
+
+	default:
+		return "", fmt.Errorf("agent router: unsupported command: %s", command)
+	}
 }

--- a/adapter/internal/agent/router_test.go
+++ b/adapter/internal/agent/router_test.go
@@ -104,3 +104,139 @@ func TestRouter_NilRegisterNoop(t *testing.T) {
 		t.Fatal("nil Register should not add entries")
 	}
 }
+
+// stubResolver is a minimal SessionResolver for testing SendSlashCommand.
+type stubResolver struct {
+	driverName string
+	sid        SessionID
+	found      bool
+	resetCalls []string
+	stopCalled bool
+}
+
+func (s *stubResolver) ResolveSession(sessionKey string) (string, SessionID, bool) {
+	return s.driverName, s.sid, s.found
+}
+
+func (s *stubResolver) ResetSession(sessionKey string) {
+	s.resetCalls = append(s.resetCalls, sessionKey)
+}
+
+func TestRouter_SendSlashCommand_Stop(t *testing.T) {
+	r := NewRouter()
+	log := obs.NewLogger()
+	d := &stubDriver{name: "alpha"}
+	r.Register(d, log)
+
+	// /stop with a live session should call Stop on the driver.
+	resolver := &stubResolver{driverName: "alpha", sid: "alpha-sid", found: true}
+	r.SetSessionResolver(resolver)
+
+	ctx := context.Background()
+	reply, err := r.SendSlashCommand(ctx, "/stop", "ls-abc")
+	if err != nil {
+		t.Fatalf("/stop unexpected error: %v", err)
+	}
+	// reply is empty — pipeline layer adds the confirmation text.
+	if reply != "" {
+		t.Errorf("/stop reply want empty got %q", reply)
+	}
+}
+
+func TestRouter_SendSlashCommand_StopNoSession(t *testing.T) {
+	r := NewRouter()
+	log := obs.NewLogger()
+	r.Register(&stubDriver{name: "alpha"}, log)
+
+	// /stop with no live session is a no-op, not an error.
+	resolver := &stubResolver{found: false}
+	r.SetSessionResolver(resolver)
+
+	ctx := context.Background()
+	reply, err := r.SendSlashCommand(ctx, "/stop", "ls-missing")
+	if err != nil {
+		t.Fatalf("/stop no-session unexpected error: %v", err)
+	}
+	if reply != "" {
+		t.Errorf("/stop no-session reply want empty got %q", reply)
+	}
+}
+
+func TestRouter_SendSlashCommand_New(t *testing.T) {
+	r := NewRouter()
+	log := obs.NewLogger()
+	r.Register(&stubDriver{name: "alpha"}, log)
+
+	resolver := &stubResolver{found: false}
+	r.SetSessionResolver(resolver)
+
+	ctx := context.Background()
+	reply, err := r.SendSlashCommand(ctx, "/new", "ls-abc")
+	if err != nil {
+		t.Fatalf("/new unexpected error: %v", err)
+	}
+	if reply != "" {
+		t.Errorf("/new reply want empty got %q", reply)
+	}
+	if len(resolver.resetCalls) != 1 || resolver.resetCalls[0] != "ls-abc" {
+		t.Errorf("/new: ResetSession not called with correct key, got %v", resolver.resetCalls)
+	}
+}
+
+func TestRouter_SendSlashCommand_Status(t *testing.T) {
+	r := NewRouter()
+	log := obs.NewLogger()
+	r.Register(&stubDriver{name: "alpha"}, log)
+
+	// With a live session, /status includes driver + session id.
+	resolver := &stubResolver{driverName: "alpha", sid: "alpha-sid", found: true}
+	r.SetSessionResolver(resolver)
+
+	ctx := context.Background()
+	reply, err := r.SendSlashCommand(ctx, "/status", "ls-abc")
+	if err != nil {
+		t.Fatalf("/status unexpected error: %v", err)
+	}
+	if !contains(reply, "alpha") {
+		t.Errorf("/status reply %q should contain driver name", reply)
+	}
+}
+
+func TestRouter_SendSlashCommand_StatusNoResolver(t *testing.T) {
+	r := NewRouter()
+	log := obs.NewLogger()
+	r.Register(&stubDriver{name: "beta"}, log)
+	// No resolver set — /status falls back to default driver name.
+
+	ctx := context.Background()
+	reply, err := r.SendSlashCommand(ctx, "/status", "")
+	if err != nil {
+		t.Fatalf("/status no-resolver unexpected error: %v", err)
+	}
+	if !contains(reply, "beta") {
+		t.Errorf("/status no-resolver reply %q should contain driver name", reply)
+	}
+}
+
+func TestRouter_SendSlashCommand_Unknown(t *testing.T) {
+	r := NewRouter()
+	r.Register(&stubDriver{name: "alpha"}, obs.NewLogger())
+
+	ctx := context.Background()
+	_, err := r.SendSlashCommand(ctx, "/unknown", "")
+	if err == nil {
+		t.Fatal("/unknown should return error")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/adapter/internal/httpapi/agent.go
+++ b/adapter/internal/httpapi/agent.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/daboluocc/bbclaw/adapter/internal/agent"
 	"github.com/daboluocc/bbclaw/adapter/internal/agent/logicalsession"
+	"github.com/daboluocc/bbclaw/adapter/internal/voicecmd"
 )
 
 // Session sweeper tunables. Sessions inactive for more than sessionTTL are
@@ -130,6 +131,68 @@ func (s *Server) SetAgentRouter(r *agent.Router) {
 	s.wsHub = newWSHub(s.log)
 	s.notifQueue = newNotificationQueue(32)
 	go s.runSessionSweeper(s.agentCtx, sweepInterval, sessionTTL)
+	// Wire the server as the session resolver so the router's SendSlashCommand
+	// can stop/reset live sessions for Agent Bus drivers (issue #53).
+	r.SetSessionResolver(s)
+}
+
+// ResolveSession implements agent.SessionResolver. It maps a device-visible
+// session key (logical "ls-" id or raw CLI id) to the live (driverName,
+// SessionID) pair held in the session registry.
+//
+// For logical ids the CLISessionID stored in the logical-session manager is
+// used to look up the registry entry. For raw CLI ids the registry is
+// consulted directly.
+func (s *Server) ResolveSession(sessionKey string) (driverName string, sid agent.SessionID, ok bool) {
+	if s.agentSessions == nil {
+		return "", "", false
+	}
+	// Logical session path: resolve ls- id → CLI session id → registry entry.
+	if s.sessions != nil && strings.HasPrefix(sessionKey, "ls-") {
+		ls, found := s.sessions.Get(logicalsession.ID(sessionKey))
+		if found && ls.CLISessionID != "" {
+			if entry, found2 := s.agentSessions.get(ls.CLISessionID); found2 {
+				return entry.driverName, entry.sid, true
+			}
+		}
+		return "", "", false
+	}
+	// Raw CLI id path.
+	if entry, found := s.agentSessions.get(sessionKey); found {
+		return entry.driverName, entry.sid, true
+	}
+	return "", "", false
+}
+
+// ResetSession implements agent.SessionResolver. It clears the live session
+// binding for the given key so the next agent turn starts a fresh CLI
+// conversation. For logical ids the CLISessionID is cleared in the manager;
+// for raw CLI ids the registry entry is removed.
+func (s *Server) ResetSession(sessionKey string) {
+	if s.agentSessions == nil {
+		return
+	}
+	// Logical session path.
+	if s.sessions != nil && strings.HasPrefix(sessionKey, "ls-") {
+		ls, found := s.sessions.Get(logicalsession.ID(sessionKey))
+		if found {
+			// Remove the live registry entry so the next turn starts fresh.
+			if ls.CLISessionID != "" {
+				s.agentSessions.mu.Lock()
+				delete(s.agentSessions.sessions, ls.CLISessionID)
+				s.agentSessions.mu.Unlock()
+			}
+			// Clear the stored CLI session id so drv.Start won't try to resume it.
+			if err := s.sessions.UpdateCLISessionID(ls.ID, ""); err != nil {
+				s.log.Warnf("agent: ResetSession clear cli id logical=%s err=%v", ls.ID, err)
+			}
+		}
+		return
+	}
+	// Raw CLI id path.
+	s.agentSessions.mu.Lock()
+	delete(s.agentSessions.sessions, sessionKey)
+	s.agentSessions.mu.Unlock()
 }
 
 // runSessionSweeper periodically evicts sessions that have been idle for
@@ -338,6 +401,40 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	requestedDriver := strings.TrimSpace(req.Driver)
+
+	// Voice command interception: if the transcript matches a slash command
+	// (e.g. "停止" → /stop, "新对话" → /new, "状态" → /status), dispatch it
+	// directly to the router and return a confirmation — no agent turn needed.
+	// This mirrors the pipeline.Wrap interception used on the stream/finish
+	// path and fixes silent command drops for Agent Bus drivers (issue #53).
+	if vcmd := voicecmd.Match(text); vcmd != nil {
+		sessionKey := strings.TrimSpace(req.SessionId)
+		s.log.Infof("agent: voice_command cmd=%s session=%s", vcmd.Command, sessionKey)
+		reply, err := s.router.SendSlashCommand(r.Context(), vcmd.Command, sessionKey)
+		if err != nil {
+			s.log.Errorf("agent: voice_command failed cmd=%s err=%v", vcmd.Command, err)
+		}
+		if reply == "" {
+			switch vcmd.Command {
+			case "/stop":
+				reply = "已停止"
+			case "/new":
+				reply = "新对话已开始"
+			case "/status":
+				reply = "状态已查询"
+			default:
+				reply = "已执行"
+			}
+		}
+		sw, ok := newFinishStreamWriter(w)
+		if !ok {
+			writeJSON(w, http.StatusInternalServerError, response{OK: false, Error: "STREAMING_NOT_SUPPORTED"})
+			return
+		}
+		_ = sw.write(map[string]any{"type": "text", "text": reply, "seq": 0})
+		_ = sw.write(map[string]any{"type": string(agent.EvTurnEnd), "seq": 1})
+		return
+	}
 
 	// Resolve an initial candidate driver. If the caller named one, it must
 	// exist; otherwise we fall back to the router default. A reused session

--- a/adapter/internal/httpapi/agent_test.go
+++ b/adapter/internal/httpapi/agent_test.go
@@ -519,3 +519,80 @@ func readNDJSONFrames(t *testing.T, r interface {
 	}
 	return frames
 }
+
+// TestHandleAgentMessage_VoiceCommand verifies that voice command phrases
+// (e.g. "停止", "新对话", "状态") are intercepted in handleAgentMessage and
+// return a confirmation reply without forwarding to the driver (issue #53).
+func TestHandleAgentMessage_VoiceCommand(t *testing.T) {
+	cases := []struct {
+		phrase  string
+		wantKey string // substring expected in reply text
+	}{
+		{"停止", "停止"},
+		{"新对话", "新对话"},
+		{"状态", "driver"},
+		{"stop", "停止"},
+		{"new", "新对话"},
+		{"status", "driver"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.phrase, func(t *testing.T) {
+			drv := newMockDriver()
+			r := agent.NewRouter()
+			r.Register(drv, obs.NewLogger())
+
+			dir := t.TempDir()
+			mgr, err := logicalsession.NewManager(
+				filepath.Join(dir, "sessions.json"), dir, obs.NewLogger(),
+			)
+			if err != nil {
+				t.Fatalf("NewManager: %v", err)
+			}
+
+			srv := NewServer(AppConfig{}, nil, nil, nil, nil, obs.NewLogger(), obs.NewMetrics())
+			srv.SetAgentRouter(r)
+			srv.SetSessionManager(mgr)
+
+			body, _ := json.Marshal(map[string]any{"text": tc.phrase})
+			req := httptest.NewRequest(http.MethodPost, "/v1/agent/message", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rr := httptest.NewRecorder()
+
+			srv.handleAgentMessage(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+			}
+
+			frames := readNDJSONFrames(t, rr.Body)
+			if len(frames) < 2 {
+				t.Fatalf("expected at least 2 frames (text + turn_end), got %d: %v", len(frames), frames)
+			}
+
+			// First frame must be a text frame with the confirmation.
+			first := frames[0]
+			if first["type"] != "text" {
+				t.Errorf("first frame type=%v want text", first["type"])
+			}
+			replyText, _ := first["text"].(string)
+			if !strings.Contains(replyText, tc.wantKey) {
+				t.Errorf("reply %q does not contain %q", replyText, tc.wantKey)
+			}
+
+			// Last frame must be turn_end.
+			last := frames[len(frames)-1]
+			if last["type"] != "turn_end" {
+				t.Errorf("last frame type=%v want turn_end", last["type"])
+			}
+
+			// The driver must NOT have received the voice command text.
+			drv.mu.Lock()
+			received := drv.received
+			drv.mu.Unlock()
+			if len(received) != 0 {
+				t.Errorf("driver should not have received any text, got %v", received)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #53

## What changed

**Root cause:** The pipeline's `commandSender` type assertion only matched `openclaw.Client`. When any Agent Bus driver (`claudecode`, `opencode`, `ollama`, `aider`) was active, `/stop`, `/new`, and `/status` were silently discarded with a WARN log. Additionally, the `/v1/agent/message` path bypasses `pipeline.Wrap` entirely, so voice commands sent via that endpoint were also dropped regardless of driver.

**Two-part fix:**

### 1. `Router.SendSlashCommand` (`adapter/internal/agent/router.go`)
Implements the `commandSender` interface on `*agent.Router`:
- `/stop` — calls `Driver.Stop` on the live session via the resolver
- `/new` — clears the session binding so the next turn starts a fresh CLI conversation
- `/status` — returns active driver name + session id

A new `SessionResolver` interface is injected from the HTTP layer to map the device-visible session key (logical `ls-` id) to the live `(driverName, SessionID)` pair, avoiding a circular import.

### 2. Voice command interception in `handleAgentMessage` (`adapter/internal/httpapi/agent.go`)
Added `voicecmd.Match` interception at the top of `handleAgentMessage`. Matched commands are dispatched to `router.SendSlashCommand` and a confirmation NDJSON stream (`text` + `turn_end`) is returned immediately — the driver never sees the command text.

`httpapi.Server` implements `agent.SessionResolver` (`ResolveSession` + `ResetSession`) and is wired to the router in `SetAgentRouter`.

## Testing
- Unit tests added for all three commands (`/stop`, `/new`, `/status`) on `Router.SendSlashCommand` with and without a live session
- Integration test `TestHandleAgentMessage_VoiceCommand` covers all 6 voice phrases (Chinese + English) via the HTTP handler, verifying the driver receives no text and the response is a confirmation stream
- Full `go test ./...` passes (15 packages)

## Not tested (hardware required)
End-to-end PTT → ASR → voice command → device feedback requires a physical BBClaw device or the LVGL simulator with audio input. The code path through `handleFinish` → `pipeline.Wrap` → `Router.SendSlashCommand` is covered by the unit tests above.