### PR TITLE
feat(adapter): openclaw driver 迁移到 method:"agent" + event streaming 协议

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ BBClaw 设备 ──WiFi──► 同一内网 ◄──WiFi── 运行面 (Ad
 - [ ] 面向极客套件的文档（接线、BOM、打印注意事项）
 - [ ] 社区反馈与稳定性迭代
 - [ ] **语音命令拦截**：ASR 后、LLM 前识别 /stop /new /status 等 slash command（adapter 侧）
-- [ ] **OpenClaw Agent 协议对接**：从 node.event/voice.transcript 切换到 method:"agent" + event streaming，支持长任务 subagent、实时 delta 播报、chat.abort 取消
+- [x] **OpenClaw Agent 协议对接**：从 node.event/voice.transcript 切换到 method:"agent" + event streaming，支持长任务 subagent、实时 delta 播报、chat.abort 取消
 
 ### v1.0.0 — 极客版 + 3D 打印成品形态
 

--- a/adapter/internal/agent/openclawdriver/driver.go
+++ b/adapter/internal/agent/openclawdriver/driver.go
@@ -1,6 +1,6 @@
 // Package openclawdriver implements agent.Driver on top of the existing
 // openclaw WebSocket client. It wraps internal/openclaw's Client and
-// translates VoiceTranscriptStream events into the unified agent.Event
+// translates the method:"agent" event stream into the unified agent.Event
 // stream.
 //
 // Why a separate package next to internal/openclaw:
@@ -12,13 +12,12 @@
 //     internal/openclaw — both can be imported in the same file.
 //
 // Capabilities:
-//   - ToolApproval: false. openclaw emits session.tool / toolCall events but
-//     has no approval round-trip — the agent just runs the tool itself.
+//   - ToolApproval: false. openclaw runs tools server-side; no approval
+//     round-trip is exposed to the adapter.
 //   - Resume: true. Multi-turn continuity is achieved by reusing the same
-//     session_key across Send calls (see openclaw.Client chat.subscribe /
-//     waitChatFinalText, which maintains server-side history under that
-//     key).
-//   - Streaming: true. SendVoiceTranscriptStream emits reply.delta chunks.
+//     session_key across Send calls — the gateway maintains chat history
+//     keyed off the session_key.
+//   - Streaming: true. SendAgentStream emits agent.delta chunks in real time.
 //   - MaxInputBytes: 64 KiB.
 package openclawdriver
 
@@ -46,11 +45,12 @@ const (
 // indirection exists purely so tests can swap in a mock without spinning up
 // a real WebSocket gateway.
 type openclawClient interface {
-	SendVoiceTranscriptStream(
+	SendAgentStream(
 		ctx context.Context,
-		event openclaw.VoiceTranscriptEvent,
-		onEvent func(openclaw.VoiceTranscriptStreamEvent),
-	) (openclaw.VoiceTranscriptDelivery, error)
+		params openclaw.AgentParams,
+		onEvent func(openclaw.AgentStreamEvent),
+	) error
+	SendChatAbort(ctx context.Context, sessionKey string) error
 }
 
 // Options configures the driver.
@@ -60,16 +60,16 @@ type Options struct {
 	// AuthToken is forwarded to openclaw.NewClient.
 	AuthToken string
 	// NodeID identifies this adapter on the openclaw bus and is threaded
-	// into every VoiceTranscriptEvent.NodeID.
+	// into every AgentParams.NodeID.
 	NodeID string
 	// DeviceIdentityPath is the on-disk path for the persistent device
 	// keypair openclaw expects. Empty means use openclaw's default.
 	DeviceIdentityPath string
-	// ReplyWaitTimeout is the idle window the openclaw client waits for the
-	// final chat reply after the initial RPC ack.
+	// ReplyWaitTimeout overrides the agent stream idle timeout. Zero means
+	// use the openclaw default (120 s).
 	ReplyWaitTimeout time.Duration
 	// HTTPTimeout is the per-request timeout used by the underlying
-	// http/websocket client.
+	// http/websocket client (connect handshake, etc.).
 	HTTPTimeout time.Duration
 }
 
@@ -163,13 +163,14 @@ func (d *Driver) Events(sid agent.SessionID) <-chan agent.Event {
 	return s.events
 }
 
-// Send forwards text to openclaw via SendVoiceTranscriptStream. Stream
-// events are translated 1:1 into agent.Event:
+// Send forwards text to openclaw via the method:"agent" + event stream
+// protocol. Stream events are translated into agent.Event:
 //
-//	reply.delta -> EvText
-//	thinking    -> dropped (would confuse end users; logs only)
-//	tool_call   -> EvToolCall (display-only; ToolApproval=false)
-//	others      -> dropped
+//	agent.delta     -> EvText  (emitted immediately, no buffering)
+//	agent.tool_call -> EvToolCall (display-only; ToolApproval=false)
+//	agent.thinking  -> dropped (logs only; confusing on small screens)
+//	agent.done      -> triggers EvTurnEnd
+//	others          -> dropped (logged)
 //
 // On stream completion (or error) an EvTurnEnd is always emitted.
 func (d *Driver) Send(sid agent.SessionID, text string) error {
@@ -187,7 +188,7 @@ func (d *Driver) Send(sid agent.SessionID, text string) error {
 	s.setCancel(cancel)
 	defer cancel()
 
-	event := openclaw.VoiceTranscriptEvent{
+	params := openclaw.AgentParams{
 		Text:       text,
 		SessionKey: s.sessionKey,
 		StreamID:   streamID,
@@ -199,13 +200,13 @@ func (d *Driver) Send(sid agent.SessionID, text string) error {
 		sid, s.sessionKey, streamID, len(text))
 
 	tStart := time.Now()
-	_, err := d.client.SendVoiceTranscriptStream(ctx, event, func(evt openclaw.VoiceTranscriptStreamEvent) {
+	err := d.client.SendAgentStream(ctx, params, func(evt openclaw.AgentStreamEvent) {
 		switch evt.Type {
-		case "reply.delta":
+		case "agent.delta":
 			if evt.Text != "" {
 				s.emit(agent.Event{Type: agent.EvText, Text: evt.Text})
 			}
-		case "thinking":
+		case "agent.thinking":
 			// Intentionally dropped: the agent_bus event schema doesn't have a
 			// "thinking" channel and surfacing partial reasoning to a small
 			// device screen is more confusing than helpful. We log it for
@@ -213,23 +214,25 @@ func (d *Driver) Send(sid agent.SessionID, text string) error {
 			if evt.Text != "" {
 				d.log.Infof("openclaw: thinking sid=%s preview=%q", sid, truncate(evt.Text, 80))
 			}
-		case "tool_call":
+		case "agent.tool_call":
 			if evt.Text != "" {
 				s.emit(agent.Event{
 					Type: agent.EvToolCall,
 					Tool: &agent.ToolCall{
 						// openclaw doesn't expose a stable per-call ID today;
 						// best-effort empty IDs are fine while ToolApproval
-						// stays false (no round-trip needs to address this
-						// call).
+						// stays false (no round-trip needs to address this call).
 						Tool: evt.Text,
 						Hint: "",
 					},
 				})
 			}
+		case "agent.done":
+			// Stream complete — EvTurnEnd is emitted below after SendAgentStream
+			// returns; nothing to do here.
 		default:
-			// tool.running / tool.done etc. — not part of the unified schema
-			// today; logged but not emitted.
+			// agent.tool_done and any future event types — not part of the
+			// unified schema today; logged but not emitted.
 			d.log.Infof("openclaw: stream evt sid=%s type=%s preview=%q",
 				sid, evt.Type, truncate(evt.Text, 80))
 		}
@@ -251,7 +254,8 @@ func (d *Driver) Approve(sid agent.SessionID, tid agent.ToolID, decision agent.D
 	return agent.ErrUnsupported
 }
 
-// Stop cancels any in-flight Send and closes the session's event channel.
+// Stop cancels any in-flight Send, sends chat.abort to the gateway
+// (best-effort, non-blocking), and closes the session's event channel.
 // Safe to call multiple times for the same sid (subsequent calls return
 // ErrUnknownSession).
 func (d *Driver) Stop(sid agent.SessionID) error {
@@ -262,13 +266,27 @@ func (d *Driver) Stop(sid agent.SessionID) error {
 	if !ok {
 		return agent.ErrUnknownSession
 	}
+
+	// Cancel the in-flight Send context first so the stream loop exits.
 	s.mu.Lock()
 	if s.cancel != nil {
 		s.cancel()
 	}
 	closed := s.closed
 	s.closed = true
+	sessionKey := s.sessionKey
 	s.mu.Unlock()
+
+	// Send chat.abort to the gateway in the background — best-effort.
+	// We use a fresh background context because s.rootCtx may already be done.
+	go func() {
+		abortCtx, abortCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer abortCancel()
+		if err := d.client.SendChatAbort(abortCtx, sessionKey); err != nil {
+			d.log.Infof("openclaw: chat.abort sid=%s err=%v (best-effort, ignored)", sid, err)
+		}
+	}()
+
 	if !closed {
 		close(s.events)
 	}
@@ -299,6 +317,15 @@ func (s *session) setCancel(c context.CancelFunc) {
 
 func (s *session) emit(e agent.Event) {
 	e.Seq = atomic.AddUint64(&s.seq, 1)
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return
+	}
+	// Use recover to guard against the rare race where Stop() closes the
+	// channel between the closed-check above and the channel send below.
+	defer func() { recover() }() //nolint:errcheck
 	select {
 	case s.events <- e:
 	case <-s.rootCtx.Done():

--- a/adapter/internal/agent/openclawdriver/driver_test.go
+++ b/adapter/internal/agent/openclawdriver/driver_test.go
@@ -13,33 +13,32 @@ import (
 	"github.com/daboluocc/bbclaw/adapter/internal/openclaw"
 )
 
-// fakeClient is a mock implementation of openclawClient. Each call to
-// SendVoiceTranscriptStream replays the canned events list and then returns
-// the canned err.
+// fakeClient is a mock implementation of openclawClient using the new
+// method:"agent" interface. Each call to SendAgentStream replays the canned
+// events list and then returns the canned err.
 type fakeClient struct {
 	mu sync.Mutex
 
 	// events is the list of stream events to feed onEvent on each call.
-	events []openclaw.VoiceTranscriptStreamEvent
-	// err is returned from SendVoiceTranscriptStream after replaying events.
+	events []openclaw.AgentStreamEvent
+	// err is returned from SendAgentStream after replaying events.
 	err error
-	// reply is returned in the VoiceTranscriptDelivery.
-	reply string
 
-	// recorded:
-	calls []openclaw.VoiceTranscriptEvent
+	// recorded calls:
+	agentCalls []openclaw.AgentParams
+	abortCalls []string // session keys passed to SendChatAbort
+	abortErr   error    // error to return from SendChatAbort
 }
 
-func (f *fakeClient) SendVoiceTranscriptStream(
+func (f *fakeClient) SendAgentStream(
 	ctx context.Context,
-	event openclaw.VoiceTranscriptEvent,
-	onEvent func(openclaw.VoiceTranscriptStreamEvent),
-) (openclaw.VoiceTranscriptDelivery, error) {
+	params openclaw.AgentParams,
+	onEvent func(openclaw.AgentStreamEvent),
+) error {
 	f.mu.Lock()
-	f.calls = append(f.calls, event)
-	evs := append([]openclaw.VoiceTranscriptStreamEvent(nil), f.events...)
+	f.agentCalls = append(f.agentCalls, params)
+	evs := append([]openclaw.AgentStreamEvent(nil), f.events...)
 	err := f.err
-	reply := f.reply
 	f.mu.Unlock()
 
 	if onEvent != nil {
@@ -47,14 +46,30 @@ func (f *fakeClient) SendVoiceTranscriptStream(
 			onEvent(e)
 		}
 	}
-	return openclaw.VoiceTranscriptDelivery{ReplyText: reply}, err
+	return err
 }
 
-func (f *fakeClient) snapshot() []openclaw.VoiceTranscriptEvent {
+func (f *fakeClient) SendChatAbort(ctx context.Context, sessionKey string) error {
+	f.mu.Lock()
+	f.abortCalls = append(f.abortCalls, sessionKey)
+	err := f.abortErr
+	f.mu.Unlock()
+	return err
+}
+
+func (f *fakeClient) snapshotAgentCalls() []openclaw.AgentParams {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	out := make([]openclaw.VoiceTranscriptEvent, len(f.calls))
-	copy(out, f.calls)
+	out := make([]openclaw.AgentParams, len(f.agentCalls))
+	copy(out, f.agentCalls)
+	return out
+}
+
+func (f *fakeClient) snapshotAbortCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.abortCalls))
+	copy(out, f.abortCalls)
 	return out
 }
 
@@ -95,25 +110,26 @@ func TestCapabilitiesAndName(t *testing.T) {
 		t.Error("Resume must be true: session_key reuse provides continuity")
 	}
 	if !caps.Streaming {
-		t.Error("Streaming must be true: SendVoiceTranscriptStream emits deltas")
+		t.Error("Streaming must be true: SendAgentStream emits deltas")
 	}
 	if caps.MaxInputBytes != 64*1024 {
 		t.Errorf("MaxInputBytes=%d want 65536", caps.MaxInputBytes)
 	}
 }
 
-// TestSendTranslatesStreamEvents feeds reply.delta + thinking + tool_call
-// events through the driver and verifies the unified agent.Event mapping.
+// TestSendTranslatesStreamEvents feeds agent.delta + agent.thinking +
+// agent.tool_call + agent.done events through the driver and verifies the
+// unified agent.Event mapping.
 func TestSendTranslatesStreamEvents(t *testing.T) {
 	fake := &fakeClient{
-		events: []openclaw.VoiceTranscriptStreamEvent{
-			{Type: "reply.delta", Text: "Hello"},
-			{Type: "thinking", Text: "let me think..."}, // must be dropped
-			{Type: "reply.delta", Text: " world"},
-			{Type: "tool_call", Text: "Bash"},
-			{Type: "tool.running", Text: "Bash"}, // unknown — dropped
+		events: []openclaw.AgentStreamEvent{
+			{Type: "agent.delta", Text: "Hello"},
+			{Type: "agent.thinking", Text: "let me think..."}, // must be dropped
+			{Type: "agent.delta", Text: " world"},
+			{Type: "agent.tool_call", Text: "Bash"},
+			{Type: "agent.tool_done", Text: "Bash"}, // unknown to schema — dropped
+			{Type: "agent.done", Text: ""},
 		},
-		reply: "Hello world",
 	}
 
 	d := newWithClient(fake, "test-node", obs.NewLogger())
@@ -165,11 +181,11 @@ func TestSendTranslatesStreamEvents(t *testing.T) {
 		t.Errorf("errs=%d want 0", errs)
 	}
 
-	// Outbound event must carry the resumed session_key and the configured
+	// Outbound params must carry the resumed session_key and the configured
 	// node id. StreamID is per-turn, prefixed with the session id.
-	calls := fake.snapshot()
+	calls := fake.snapshotAgentCalls()
 	if len(calls) != 1 {
-		t.Fatalf("calls=%d want 1", len(calls))
+		t.Fatalf("agentCalls=%d want 1", len(calls))
 	}
 	if calls[0].SessionKey != "session-123" {
 		t.Errorf("SessionKey=%q want session-123 (resume id was provided)", calls[0].SessionKey)
@@ -250,9 +266,9 @@ func TestStartGeneratesSessionKeyWhenNoResume(t *testing.T) {
 		t.Fatalf("Send: %v", err)
 	}
 
-	calls := fake.snapshot()
+	calls := fake.snapshotAgentCalls()
 	if len(calls) != 1 {
-		t.Fatalf("calls=%d want 1", len(calls))
+		t.Fatalf("agentCalls=%d want 1", len(calls))
 	}
 	if strings.TrimSpace(calls[0].SessionKey) == "" {
 		t.Error("auto-generated session_key must not be empty")
@@ -284,4 +300,98 @@ func TestApproveUnsupported(t *testing.T) {
 	if err := d.Approve(sid, "tool-1", agent.DecisionOnce); !errors.Is(err, agent.ErrUnsupported) {
 		t.Errorf("Approve err=%v want ErrUnsupported", err)
 	}
+}
+
+// TestStopSendsChatAbort verifies that Stop() triggers a SendChatAbort call
+// with the correct session key. This is the server-side cancel path.
+func TestStopSendsChatAbort(t *testing.T) {
+	fake := &fakeClient{}
+	blockingFake := &blockingClient{fakeClient: fake}
+
+	d := newWithClient(blockingFake, "n", obs.NewLogger())
+	sid, err := d.Start(context.Background(), agent.StartOpts{ResumeID: "abort-session-key"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	sendStarted := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(sendStarted)
+		done <- d.Send(sid, "long task")
+	}()
+	<-sendStarted
+	// Give Send a moment to enter the blocking client.
+	time.Sleep(10 * time.Millisecond)
+
+	if err := d.Stop(sid); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	// Wait for Send to finish (context cancelled by Stop).
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Send returned err=%v; want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send did not return after Stop")
+	}
+
+	// Give the background abort goroutine time to run.
+	time.Sleep(50 * time.Millisecond)
+
+	aborts := fake.snapshotAbortCalls()
+	if len(aborts) == 0 {
+		t.Fatal("SendChatAbort was not called after Stop")
+	}
+	if aborts[0] != "abort-session-key" {
+		t.Errorf("SendChatAbort sessionKey=%q want abort-session-key", aborts[0])
+	}
+}
+
+// TestStopChatAbortErrorIsIgnored verifies that a SendChatAbort failure does
+// not propagate — it is best-effort.
+func TestStopChatAbortErrorIsIgnored(t *testing.T) {
+	fake := &fakeClient{
+		abortErr: errors.New("gateway unreachable"),
+	}
+	d := newWithClient(fake, "n", obs.NewLogger())
+	sid, err := d.Start(context.Background(), agent.StartOpts{ResumeID: "key-x"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	// Stop without an active Send — should not panic or return error.
+	if err := d.Stop(sid); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	// Give the background goroutine time to run.
+	time.Sleep(50 * time.Millisecond)
+	// No assertion needed — the test passes if it doesn't panic.
+}
+
+// ─── blockingClient ──────────────────────────────────────────────────────────
+
+// blockingClient wraps fakeClient but blocks SendAgentStream until ctx is
+// cancelled. Used to simulate an in-flight long-running agent turn.
+type blockingClient struct {
+	fakeClient *fakeClient
+}
+
+func (b *blockingClient) SendAgentStream(
+	ctx context.Context,
+	params openclaw.AgentParams,
+	onEvent func(openclaw.AgentStreamEvent),
+) error {
+	b.fakeClient.mu.Lock()
+	b.fakeClient.agentCalls = append(b.fakeClient.agentCalls, params)
+	b.fakeClient.mu.Unlock()
+
+	// Block until context is cancelled.
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (b *blockingClient) SendChatAbort(ctx context.Context, sessionKey string) error {
+	return b.fakeClient.SendChatAbort(ctx, sessionKey)
 }

--- a/adapter/internal/openclaw/client.go
+++ b/adapter/internal/openclaw/client.go
@@ -37,6 +37,29 @@ type VoiceTranscriptStreamEvent struct {
 	Text string
 }
 
+// AgentParams holds the parameters for a method:"agent" request.
+type AgentParams struct {
+	// SessionKey is the openclaw session key (multi-turn continuity).
+	SessionKey string
+	// Text is the user message to send.
+	Text string
+	// StreamID is an optional per-turn idempotency key.
+	StreamID string
+	// Source identifies the caller (e.g. "bbclaw.adapter.agent").
+	Source string
+	// NodeID identifies this adapter node.
+	NodeID string
+}
+
+// AgentStreamEvent is a single event received from the method:"agent" event stream.
+type AgentStreamEvent struct {
+	// Type is one of: "agent.delta", "agent.tool_call", "agent.tool_done",
+	// "agent.thinking", "agent.done", or any other gateway-defined type.
+	Type string
+	// Text carries the text payload (delta text, tool name, etc.).
+	Text string
+}
+
 // SendSlashCommand sends a slash command via the WS protocol using chat.send
 // with operator role. Gateway parses /commands from chat.send when senderIsOwner.
 func (c *Client) SendSlashCommand(ctx context.Context, command, sessionKey string) (string, error) {
@@ -1000,6 +1023,238 @@ func extractChatText(payload map[string]any) string {
 		}
 	}
 	return strings.TrimSpace(strings.Join(parts, "\n"))
+}
+
+// SendAgentStream sends a method:"agent" request over the WS connection and
+// streams the resulting events to onEvent. It uses an idle-based timeout
+// (resolveReplyWaitTimeout) rather than a fixed HTTP timeout, so long-running
+// tool chains (>30 s) are supported as long as the gateway keeps sending
+// events.
+//
+// Event types forwarded to onEvent:
+//
+//	"agent.delta"     — incremental text from the assistant
+//	"agent.tool_call" — tool invocation started
+//	"agent.tool_done" — tool invocation finished
+//	"agent.thinking"  — internal reasoning (callers may drop this)
+//	"agent.done"      — turn complete; onEvent is called once then the method returns
+//
+// Any other event type is forwarded as-is so callers can handle future types.
+func (c *Client) SendAgentStream(
+	ctx context.Context,
+	params AgentParams,
+	onEvent func(AgentStreamEvent),
+) error {
+	// Normalize session key — gateway canonicalises to lowercase.
+	params.SessionKey = strings.ToLower(strings.TrimSpace(params.SessionKey))
+
+	conn, _, err := c.dialer.DialContext(ctx, c.endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("dial openclaw ws: %w", err)
+	}
+	defer conn.Close()
+
+	// ── auth handshake ──────────────────────────────────────────────────────
+	nonce, err := c.waitConnectChallenge(conn)
+	if err != nil {
+		return err
+	}
+	connectParams, err := c.buildConnectParams(nonce)
+	if err != nil {
+		return err
+	}
+	connectReqID := "connect-" + uuid.NewString()
+	if err := c.writeJSON(ctx, conn, map[string]any{
+		"type":   "req",
+		"id":     connectReqID,
+		"method": "connect",
+		"params": connectParams,
+	}); err != nil {
+		return err
+	}
+	if err := c.waitResponseOK(conn, connectReqID); err != nil {
+		return fmt.Errorf("openclaw connect failed: %w", err)
+	}
+
+	// ── send method:"agent" request ─────────────────────────────────────────
+	agentReqID := "agent-" + uuid.NewString()
+	if err := c.writeJSON(ctx, conn, map[string]any{
+		"type":   "req",
+		"id":     agentReqID,
+		"method": "agent",
+		"params": map[string]any{
+			"sessionKey": params.SessionKey,
+			"text":       params.Text,
+			"streamId":   params.StreamID,
+			"source":     params.Source,
+			"nodeId":     params.NodeID,
+		},
+	}); err != nil {
+		return err
+	}
+	// Wait for the initial ack (ok:true) before entering the stream loop.
+	if err := c.waitResponseOK(conn, agentReqID); err != nil {
+		return fmt.Errorf("openclaw agent request failed: %w", err)
+	}
+
+	// ── stream event loop ───────────────────────────────────────────────────
+	// Use idle timeout: any message from the gateway resets the deadline.
+	idleTimeout := resolveAgentIdleTimeout(c.replyWaitTimeout)
+	deadline := time.Now().Add(idleTimeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err := conn.SetReadDeadline(deadline); err != nil {
+			return fmt.Errorf("set read deadline: %w", err)
+		}
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			if isTimeoutErr(err) {
+				return fmt.Errorf("openclaw agent stream idle timeout after %s", idleTimeout)
+			}
+			return fmt.Errorf("read agent stream: %w", err)
+		}
+		// Any message resets the idle deadline.
+		deadline = time.Now().Add(idleTimeout)
+		if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+			deadline = ctxDeadline
+		}
+
+		var frame map[string]any
+		if err := json.Unmarshal(msg, &frame); err != nil {
+			continue
+		}
+
+		// We expect event frames: {"type":"event","event":"agent","payload":{...}}
+		if frame["type"] != "event" || frame["event"] != "agent" {
+			continue
+		}
+		payload, _ := frame["payload"].(map[string]any)
+		if payload == nil {
+			continue
+		}
+		// Verify session key matches.
+		payloadSessionKey, _ := payload["sessionKey"].(string)
+		if !sessionKeyMatches(payloadSessionKey, params.SessionKey) {
+			continue
+		}
+
+		evtType, _ := payload["type"].(string)
+		evtType = strings.TrimSpace(evtType)
+		if evtType == "" {
+			continue
+		}
+
+		// Extract text from common payload shapes.
+		text := extractAgentEventText(payload)
+
+		if onEvent != nil {
+			onEvent(AgentStreamEvent{Type: evtType, Text: text})
+		}
+
+		if evtType == "agent.done" {
+			return nil
+		}
+	}
+}
+
+// extractAgentEventText pulls the text value out of an agent event payload.
+// The gateway may use "text", "delta", or "name" depending on event type.
+func extractAgentEventText(payload map[string]any) string {
+	for _, key := range []string{"text", "delta", "name"} {
+		if v, ok := payload[key].(string); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	// Nested data object (some gateway versions wrap in data:{text:...})
+	if data, ok := payload["data"].(map[string]any); ok {
+		for _, key := range []string{"text", "delta", "name"} {
+			if v, ok := data[key].(string); ok && strings.TrimSpace(v) != "" {
+				return strings.TrimSpace(v)
+			}
+		}
+	}
+	return ""
+}
+
+// SendChatAbort sends a chat.abort request to the gateway for the given
+// sessionKey. This notifies the server to cancel any in-progress agent turn.
+// It is best-effort: errors are logged but not returned to the caller.
+//
+// SendChatAbort opens its own short-lived WS connection so it can be called
+// from Stop() independently of the Send() connection.
+func (c *Client) SendChatAbort(ctx context.Context, sessionKey string) error {
+	sessionKey = strings.ToLower(strings.TrimSpace(sessionKey))
+	if sessionKey == "" {
+		return nil
+	}
+
+	// Use a short timeout for the abort — we don't want Stop() to block.
+	abortTimeout := 5 * time.Second
+	dialCtx, cancel := context.WithTimeout(ctx, abortTimeout)
+	defer cancel()
+
+	conn, _, err := c.dialer.DialContext(dialCtx, c.endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("dial openclaw ws for abort: %w", err)
+	}
+	defer conn.Close()
+
+	nonce, err := c.waitConnectChallenge(conn)
+	if err != nil {
+		return fmt.Errorf("abort connect challenge: %w", err)
+	}
+	// Use operator role for abort — same as slash command path.
+	connectParams, err := c.buildOperatorConnectParams(nonce)
+	if err != nil {
+		return fmt.Errorf("abort build connect params: %w", err)
+	}
+	connectReqID := "abort-connect-" + uuid.NewString()
+	if err := c.writeJSON(dialCtx, conn, map[string]any{
+		"type":   "req",
+		"id":     connectReqID,
+		"method": "connect",
+		"params": connectParams,
+	}); err != nil {
+		return fmt.Errorf("abort connect write: %w", err)
+	}
+	if err := c.waitResponseOK(conn, connectReqID); err != nil {
+		return fmt.Errorf("abort connect failed: %w", err)
+	}
+
+	abortReqID := "abort-" + uuid.NewString()
+	if err := c.writeJSON(dialCtx, conn, map[string]any{
+		"type":   "req",
+		"id":     abortReqID,
+		"method": "chat.abort",
+		"params": map[string]any{
+			"sessionKey": sessionKey,
+		},
+	}); err != nil {
+		return fmt.Errorf("abort write: %w", err)
+	}
+	// Best-effort wait for ack — ignore errors (gateway may not support abort yet).
+	_ = c.waitResponseOK(conn, abortReqID)
+	return nil
+}
+
+// resolveAgentIdleTimeout returns the idle timeout for the agent event stream.
+// It is more generous than the HTTP timeout to support long tool chains.
+func resolveAgentIdleTimeout(override time.Duration) time.Duration {
+	const defaultIdle = 120 * time.Second
+	const maxIdle = 300 * time.Second
+	if override > 0 {
+		if override > maxIdle {
+			return maxIdle
+		}
+		return override
+	}
+	return defaultIdle
 }
 
 func isTimeoutErr(err error) bool {


### PR DESCRIPTION
Fixes #55

## 变更内容

### `adapter/internal/openclaw/client.go`
- 新增 `AgentParams` 和 `AgentStreamEvent` 类型
- 新增 `SendAgentStream()` 方法：通过 WS 发送 `method:"agent"` 请求，以 idle-based timeout（默认 120s，最大 300s）读取事件流，支持长任务工具调用链（>30s）
- 新增 `SendChatAbort()` 方法：通过独立短连接以 operator 角色发送 `chat.abort`，best-effort（失败只记日志）
- 新增 `resolveAgentIdleTimeout()` 和 `extractAgentEventText()` 辅助函数

### `adapter/internal/agent/openclawdriver/driver.go`
- `openclawClient` 接口从 `SendVoiceTranscriptStream` 切换为 `SendAgentStream` + `SendChatAbort`
- `Send()` 改用 `SendAgentStream`：`agent.delta` → `EvText`（实时，不缓冲），`agent.tool_call` → `EvToolCall`，`agent.thinking` → 丢弃（仅日志），`agent.done` → 触发 `EvTurnEnd`
- `Stop()` 在 cancel context 前，在后台 goroutine 发送 `chat.abort` 通知 Gateway 中止 agent turn
- `session.emit()` 增加 closed 检查 + recover，防止 Stop/Send 并发时 send-on-closed-channel panic

### `adapter/internal/agent/openclawdriver/driver_test.go`
- `fakeClient` 重写为实现新接口（`SendAgentStream` + `SendChatAbort`）
- 更新所有现有测试使用新事件类型（`agent.delta` / `agent.tool_call` / `agent.done`）
- 新增 `TestStopSendsChatAbort`：验证 Stop() 触发 SendChatAbort 且携带正确 session key
- 新增 `TestStopChatAbortErrorIsIgnored`：验证 abort 失败不影响 Stop() 返回值

### `ROADMAP.md`
- v0.2.x「OpenClaw Agent 协议对接」标记为完成 ✅

## 测试

全部 adapter 单元测试通过（含 race detector）：`go test ./... -race`

## 未验证（需硬件/Gateway）

- 实际 OpenClaw Gateway 的 `method:"agent"` wire format 需与真实 Gateway 对接验证
- `chat.abort` 的 Gateway 端支持需确认（当前 best-effort，Gateway 不支持时静默忽略）