### PR TITLE
feat: long-press OK in CHAT enters SETTINGS

### DIFF
--- a/firmware/include/bb_nav_input.h
+++ b/firmware/include/bb_nav_input.h
@@ -20,7 +20,12 @@
  * LEFT and RIGHT are NEW events — only the Flipper 6-button mode emits them;
  * legacy modes never do, so call sites must treat them as optional.
  *
- * Keep BB_NAV_EVENT_COUNT immediately after the 6 real values so it is the
+ * OK_LONG is a NEW event — only the Flipper 6-button mode emits it. It fires
+ * when the OK button is held for BBCLAW_NAV_LONG_PRESS_MS (700 ms). When
+ * OK_LONG fires, the subsequent release edge does NOT also emit OK, so the
+ * two gestures are mutually exclusive.
+ *
+ * Keep BB_NAV_EVENT_COUNT immediately after all real values so it is the
  * size used for any per-event versioning array. Aliases sit AFTER the count
  * marker so they do not inflate it.
  */
@@ -31,6 +36,7 @@ typedef enum {
   BB_NAV_EVENT_RIGHT,
   BB_NAV_EVENT_OK,
   BB_NAV_EVENT_BACK,
+  BB_NAV_EVENT_OK_LONG, /* long-press OK: enter SETTINGS from CHAT (Flipper mode only) */
   BB_NAV_EVENT_COUNT,
 
   /* Backwards-compat aliases (Option A naming). Same numeric value as the

--- a/firmware/src/bb_nav_input.c
+++ b/firmware/src/bb_nav_input.c
@@ -50,6 +50,9 @@ static bb_nav_btn_t s_btn_left = {.gpio = BBCLAW_NAV_BTN_LEFT_GPIO};
 static bb_nav_btn_t s_btn_right = {.gpio = BBCLAW_NAV_BTN_RIGHT_GPIO};
 static bb_nav_btn_t s_btn_ok = {.gpio = BBCLAW_NAV_BTN_OK_GPIO};
 static bb_nav_btn_t s_btn_back = {.gpio = BBCLAW_NAV_BTN_BACK_GPIO};
+/* Tracks whether a long-press has already been emitted for the current OK
+ * hold, so the subsequent release edge does NOT also fire BB_NAV_EVENT_OK. */
+static int s_ok_long_press_sent;
 #elif BBCLAW_NAV_BUTTONS_INSTEAD_OF_ENC
 /* Two-buttons-as-encoder mode: each press on the A pin emits ROTATE_CCW,
  * each press on the B pin emits ROTATE_CW. Same debounce logic as the
@@ -102,13 +105,14 @@ static int read_key_pressed(void) {
 
 static const char* nav_event_name(bb_nav_event_t event) {
   switch (event) {
-    case BB_NAV_EVENT_UP:    return "UP";
-    case BB_NAV_EVENT_DOWN:  return "DOWN";
-    case BB_NAV_EVENT_LEFT:  return "LEFT";
-    case BB_NAV_EVENT_RIGHT: return "RIGHT";
-    case BB_NAV_EVENT_OK:    return "OK";
-    case BB_NAV_EVENT_BACK:  return "BACK";
-    default:                 return "?";
+    case BB_NAV_EVENT_UP:      return "UP";
+    case BB_NAV_EVENT_DOWN:    return "DOWN";
+    case BB_NAV_EVENT_LEFT:    return "LEFT";
+    case BB_NAV_EVENT_RIGHT:   return "RIGHT";
+    case BB_NAV_EVENT_OK:      return "OK";
+    case BB_NAV_EVENT_BACK:    return "BACK";
+    case BB_NAV_EVENT_OK_LONG: return "OK_LONG";
+    default:                   return "?";
   }
 }
 
@@ -229,9 +233,37 @@ static void nav_poll_cb(void* arg) {
   if (poll_btn(&s_btn_right, eff_debounce) > 0) {
     emit_event(BB_NAV_EVENT_RIGHT);
   }
-  /* OK: release edge → click (so a quick tap doesn't fire on press too). */
-  if (poll_btn(&s_btn_ok, eff_debounce) < 0) {
-    emit_event(BB_NAV_EVENT_OK);
+  /* OK: release edge → click (short-press), OR long-press → BB_NAV_EVENT_OK_LONG.
+   *
+   * On press edge: record the press timestamp and clear the long-press flag.
+   * While held: once BBCLAW_NAV_LONG_PRESS_MS elapses, emit OK_LONG and set
+   *   s_ok_long_press_sent so the release edge is swallowed.
+   * On release edge: emit OK only if no long-press was already sent.
+   *
+   * This makes short-press and long-press mutually exclusive — the user gets
+   * exactly one event per OK gesture regardless of hold duration.
+   */
+  {
+    int ok_edge = poll_btn(&s_btn_ok, eff_debounce);
+    if (ok_edge > 0) {
+      /* Press edge: arm long-press timer. */
+      s_btn_ok.press_started_ms = now_ms;
+      s_ok_long_press_sent = 0;
+    } else if (ok_edge < 0) {
+      /* Release edge: emit short-press only if long-press was not already sent. */
+      if (!s_ok_long_press_sent) {
+        emit_event(BB_NAV_EVENT_OK);
+      }
+      s_btn_ok.press_started_ms = 0;
+      s_ok_long_press_sent = 0;
+    } else if (s_btn_ok.stable && s_btn_ok.press_started_ms > 0 && !s_ok_long_press_sent) {
+      /* Still held: check if threshold reached. */
+      int64_t held_ms = now_ms - s_btn_ok.press_started_ms;
+      if (held_ms >= BBCLAW_NAV_LONG_PRESS_MS) {
+        s_ok_long_press_sent = 1;
+        emit_event(BB_NAV_EVENT_OK_LONG);
+      }
+    }
   }
   /* BACK: explicit dedicated key — press edge maps to the "exit overlay"
    * gesture that was previously a long-press hold on the encoder click. */
@@ -347,6 +379,7 @@ esp_err_t bb_nav_input_init(bb_nav_input_callback_t callback) {
     b->press_started_ms = 0;
     b->last_repeat_ms = 0;
   }
+  s_ok_long_press_sent = 0;
 #else
   gpio_config_t io_conf = {
       .pin_bit_mask =

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -433,9 +433,8 @@ static volatile int s_settings_active;
 static lv_obj_t* s_settings_root;
 
 /* settings_overlay_enter: entry point for the SETTINGS overlay.
- * The session picker no longer exposes a Settings row (issue #64); this
- * function is kept for a future entry point (e.g. long-press OK in CHAT). */
-static int __attribute__((unused)) settings_overlay_enter(void) {
+ * Triggered by long-press OK in CHAT (issue #67). */
+static int settings_overlay_enter(void) {
   if (s_settings_active) return 0;
   if (!lvgl_port_lock(pdMS_TO_TICKS(500))) {
     ESP_LOGW(TAG, "settings_enter: lvgl_port_lock timeout");
@@ -1770,6 +1769,16 @@ static void stream_task(void* arg) {
                     lvgl_port_unlock();
                   } else {
                     ESP_LOGW(TAG, "CHAT: OK session picker lock timeout");
+                  }
+                  break;
+                case BB_NAV_EVENT_OK_LONG:
+                  /* Long-press OK in CHAT → enter SETTINGS (issue #67).
+                   * Always allowed regardless of busy state — SETTINGS is safe
+                   * to enter mid-reply; the streaming turn continues in the
+                   * background and is visible when the user returns to CHAT. */
+                  if (settings_overlay_enter() == 0) {
+                    set_radio_app_state(BBCLAW_STATE_SETTINGS);
+                    ESP_LOGI(TAG, "CHAT: OK_LONG -> SETTINGS");
                   }
                   break;
                 case BB_NAV_EVENT_BACK:


### PR DESCRIPTION
Fixes #67

## What changed

**firmware/include/bb_nav_input.h**
- Added BB_NAV_EVENT_OK_LONG to the nav event enum (placed before BB_NAV_EVENT_COUNT so the versioning array is sized correctly)
- Updated header comment to document the new event and its mutual-exclusivity guarantee with short-press OK

**firmware/src/bb_nav_input.c** (Flipper 6-button mode only)
- Added s_ok_long_press_sent flag to track whether a long-press has already fired for the current OK hold
- Replaced the simple release-edge OK emission with a three-phase handler:
  - Press edge: record press_started_ms, clear flag
  - While held: once >= BBCLAW_NAV_LONG_PRESS_MS (700 ms), emit BB_NAV_EVENT_OK_LONG and set flag
  - Release edge: emit BB_NAV_EVENT_OK only if flag is clear (short-press path)
- Added BB_NAV_EVENT_OK_LONG to nav_event_name() for log readability
- Initialised s_ok_long_press_sent = 0 in the Flipper init block

**firmware/src/bb_radio_app.c**
- Removed __attribute__((unused)) from settings_overlay_enter() -- it now has a live call site
- Added case BB_NAV_EVENT_OK_LONG in the normal CHAT nav block: calls settings_overlay_enter() + set_radio_app_state(BBCLAW_STATE_SETTINGS). Entry is always allowed regardless of busy state (a streaming reply continues in the background)

## Behaviour

Tap OK (< 700 ms): emits BB_NAV_EVENT_OK -> opens session picker (unchanged)
Hold OK (>= 700 ms): emits BB_NAV_EVENT_OK_LONG -> enters SETTINGS page

The two gestures are mutually exclusive -- holding OK never also opens the session picker.
Legacy encoder/breadboard boards are unaffected: BB_NAV_EVENT_OK_LONG is only emitted in Flipper 6-button mode.

## Testing notes

- No unit test framework for firmware; build verification requires ESP-IDF toolchain (not available in CI)
- Hardware verification (Flipper 6-button board) needed to confirm 700 ms threshold feels natural and that short-press/long-press do not race
- Encoder-only boards: BB_NAV_EVENT_OK_LONG is never emitted, so SETTINGS remains unreachable on those boards -- consistent with pre-existing behaviour