### PR TITLE
fix: gate SESSION_NOT_FOUND broadcast and add proactive CLISessionExists check

### DIFF
--- a/adapter/internal/httpapi/agent.go
+++ b/adapter/internal/httpapi/agent.go
@@ -606,6 +606,24 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 	s.metrics.Inc("agent_message_start")
 	ctx := r.Context()
 
+	// Proactive resume validation: if the driver can check whether a CLI
+	// conversation still exists on disk, do so before the attempt loop.
+	// A missing transcript means --resume would immediately fail with
+	// SESSION_NOT_FOUND, wasting 4-7s on a doomed cold-start. Clearing
+	// resumeFromLogical here lets the first attempt go straight to a fresh
+	// session instead of triggering the reactive retry cascade (issue #58,
+	// mirrors homeadapter/agent_proxy.go).
+	if resumeFromLogical != "" {
+		if checker, ok := drv.(agent.CLISessionChecker); ok {
+			if !checker.CLISessionExists(resumeFromLogical) {
+				s.log.Infof("agent: resume target missing on disk, skipping resume cli=%s logical=%s",
+					resumeFromLogical, logicalID)
+				s.metrics.Inc("agent_message_resume_skipped_missing")
+				resumeFromLogical = ""
+			}
+		}
+	}
+
 	// Outer loop wraps one or two attempts. Attempt 0 resumes the requested
 	// session; attempt 1 fires only if the driver emits SESSION_NOT_FOUND
 	// (ADR-014) — we mint a fresh session and re-send the user text so the
@@ -742,14 +760,20 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 				case agent.EvError:
 					errorCount++
 					lastError = ev.Text
-					s.agentSessions.setState(string(sid), "error")
-					broadcastSID := string(sid)
-					if usingLogical && logicalID != "" {
-						broadcastSID = string(logicalID)
-					}
-					s.broadcastSessionStateChange(broadcastSID, "error", ev.Text)
 					if strings.HasPrefix(ev.Text, "SESSION_NOT_FOUND") {
 						sessionNotFound = true
+					}
+					// Only broadcast the error state when we are NOT going to
+					// retry transparently. Broadcasting before the retry fires
+					// leaks a transient SESSION_NOT_FOUND to WebSocket-connected
+					// devices as AGENT_TURN_FAILED (ADR-014 Phase A gap, issue #58).
+					if !sessionNotFound || attempt+1 >= maxAttempts {
+						s.agentSessions.setState(string(sid), "error")
+						broadcastSID := string(sid)
+						if usingLogical && logicalID != "" {
+							broadcastSID = string(logicalID)
+						}
+						s.broadcastSessionStateChange(broadcastSID, "error", ev.Text)
 					}
 				case agent.EvTurnEnd:
 					turnEnded = true


### PR DESCRIPTION
Fixes #58

## What changed

Two surgical fixes in `adapter/internal/httpapi/agent.go` to close the ADR-014 Phase A gap where `SESSION_NOT_FOUND` surfaced as `AGENT_TURN_FAILED` on WebSocket-connected devices.

### 1. Gate `broadcastSessionStateChange` on retryability

The `EvError` handler previously called `setState` + `broadcastSessionStateChange` unconditionally, before checking whether the error was `SESSION_NOT_FOUND`. This leaked the transient error to WS clients (and through the cloud relay to the device) before the retry loop had a chance to recover silently.

The broadcast is now skipped when `sessionNotFound=true` and a retry attempt remains — consistent with the existing NDJSON frame suppression logic immediately below it.

### 2. Proactive `CLISessionExists` check before the retry loop

When `resumeFromLogical` is set and the driver implements `agent.CLISessionChecker`, the on-disk JSONL is verified before attempt 0. If missing, `resumeFromLogical` is cleared so the first attempt goes straight to a fresh session instead of spending 4-7s on a doomed `--resume` that triggers the reactive retry cascade.

This mirrors the identical check already present in `homeadapter/agent_proxy.go` (lines 717-726) — the HTTP API path was the only ingress missing it.

## Testing

- `go build ./...` — clean
- `go test ./internal/httpapi/... ./internal/agent/...` — all pass
- Runtime verification requires a physical device or the local SOP (delete a Claude CLI conversation file, send a message on the same logical session, confirm no `AGENT_TURN_FAILED` reaches the device). Hardware not available in CI.