### PR TITLE
fix: iOS-style battery icon redesign (#61)

### DIFF
--- a/firmware/include/bb_display.h
+++ b/firmware/include/bb_display.h
@@ -27,8 +27,9 @@ void bb_display_set_tts_playing(int playing);
 void bb_display_set_tts_sentence(const char* sentence_text);
 /** PTT 录音阶段的实时输入电平（0-100）与是否检测到有效声音 */
 void bb_display_set_record_level(uint8_t level_pct, int voiced);
-/** 状态栏电池信息；supported=0 时整个组件隐藏，available=0 时显示占位 */
-void bb_display_set_battery(int supported, int available, int percent, int low);
+/** 状态栏电池信息；supported=0 时整个组件隐藏，available=0 时显示占位。
+ *  charging=1 时顶栏图标显示绿色满格+闪电（数据层当前恒 0，等 VBUS GPIO 接好后启用）。 */
+void bb_display_set_battery(int supported, int available, int percent, int low, int charging);
 /** 底栏 session id；NULL/"" 清空。长 id 会自动截短为前 8 位展示 */
 void bb_display_set_session_id(const char* session_id);
 /** 底栏 CWD pool 名；NULL/"" 清空 */

--- a/firmware/include/bb_page_locked.h
+++ b/firmware/include/bb_page_locked.h
@@ -4,8 +4,10 @@
 
 /* LOCKED page: independent full-screen padlock view.
  * Shown when cloud_saas passphrase unlock is required.
- * update_status() handles BB_STATUS_VERIFY_TX/VERIFY/VERIFY_ERR transitions. */
+ * update_status() handles BB_STATUS_VERIFY_TX/VERIFY/VERIFY_ERR transitions.
+ * update_battery() refreshes the large battery widget below the padlock. */
 
 void bb_page_locked_create(lv_obj_t* scr);
 void bb_page_locked_set_visible(int visible);
 void bb_page_locked_update_status(const char* status);
+void bb_page_locked_update_battery(int supported, int available, int percent, int low, int charging);

--- a/firmware/include/bb_power.h
+++ b/firmware/include/bb_power.h
@@ -8,8 +8,12 @@ typedef struct {
   int millivolts;
   int percent;
   int low;
+  int charging; /* 1 = USB power detected; 0 = on battery (or unknown) */
 } bb_power_state_t;
 
 esp_err_t bb_power_init(void);
 esp_err_t bb_power_refresh(void);
 void bb_power_get_state(bb_power_state_t* out_state);
+/* Returns 1 if the device is currently charging, 0 otherwise.
+ * Always returns 0 until VBUS GPIO detection is wired up. */
+int bbclaw_power_is_charging(void);

--- a/firmware/src/bb_lvgl_display.c
+++ b/firmware/src/bb_lvgl_display.c
@@ -109,11 +109,25 @@ LV_FONT_DECLARE(lv_font_montserrat_48)
 #define UI_WIFI_BAR_GAP    2
 #define UI_WIFI_BAR_H_STEP 4
 
-/* Battery widget */
-#define UI_BATTERY_W       44
-#define UI_BATTERY_H       14
-#define UI_BATTERY_FILL_W  18
-#define UI_BATTERY_FILL_H  8
+/* Battery widget — iOS-style icon (no percent text in topbar) */
+#define UI_BATTERY_W        24  /* total container width (frame 22 + cap 2) */
+#define UI_BATTERY_H        11  /* total container height */
+#define UI_BATTERY_FRAME_W  22  /* outer rounded-rect width */
+#define UI_BATTERY_FRAME_H  11  /* outer rounded-rect height */
+#define UI_BATTERY_FILL_W   18  /* max fill width inside frame */
+#define UI_BATTERY_FILL_H    7  /* fill height inside frame */
+#define UI_BATTERY_CAP_W     2  /* positive terminal cap width */
+#define UI_BATTERY_CAP_H     5  /* positive terminal cap height */
+
+/* Large battery for LOCKED page */
+#define UI_BATTERY_LG_W         60  /* total container width (frame 56 + cap 4) */
+#define UI_BATTERY_LG_H         24  /* total container height */
+#define UI_BATTERY_LG_FRAME_W   56  /* outer rounded-rect width */
+#define UI_BATTERY_LG_FRAME_H   24  /* outer rounded-rect height */
+#define UI_BATTERY_LG_FILL_W    50  /* max fill width inside frame */
+#define UI_BATTERY_LG_FILL_H    18  /* fill height inside frame */
+#define UI_BATTERY_LG_CAP_W      4  /* positive terminal cap width */
+#define UI_BATTERY_LG_CAP_H     12  /* positive terminal cap height */
 
 /* Bottom info bar (session / cwd pool) */
 #define UI_BOTTOM_BAR_H    16
@@ -203,9 +217,10 @@ static lv_obj_t* s_obj_status_wifi;
 static lv_obj_t* s_lbl_status_wifi_info;
 static lv_obj_t* s_bar_status_wifi[UI_WIFI_BAR_COUNT];
 static lv_obj_t* s_obj_status_battery;
+static lv_obj_t* s_obj_status_battery_frame;
 static lv_obj_t* s_obj_status_battery_fill;
-static lv_obj_t* s_img_status_battery;
-static lv_obj_t* s_lbl_status_battery;
+static lv_obj_t* s_obj_status_battery_cap;
+static lv_obj_t* s_obj_status_battery_charge_lbl; /* ⚡ overlay for charging state */
 
 /* Bottom info bar (session id / cwd pool name) */
 static lv_obj_t* s_obj_bottom_bar;
@@ -251,6 +266,7 @@ static int s_battery_available;
 static int s_battery_percent = -1;
 static int s_battery_low;
 static int s_battery_supported;
+static int s_battery_charging;
 static int s_cloud_mode;  /* 1 = cloud_saas, 0 = local_home */
 static int s_chat_active; /* 1 when agent chat overlay is active */
 
@@ -307,17 +323,19 @@ static void apply_wifi_bars(lv_obj_t* bars[], lv_obj_t* info_lbl, const char* st
 }
 
 static void apply_battery_widget(void) {
-  if (s_obj_status_battery == NULL || s_obj_status_battery_fill == NULL || s_lbl_status_battery == NULL) return;
+  if (s_obj_status_battery == NULL || s_obj_status_battery_fill == NULL) return;
 
   int supported = 0;
   int available = 0;
   int percent = -1;
   int low = 0;
+  int charging = 0;
   portENTER_CRITICAL(&s_state_lock);
   supported = s_battery_supported;
   available = s_battery_available;
   percent = s_battery_percent;
   low = s_battery_low;
+  charging = s_battery_charging;
   portEXIT_CRITICAL(&s_state_lock);
 
   if (!supported) {
@@ -327,20 +345,48 @@ static void apply_battery_widget(void) {
 
   lv_obj_clear_flag(s_obj_status_battery, LV_OBJ_FLAG_HIDDEN);
   if (!available || percent < 0) {
+    /* No reading yet — show empty frame, hide fill */
     lv_obj_add_flag(s_obj_status_battery_fill, LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_text(s_lbl_status_battery, "--");
+    if (s_obj_status_battery_charge_lbl != NULL)
+      lv_obj_add_flag(s_obj_status_battery_charge_lbl, LV_OBJ_FLAG_HIDDEN);
     return;
   }
 
   if (percent > 100) percent = 100;
   if (percent < 0) percent = 0;
-  lv_obj_clear_flag(s_obj_status_battery_fill, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_set_width(s_obj_status_battery_fill, (percent * UI_BATTERY_FILL_W) / 100);
-  lv_obj_set_style_bg_color(s_obj_status_battery_fill, lv_color_hex(low ? 0xe66f6f : UI_ME_ACCENT), 0);
 
-  char pct[8];
-  snprintf(pct, sizeof(pct), "%d", percent);
-  lv_label_set_text(s_lbl_status_battery, pct);
+  /* Choose fill color by state: charging > low > normal */
+  uint32_t fill_color;
+  if (charging) {
+    fill_color = 0x4cd964; /* green */
+  } else if (low) {
+    fill_color = 0xe66f6f; /* red */
+  } else {
+    fill_color = UI_ME_ACCENT; /* theme green */
+  }
+
+  /* Fill width: charging shows full bar regardless of percent */
+  int fill_w = charging ? UI_BATTERY_FILL_W : (percent * UI_BATTERY_FILL_W) / 100;
+  if (fill_w < 1 && percent > 0) fill_w = 1; /* always show at least 1px when non-zero */
+
+  lv_obj_clear_flag(s_obj_status_battery_fill, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_set_width(s_obj_status_battery_fill, fill_w);
+  lv_obj_set_style_bg_color(s_obj_status_battery_fill, lv_color_hex(fill_color), 0);
+
+  /* Frame border color matches fill for charging/low, dim otherwise */
+  if (s_obj_status_battery_frame != NULL) {
+    lv_obj_set_style_border_color(s_obj_status_battery_frame,
+                                  lv_color_hex(charging ? 0x4cd964 : (low ? 0xe66f6f : UI_STATUS_FG)), 0);
+  }
+
+  /* Charging lightning overlay */
+  if (s_obj_status_battery_charge_lbl != NULL) {
+    if (charging) {
+      lv_obj_clear_flag(s_obj_status_battery_charge_lbl, LV_OBJ_FLAG_HIDDEN);
+    } else {
+      lv_obj_add_flag(s_obj_status_battery_charge_lbl, LV_OBJ_FLAG_HIDDEN);
+    }
+  }
 }
 
 static void apply_bottom_bar(void) {
@@ -734,33 +780,54 @@ static lv_obj_t* create_wifi_widget(lv_obj_t* parent, int x, int y, lv_obj_t* ba
 }
 
 static lv_obj_t* create_battery_widget(lv_obj_t* parent, int x, int y) {
-  const lv_font_t* font = ui_font();
+  /* iOS-style battery icon: rounded-rect frame + fill bar + positive terminal cap.
+   * No percent text — topbar space is tight. Charging state shown via ⚡ overlay. */
   lv_obj_t* container = lv_obj_create(parent);
   lv_obj_remove_style_all(container);
   lv_obj_set_size(container, UI_BATTERY_W, UI_BATTERY_H);
   lv_obj_set_pos(container, x, y);
   lv_obj_clear_flag(container, LV_OBJ_FLAG_SCROLLABLE);
 
+  /* Fill bar — drawn first so frame border renders on top */
   s_obj_status_battery_fill = lv_obj_create(container);
   lv_obj_remove_style_all(s_obj_status_battery_fill);
+  /* Position: 1px inset from frame border on all sides */
   lv_obj_set_size(s_obj_status_battery_fill, UI_BATTERY_FILL_W, UI_BATTERY_FILL_H);
-  lv_obj_set_pos(s_obj_status_battery_fill, 2, 3);
+  lv_obj_set_pos(s_obj_status_battery_fill, 2, 2);
   lv_obj_set_style_radius(s_obj_status_battery_fill, 1, 0);
   lv_obj_set_style_bg_color(s_obj_status_battery_fill, lv_color_hex(UI_ME_ACCENT), 0);
   lv_obj_set_style_bg_opa(s_obj_status_battery_fill, LV_OPA_COVER, 0);
 
-  s_img_status_battery = lv_image_create(container);
-  lv_image_set_src(s_img_status_battery, &bb_el_battery_frame_26x12);
-  lv_obj_set_pos(s_img_status_battery, 0, 1);
+  /* Outer frame — rounded rect, no background fill, just border */
+  s_obj_status_battery_frame = lv_obj_create(container);
+  lv_obj_remove_style_all(s_obj_status_battery_frame);
+  lv_obj_set_size(s_obj_status_battery_frame, UI_BATTERY_FRAME_W, UI_BATTERY_FRAME_H);
+  lv_obj_set_pos(s_obj_status_battery_frame, 0, 0);
+  lv_obj_set_style_radius(s_obj_status_battery_frame, 2, 0);
+  lv_obj_set_style_border_width(s_obj_status_battery_frame, 1, 0);
+  lv_obj_set_style_border_color(s_obj_status_battery_frame, lv_color_hex(UI_STATUS_FG), 0);
+  lv_obj_set_style_border_opa(s_obj_status_battery_frame, LV_OPA_COVER, 0);
+  lv_obj_set_style_bg_opa(s_obj_status_battery_frame, LV_OPA_0, 0);
+  lv_obj_clear_flag(s_obj_status_battery_frame, LV_OBJ_FLAG_SCROLLABLE);
 
-  s_lbl_status_battery = lv_label_create(container);
-  lv_obj_set_width(s_lbl_status_battery, 16);
-  lv_obj_set_style_text_color(s_lbl_status_battery, lv_color_hex(UI_TEXT_MAIN), 0);
-  lv_obj_set_style_text_font(s_lbl_status_battery, font, 0);
-  lv_obj_set_style_text_align(s_lbl_status_battery, LV_TEXT_ALIGN_RIGHT, 0);
-  lv_label_set_long_mode(s_lbl_status_battery, LV_LABEL_LONG_MODE_CLIP);
-  lv_label_set_text(s_lbl_status_battery, "--");
-  lv_obj_set_pos(s_lbl_status_battery, 28, 0);
+  /* Positive terminal cap — small rect on the right side, vertically centered */
+  s_obj_status_battery_cap = lv_obj_create(container);
+  lv_obj_remove_style_all(s_obj_status_battery_cap);
+  lv_obj_set_size(s_obj_status_battery_cap, UI_BATTERY_CAP_W, UI_BATTERY_CAP_H);
+  lv_obj_set_pos(s_obj_status_battery_cap,
+                 UI_BATTERY_FRAME_W,
+                 (UI_BATTERY_FRAME_H - UI_BATTERY_CAP_H) / 2);
+  lv_obj_set_style_radius(s_obj_status_battery_cap, 1, 0);
+  lv_obj_set_style_bg_color(s_obj_status_battery_cap, lv_color_hex(UI_STATUS_FG), 0);
+  lv_obj_set_style_bg_opa(s_obj_status_battery_cap, LV_OPA_COVER, 0);
+
+  /* Charging lightning label — centered over the frame, hidden by default */
+  s_obj_status_battery_charge_lbl = lv_label_create(container);
+  lv_obj_set_style_text_color(s_obj_status_battery_charge_lbl, lv_color_hex(0x0a0e0c), 0);
+  lv_obj_set_style_text_font(s_obj_status_battery_charge_lbl, lv_font_get_default(), 0);
+  lv_label_set_text(s_obj_status_battery_charge_lbl, LV_SYMBOL_CHARGE);
+  lv_obj_set_pos(s_obj_status_battery_charge_lbl, 4, 0);
+  lv_obj_add_flag(s_obj_status_battery_charge_lbl, LV_OBJ_FLAG_HIDDEN);
 
   return container;
 }
@@ -1094,6 +1161,17 @@ static void refresh_ui(void) {
     s_record_view_visible = 0;
   } else if (mode == UI_VIEW_LOCKED) {
     bb_page_locked_update_status(status);
+    {
+      int bat_supported, bat_available, bat_percent, bat_low, bat_charging;
+      portENTER_CRITICAL(&s_state_lock);
+      bat_supported = s_battery_supported;
+      bat_available = s_battery_available;
+      bat_percent   = s_battery_percent;
+      bat_low       = s_battery_low;
+      bat_charging  = s_battery_charging;
+      portEXIT_CRITICAL(&s_state_lock);
+      bb_page_locked_update_battery(bat_supported, bat_available, bat_percent, bat_low, bat_charging);
+    }
     s_record_view_visible = 0;
   } else {
     /* ACTIVE view (chat) — full layout with top bar + bottom bar */
@@ -1262,6 +1340,7 @@ esp_err_t bb_display_init(void) {
   s_battery_percent = -1;
   s_battery_low = 0;
   s_battery_supported = 0;
+  s_battery_charging = 0;
   memset(&s_auto_scroll_text, 0, sizeof(s_auto_scroll_text));
 
   create_ui();
@@ -1293,6 +1372,7 @@ esp_err_t bb_display_init(void) {
   s_battery_percent = -1;
   s_battery_low = 0;
   s_battery_supported = 0;
+  s_battery_charging = 0;
   memset(&s_auto_scroll_text, 0, sizeof(s_auto_scroll_text));
 
   ESP_RETURN_ON_ERROR(init_panel(), TAG, "panel init failed");
@@ -1526,12 +1606,13 @@ void bb_display_set_record_level(uint8_t level_pct, int voiced) {
   portEXIT_CRITICAL(&s_state_lock);
 }
 
-void bb_display_set_battery(int supported, int available, int percent, int low) {
+void bb_display_set_battery(int supported, int available, int percent, int low, int charging) {
   portENTER_CRITICAL(&s_state_lock);
   s_battery_supported = supported ? 1 : 0;
   s_battery_available = available ? 1 : 0;
   s_battery_percent = percent;
   s_battery_low = low ? 1 : 0;
+  s_battery_charging = charging ? 1 : 0;
   portEXIT_CRITICAL(&s_state_lock);
   if (s_ready) refresh_ui();
 }

--- a/firmware/src/bb_page_locked.c
+++ b/firmware/src/bb_page_locked.c
@@ -30,6 +30,24 @@ static lv_obj_t* s_obj_slot;
 static lv_obj_t* s_lbl_title;
 static lv_obj_t* s_lbl_hint;
 
+/* Large battery widget (below padlock) */
+static lv_obj_t* s_bat_container;
+static lv_obj_t* s_bat_frame;
+static lv_obj_t* s_bat_fill;
+static lv_obj_t* s_bat_cap;
+static lv_obj_t* s_bat_charge_lbl;
+static lv_obj_t* s_bat_pct_lbl;
+
+/* Large battery dimensions */
+#define BAT_LG_W         60
+#define BAT_LG_H         24
+#define BAT_LG_FRAME_W   56
+#define BAT_LG_FRAME_H   24
+#define BAT_LG_FILL_W    50
+#define BAT_LG_FILL_H    18
+#define BAT_LG_CAP_W      4
+#define BAT_LG_CAP_H     12
+
 static const lv_font_t* ui_font(void) {
 #ifdef BBCLAW_HAVE_CJK_FONT
   return &lv_font_bbclaw_cjk;
@@ -82,29 +100,145 @@ void bb_page_locked_create(lv_obj_t* scr) {
   lv_obj_set_style_bg_color(s_obj_slot, lv_color_hex(UI_ME_ACCENT), 0);
   lv_obj_set_style_bg_opa(s_obj_slot, LV_OPA_90, 0);
 
-  /* Title */
+  /* Title — shifted down to make room for battery widget */
   s_lbl_title = lv_label_create(s_view);
   lv_obj_set_width(s_lbl_title, body_w);
   lv_obj_set_style_text_color(s_lbl_title, lv_color_hex(UI_TEXT_MAIN), 0);
   lv_obj_set_style_text_font(s_lbl_title, font, 0);
   lv_obj_set_style_text_align(s_lbl_title, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_text(s_lbl_title, "设备已锁定");
-  lv_obj_set_pos(s_lbl_title, UI_SAFE_LEFT, 118);
+  lv_obj_set_pos(s_lbl_title, UI_SAFE_LEFT, 208);
 
-  /* Hint */
+  /* Hint — shifted down */
   s_lbl_hint = lv_label_create(s_view);
   lv_obj_set_width(s_lbl_hint, body_w);
   lv_obj_set_style_text_color(s_lbl_hint, lv_color_hex(UI_TEXT_DIM), 0);
   lv_obj_set_style_text_font(s_lbl_hint, font, 0);
   lv_obj_set_style_text_align(s_lbl_hint, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_text(s_lbl_hint, "请按住说话键后说出密语");
-  lv_obj_set_pos(s_lbl_hint, UI_SAFE_LEFT, 140);
+  lv_obj_set_pos(s_lbl_hint, UI_SAFE_LEFT, 230);
+
+  /* Large battery widget — centered below padlock (padlock body bottom ≈ y=104) */
+  {
+    const int bat_x = (DISP_W - BAT_LG_W) / 2;
+    const int bat_y = 116; /* just below padlock body */
+
+    s_bat_container = lv_obj_create(s_view);
+    lv_obj_remove_style_all(s_bat_container);
+    lv_obj_set_size(s_bat_container, BAT_LG_W, BAT_LG_H);
+    lv_obj_set_pos(s_bat_container, bat_x, bat_y);
+    lv_obj_clear_flag(s_bat_container, LV_OBJ_FLAG_SCROLLABLE);
+
+    /* Fill bar */
+    s_bat_fill = lv_obj_create(s_bat_container);
+    lv_obj_remove_style_all(s_bat_fill);
+    lv_obj_set_size(s_bat_fill, BAT_LG_FILL_W, BAT_LG_FILL_H);
+    lv_obj_set_pos(s_bat_fill, 3, 3);
+    lv_obj_set_style_radius(s_bat_fill, 2, 0);
+    lv_obj_set_style_bg_color(s_bat_fill, lv_color_hex(UI_ME_ACCENT), 0);
+    lv_obj_set_style_bg_opa(s_bat_fill, LV_OPA_COVER, 0);
+
+    /* Outer frame */
+    s_bat_frame = lv_obj_create(s_bat_container);
+    lv_obj_remove_style_all(s_bat_frame);
+    lv_obj_set_size(s_bat_frame, BAT_LG_FRAME_W, BAT_LG_FRAME_H);
+    lv_obj_set_pos(s_bat_frame, 0, 0);
+    lv_obj_set_style_radius(s_bat_frame, 4, 0);
+    lv_obj_set_style_border_width(s_bat_frame, 2, 0);
+    lv_obj_set_style_border_color(s_bat_frame, lv_color_hex(UI_ME_ACCENT), 0);
+    lv_obj_set_style_border_opa(s_bat_frame, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_opa(s_bat_frame, LV_OPA_0, 0);
+    lv_obj_clear_flag(s_bat_frame, LV_OBJ_FLAG_SCROLLABLE);
+
+    /* Positive terminal cap */
+    s_bat_cap = lv_obj_create(s_bat_container);
+    lv_obj_remove_style_all(s_bat_cap);
+    lv_obj_set_size(s_bat_cap, BAT_LG_CAP_W, BAT_LG_CAP_H);
+    lv_obj_set_pos(s_bat_cap, BAT_LG_FRAME_W, (BAT_LG_FRAME_H - BAT_LG_CAP_H) / 2);
+    lv_obj_set_style_radius(s_bat_cap, 1, 0);
+    lv_obj_set_style_bg_color(s_bat_cap, lv_color_hex(UI_ME_ACCENT), 0);
+    lv_obj_set_style_bg_opa(s_bat_cap, LV_OPA_COVER, 0);
+
+    /* Charging lightning overlay */
+    s_bat_charge_lbl = lv_label_create(s_bat_container);
+    lv_obj_set_style_text_color(s_bat_charge_lbl, lv_color_hex(0x0a0e0c), 0);
+    lv_obj_set_style_text_font(s_bat_charge_lbl, font, 0);
+    lv_label_set_text(s_bat_charge_lbl, LV_SYMBOL_CHARGE);
+    lv_obj_center(s_bat_charge_lbl);
+    lv_obj_add_flag(s_bat_charge_lbl, LV_OBJ_FLAG_HIDDEN);
+
+    /* Percent label below battery */
+    s_bat_pct_lbl = lv_label_create(s_view);
+    lv_obj_set_width(s_bat_pct_lbl, BAT_LG_W + 20);
+    lv_obj_set_style_text_color(s_bat_pct_lbl, lv_color_hex(UI_TEXT_MAIN), 0);
+    lv_obj_set_style_text_font(s_bat_pct_lbl, font, 0);
+    lv_obj_set_style_text_align(s_bat_pct_lbl, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_text(s_bat_pct_lbl, "");
+    lv_obj_set_pos(s_bat_pct_lbl, bat_x - 10, bat_y + BAT_LG_H + 4);
+
+    /* Hidden by default until battery data arrives */
+    lv_obj_add_flag(s_bat_container, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(s_bat_pct_lbl, LV_OBJ_FLAG_HIDDEN);
+  }
 }
 
 void bb_page_locked_set_visible(int visible) {
   if (s_view == NULL) return;
   if (visible) lv_obj_clear_flag(s_view, LV_OBJ_FLAG_HIDDEN);
   else lv_obj_add_flag(s_view, LV_OBJ_FLAG_HIDDEN);
+}
+
+void bb_page_locked_update_battery(int supported, int available, int percent, int low, int charging) {
+  if (s_bat_container == NULL || s_bat_fill == NULL) return;
+
+  if (!supported || !available || percent < 0) {
+    lv_obj_add_flag(s_bat_container, LV_OBJ_FLAG_HIDDEN);
+    if (s_bat_pct_lbl != NULL) lv_obj_add_flag(s_bat_pct_lbl, LV_OBJ_FLAG_HIDDEN);
+    return;
+  }
+
+  lv_obj_clear_flag(s_bat_container, LV_OBJ_FLAG_HIDDEN);
+  if (s_bat_pct_lbl != NULL) lv_obj_clear_flag(s_bat_pct_lbl, LV_OBJ_FLAG_HIDDEN);
+
+  if (percent > 100) percent = 100;
+  if (percent < 0) percent = 0;
+
+  /* Choose color */
+  uint32_t fill_color;
+  if (charging) {
+    fill_color = 0x4cd964;
+  } else if (low) {
+    fill_color = 0xe66f6f;
+  } else {
+    fill_color = UI_ME_ACCENT;
+  }
+
+  int fill_w = charging ? BAT_LG_FILL_W : (percent * BAT_LG_FILL_W) / 100;
+  if (fill_w < 1 && percent > 0) fill_w = 1;
+
+  lv_obj_set_width(s_bat_fill, fill_w);
+  lv_obj_set_style_bg_color(s_bat_fill, lv_color_hex(fill_color), 0);
+
+  if (s_bat_frame != NULL) {
+    lv_obj_set_style_border_color(s_bat_frame,
+                                  lv_color_hex(charging ? 0x4cd964 : (low ? 0xe66f6f : UI_ME_ACCENT)), 0);
+  }
+  if (s_bat_cap != NULL) {
+    lv_obj_set_style_bg_color(s_bat_cap,
+                               lv_color_hex(charging ? 0x4cd964 : (low ? 0xe66f6f : UI_ME_ACCENT)), 0);
+  }
+
+  if (s_bat_charge_lbl != NULL) {
+    if (charging) lv_obj_clear_flag(s_bat_charge_lbl, LV_OBJ_FLAG_HIDDEN);
+    else lv_obj_add_flag(s_bat_charge_lbl, LV_OBJ_FLAG_HIDDEN);
+  }
+
+  if (s_bat_pct_lbl != NULL) {
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%d%%", percent);
+    lv_label_set_text(s_bat_pct_lbl, buf);
+    lv_obj_set_style_text_color(s_bat_pct_lbl, lv_color_hex(fill_color), 0);
+  }
 }
 
 void bb_page_locked_update_status(const char* status) {

--- a/firmware/src/bb_power.c
+++ b/firmware/src/bb_power.c
@@ -18,6 +18,7 @@ static bb_power_state_t s_state = {
     .millivolts = 0,
     .percent = -1,
     .low = 0,
+    .charging = 0,
 };
 
 #if !defined(BBCLAW_SIMULATOR) && BBCLAW_POWER_ENABLE && (BBCLAW_POWER_ADC_GPIO >= 0)
@@ -45,6 +46,10 @@ static int battery_percent_from_mv(int mv) {
 void bb_power_get_state(bb_power_state_t* out_state) {
   if (out_state == NULL) return;
   *out_state = s_state;
+}
+
+int bbclaw_power_is_charging(void) {
+  return s_state.charging;
 }
 
 esp_err_t bb_power_init(void) {
@@ -146,6 +151,7 @@ esp_err_t bb_power_refresh(void) {
   s_state.millivolts = vbat_mv;
   s_state.percent = battery_percent_from_mv(vbat_mv);
   s_state.low = s_state.percent <= BBCLAW_POWER_LOW_PERCENT ? 1 : 0;
+  s_state.charging = 0; /* TODO: set from VBUS GPIO detection when hardware supports it */
   ESP_LOGD(TAG, "battery raw=%d adc_mv=%d vbat_mv=%d percent=%d low=%d cali=%d",
            raw_avg, adc_mv, vbat_mv, s_state.percent, s_state.low, s_adc_cali_ready);
   return ESP_OK;
@@ -155,6 +161,7 @@ esp_err_t bb_power_refresh(void) {
   s_state.millivolts = 0;
   s_state.percent = -1;
   s_state.low = 0;
+  s_state.charging = 0; /* TODO: set from VBUS GPIO detection when hardware supports it */
   return ESP_OK;
 #endif
 }

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -660,7 +660,7 @@ typedef struct {
 static void refresh_power_display(void) {
   bb_power_state_t power = {0};
   bb_power_get_state(&power);
-  bb_display_set_battery(power.supported, power.available, power.percent, power.low);
+  bb_display_set_battery(power.supported, power.available, power.percent, power.low, power.charging);
 }
 
 static void log_pin_summary(void) {


### PR DESCRIPTION
Fixes #61

## What changed

### Data layer
- bb_power.h / bb_power.c: Added charging field to bb_power_state_t and bbclaw_power_is_charging() getter. charging is always 0 as a placeholder — TODO comment marks where VBUS GPIO detection should be wired when hardware supports it.

### Topbar battery widget (bb_lvgl_display.c)
- Replaced the old 44x14 bitmap-frame + percent-text widget with pure LVGL primitives iOS-style icon:
  - 22x11 rounded-rect outer frame (border=1, radius=2, no background)
  - Fill bar inside (radius=1), width proportional to percent
  - 2x5 positive terminal cap on the right, vertically centered
- Removed s_lbl_status_battery (percent text) and s_img_status_battery (old bitmap)
- Three color states: charging -> #4cd964, low (<=15%) -> #e66f6f, normal -> UI_ME_ACCENT
- LV_SYMBOL_CHARGE overlay label added for charging state (hidden by default since charging is always false)
- bb_display_set_battery() gains a charging parameter

### LOCKED page large battery (bb_page_locked.c)
- Added 60x24 large battery widget centered below the padlock (y=116)
- Percent label below the icon, colored to match the fill state
- Title shifted y=118->208, hint shifted y=140->230
- New bb_page_locked_update_battery() API called from refresh_ui() whenever LOCKED view is active

### Callers
- bb_radio_app.c: passes power.charging to the updated bb_display_set_battery()

## Topbar space note
Battery width reduced from 44px to 24px. The freed 20px is absorbed by the existing status_label_w calculation — no explicit repositioning of WiFi/clock needed since they are already right-aligned.

## Testing
- No hardware serial port available in this environment; simulator build requires ESP-IDF toolchain not present here.
- make build should be verified by the reviewer with the ESP-IDF environment.
- Charging UI is fully implemented but data layer is charging=0 placeholder — no runtime behavior change until VBUS GPIO is wired.