### PR TITLE
fix: session picker cwdName, title fallback, limit, position indicator

### DIFF
--- a/adapter/internal/agent/logicalsession/types.go
+++ b/adapter/internal/agent/logicalsession/types.go
@@ -24,4 +24,8 @@ type LogicalSession struct {
 	Title        string    `json:"title,omitempty"`
 	CreatedAt    time.Time `json:"createdAt"`
 	LastUsedAt   time.Time `json:"lastUsedAt"`
+	// CwdName is the human-readable CwdPool entry name for Cwd. It is
+	// populated on outbound responses only (reverse-lookup against the
+	// adapter's CwdPool config); it is never stored to disk.
+	CwdName string `json:"cwdName,omitempty"`
 }

--- a/adapter/internal/httpapi/agent.go
+++ b/adapter/internal/httpapi/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -974,9 +975,31 @@ func (s *Server) handleAgentSessionsLogical(w http.ResponseWriter, r *http.Reque
 		}
 		sessions = filtered
 	}
+	// Populate CwdName for each session: reverse-lookup path→name in CwdPool;
+	// fall back to filepath.Base(cwd) when no pool entry matches.
+	// We copy each session into a local struct so we don't mutate the stored
+	// LogicalSession (CwdName is an outbound-only field, never persisted).
+	type sessionWithName struct {
+		logicalsession.LogicalSession
+		CwdName string `json:"cwdName,omitempty"`
+	}
+	out := make([]sessionWithName, len(sessions))
+	for i, sess := range sessions {
+		out[i].LogicalSession = *sess
+		if sess.Cwd != "" {
+			name := filepath.Base(sess.Cwd) // default: basename
+			for _, entry := range s.cfg.CwdPool {
+				if entry.Path == sess.Cwd {
+					name = entry.Name
+					break
+				}
+			}
+			out[i].CwdName = name
+		}
+	}
 	writeJSON(w, http.StatusOK, response{
 		OK:   true,
-		Data: map[string]any{"sessions": sessions},
+		Data: map[string]any{"sessions": out},
 	})
 }
 

--- a/adapter/internal/httpapi/agent_logical_test.go
+++ b/adapter/internal/httpapi/agent_logical_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/daboluocc/bbclaw/adapter/internal/agent"
 	"github.com/daboluocc/bbclaw/adapter/internal/agent/logicalsession"
+	"github.com/daboluocc/bbclaw/adapter/internal/config"
 	"github.com/daboluocc/bbclaw/adapter/internal/obs"
 )
 
@@ -345,5 +346,88 @@ func TestHandleAgentMessage_LogicalSessionCwdPassedAfterDriverSwitch(t *testing.
 	cwds := drv.cwdsCopy()
 	if len(cwds) != 1 || cwds[0] != "/tmp/switched" {
 		t.Errorf("driver Start Cwd=%v want [\"/tmp/switched\"]", cwds)
+	}
+}
+
+// TestHandleAgentSessionsLogical_CwdName verifies that the logical session list
+// response includes a cwdName field populated by reverse-lookup against CwdPool,
+// falling back to filepath.Base(cwd) for paths not in the pool (issue #70).
+func TestHandleAgentSessionsLogical_CwdName(t *testing.T) {
+	log := obs.NewLogger()
+	metrics := obs.NewMetrics()
+
+	dir := t.TempDir()
+	mgr, err := logicalsession.NewManager(filepath.Join(dir, "sessions.json"), "", log)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	// Create three sessions:
+	//   1. cwd matches a pool entry → cwdName = pool name
+	//   2. cwd matches another pool entry → cwdName = pool name
+	//   3. cwd not in pool → cwdName = filepath.Base(cwd)
+	_, err = mgr.Create("dev-1", "claude-code", "/Users/mikas/code/myproject", "proj session")
+	if err != nil {
+		t.Fatalf("Create 1: %v", err)
+	}
+	_, err = mgr.Create("dev-1", "claude-code", "/Users/mikas/code/side", "side session")
+	if err != nil {
+		t.Fatalf("Create 2: %v", err)
+	}
+	_, err = mgr.Create("dev-1", "claude-code", "/tmp/random/work", "stray session")
+	if err != nil {
+		t.Fatalf("Create 3: %v", err)
+	}
+
+	srv := NewServer(AppConfig{
+		CwdPool: []config.CwdEntry{
+			{Name: "myproject", Path: "/Users/mikas/code/myproject"},
+			{Name: "side", Path: "/Users/mikas/code/side"},
+		},
+	}, nil, nil, nil, nil, log, metrics)
+	srv.SetSessionManager(mgr)
+
+	req := httptest.NewRequest("GET", "/v1/agent/sessions?kind=logical&deviceId=dev-1&limit=10", nil)
+	w := httptest.NewRecorder()
+	srv.handleAgentSessionsLogical(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp response
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("expected ok=true, got error=%s", resp.Error)
+	}
+
+	data := resp.Data.(map[string]any)
+	sessionsRaw, _ := json.Marshal(data["sessions"])
+	var sessions []map[string]any
+	if err := json.Unmarshal(sessionsRaw, &sessions); err != nil {
+		t.Fatalf("unmarshal sessions: %v", err)
+	}
+	if len(sessions) != 3 {
+		t.Fatalf("expected 3 sessions, got %d", len(sessions))
+	}
+
+	// Build a map from title → cwdName for easy assertion.
+	byTitle := map[string]string{}
+	for _, s := range sessions {
+		title, _ := s["title"].(string)
+		cwdName, _ := s["cwdName"].(string)
+		byTitle[title] = cwdName
+	}
+
+	if got := byTitle["proj session"]; got != "myproject" {
+		t.Errorf("proj session cwdName=%q, want myproject", got)
+	}
+	if got := byTitle["side session"]; got != "side" {
+		t.Errorf("side session cwdName=%q, want side", got)
+	}
+	if got := byTitle["stray session"]; got != "work" {
+		t.Errorf("stray session cwdName=%q, want work (filepath.Base fallback)", got)
 	}
 }

--- a/firmware/include/bb_agent_client.h
+++ b/firmware/include/bb_agent_client.h
@@ -49,7 +49,8 @@ typedef struct {
 typedef struct {
   char id[64];
   char title[24];
-  char cwd[32];       /* basename of the session's working directory; empty if unknown */
+  char cwd[32];       /* absolute cwd path (truncated); kept for compat */
+  char cwd_name[32];  /* CwdPool entry name (issue #70); empty if adapter didn't send it */
   int message_count;
   int64_t last_used_ms;
 } bb_agent_session_info_t;

--- a/firmware/src/bb_agent_client.c
+++ b/firmware/src/bb_agent_client.c
@@ -384,7 +384,7 @@ esp_err_t bb_agent_list_sessions(const char* driver_name, bb_agent_session_info_
 
   char url[320] = {0};
   char path[128] = {0};
-  snprintf(path, sizeof(path), "/v1/agent/sessions?kind=logical&driver=%s&limit=6", driver_name);
+  snprintf(path, sizeof(path), "/v1/agent/sessions?kind=logical&driver=%s&limit=16", driver_name);
   agent_build_url(url, sizeof(url), path);
 
   bb_http_dyn_accum_t accum = {0};
@@ -469,11 +469,19 @@ esp_err_t bb_agent_list_sessions(const char* driver_name, bb_agent_session_info_
         slot->last_used_ms = (int64_t)last_used->valuedouble * 1000;
       }
 
-      /* cwd: adapter sends the basename of the working directory */
+      /* cwd: adapter sends the absolute working directory path */
       const cJSON* cwd = cJSON_GetObjectItemCaseSensitive(item, "cwd");
       if (cJSON_IsString(cwd) && cwd->valuestring != NULL) {
         strncpy(slot->cwd, cwd->valuestring, sizeof(slot->cwd) - 1);
         slot->cwd[sizeof(slot->cwd) - 1] = '\0';
+      }
+
+      /* cwdName: human-readable CwdPool entry name (issue #70); absent on
+       * older adapters — slot->cwd_name stays '\0' in that case. */
+      const cJSON* cwd_name = cJSON_GetObjectItemCaseSensitive(item, "cwdName");
+      if (cJSON_IsString(cwd_name) && cwd_name->valuestring != NULL) {
+        strncpy(slot->cwd_name, cwd_name->valuestring, sizeof(slot->cwd_name) - 1);
+        slot->cwd_name[sizeof(slot->cwd_name) - 1] = '\0';
       }
     }
   }

--- a/firmware/src/bb_ui_agent_chat.c
+++ b/firmware/src/bb_ui_agent_chat.c
@@ -74,7 +74,7 @@ static inline lv_result_t safe_lv_async_call(lv_async_cb_t cb, void* user_data) 
 #define BB_CHAT_DRIVER_CACHE_MAX 6
 
 /* Session picker (Phase S1) — full-screen overlay for multi-session switching. */
-#define BB_SESSION_PICKER_MAX      8
+#define BB_SESSION_PICKER_MAX      16
 #define BB_SESSION_PICKER_VISIBLE  6
 #define BB_SESSION_PICKER_ROW_H    20
 
@@ -159,6 +159,7 @@ typedef struct {
   int session_picker_active_idx;       /* index of current session in list (-1 if not found) */
   int session_picker_visible;          /* 0=hidden, 1=loading, 2=visible */
   lv_obj_t* session_picker_root;
+  lv_obj_t* session_picker_title;      /* title label — updated by apply_styles for position indicator */
   lv_obj_t* session_picker_items[BB_SESSION_PICKER_MAX + 2]; /* Driver + New + sessions */
   int session_picker_total_rows;       /* session_list_count + 2 (Driver + New) */
   volatile int session_fetch_pending;
@@ -1897,6 +1898,25 @@ static void session_picker_apply_styles(void) {
       lv_obj_set_style_text_color(row, lv_color_hex(BB_SPICKER_FG_DIM), 0);
     }
   }
+
+  /* Update title position indicator: "Sessions (drv) cur/total" when a
+   * session row is selected; "Sessions (drv) total" otherwise. */
+  if (s_chat.session_picker_title != NULL) {
+    const int n_sessions = s_chat.session_list_count;
+    const char* drv = s_chat.driver_name[0] != '\0'
+                        ? s_chat.driver_name : BB_CHAT_DRIVER_FALLBACK;
+    char title_buf[48];
+    if (n_sessions > 0 && s_chat.session_picker_sel >= 2) {
+      /* sel >= 2 means a session row is highlighted; show 1-based index */
+      int cur = s_chat.session_picker_sel - 1; /* 1-based among session rows */
+      snprintf(title_buf, sizeof(title_buf), "Sessions (%s) %d/%d", drv, cur, n_sessions);
+    } else if (n_sessions > 0) {
+      snprintf(title_buf, sizeof(title_buf), "Sessions (%s) %d", drv, n_sessions);
+    } else {
+      snprintf(title_buf, sizeof(title_buf), "Sessions (%s)", drv);
+    }
+    lv_label_set_text(s_chat.session_picker_title, title_buf);
+  }
 }
 
 static void format_relative_time(int64_t last_used_ms, char* buf, int buf_len) {
@@ -1939,6 +1959,7 @@ static void session_picker_build_ui(void) {
   if (s_chat.session_picker_root != NULL) {
     lv_obj_del(s_chat.session_picker_root);
     s_chat.session_picker_root = NULL;
+    s_chat.session_picker_title = NULL;
     memset(s_chat.session_picker_items, 0, sizeof(s_chat.session_picker_items));
   }
 
@@ -1967,6 +1988,7 @@ static void session_picker_build_ui(void) {
 
   /* Title row. */
   lv_obj_t* title = lv_label_create(s_chat.session_picker_root);
+  s_chat.session_picker_title = title;
   lv_obj_set_size(title, lv_pct(100), BB_SPICKER_TITLE_H);
   lv_obj_set_style_text_color(title, lv_color_hex(BB_SPICKER_FG), 0);
   lv_obj_set_style_text_font(title, font, 0);
@@ -1974,7 +1996,14 @@ static void session_picker_build_ui(void) {
   char title_buf[48];
   const char* drv = s_chat.driver_name[0] != '\0'
                       ? s_chat.driver_name : BB_CHAT_DRIVER_FALLBACK;
-  snprintf(title_buf, sizeof(title_buf), "Sessions (%s)", drv);
+  if (n_sessions > 0) {
+    /* Show position indicator: current index is unknown at build time (sel
+     * may be on Driver or New row), so show total count for now. The
+     * apply_styles pass will update it once sel is known. */
+    snprintf(title_buf, sizeof(title_buf), "Sessions (%s) %d", drv, n_sessions);
+  } else {
+    snprintf(title_buf, sizeof(title_buf), "Sessions (%s)", drv);
+  }
   lv_label_set_text(title, title_buf);
 
   /* Row 0: Driver selector — shows current driver; LEFT/RIGHT cycles drivers. */
@@ -2021,7 +2050,10 @@ static void session_picker_build_ui(void) {
 
     const bb_agent_session_info_t* si = &s_chat.session_list[i];
     const char* title = si->title;
-    if (title == NULL || title[0] == '\0') title = "(untitled)";
+    /* Fallback order: title → cwd_name → "(untitled)" */
+    if (title == NULL || title[0] == '\0') {
+      title = (si->cwd_name[0] != '\0') ? si->cwd_name : "(untitled)";
+    }
 
     char time_buf[8] = {0};
     format_relative_time(si->last_used_ms, time_buf, sizeof(time_buf));
@@ -2034,8 +2066,13 @@ static void session_picker_build_ui(void) {
     if (time_buf[0] != '\0') {
       off += snprintf(suffix + off, sizeof(suffix) - (size_t)off, " %s", time_buf);
     }
-    if (si->cwd[0] != '\0') {
-      off += snprintf(suffix + off, sizeof(suffix) - (size_t)off, " %s", si->cwd);
+    /* Prefer the human-readable pool name; fall back to raw cwd only if
+     * neither cwd_name nor cwd is available (old adapter). */
+    const char* cwd_label = si->cwd_name[0] != '\0' ? si->cwd_name
+                          : si->cwd[0] != '\0'       ? si->cwd
+                          : NULL;
+    if (cwd_label != NULL) {
+      off += snprintf(suffix + off, sizeof(suffix) - (size_t)off, " %s", cwd_label);
     }
     if (i == s_chat.session_picker_active_idx) {
       snprintf(suffix + off, sizeof(suffix) - (size_t)off, " <");
@@ -2077,6 +2114,7 @@ void bb_ui_agent_chat_session_picker_hide(void) {
   if (s_chat.session_picker_root != NULL) {
     lv_obj_del(s_chat.session_picker_root);
     s_chat.session_picker_root = NULL;
+    s_chat.session_picker_title = NULL;
     memset(s_chat.session_picker_items, 0, sizeof(s_chat.session_picker_items));
   }
   s_chat.session_picker_visible = 0;


### PR DESCRIPTION
Fixes #70

## What changed

### Adapter

- logicalsession/types.go: added CwdName field (outbound-only, not persisted)
- httpapi/agent.go: handleAgentSessionsLogical reverse-looks up CwdPool path->name after expiry filter; falls back to filepath.Base(cwd) for unrecognised paths; original cwd field preserved
- httpapi/agent_logical_test.go: new TestHandleAgentSessionsLogical_CwdName covering pool hit x2 and basename fallback

### Firmware

- bb_agent_client.h: added cwd_name[32] to bb_agent_session_info_t
- bb_agent_client.c: parses cwdName JSON field; absent on old adapters -> stays empty (safe); bumped limit param 6->16
- bb_ui_agent_chat.c:
  - BB_SESSION_PICKER_MAX raised 8->16
  - session_picker_title pointer added to state; cleared on hide/rebuild
  - Title row shows position indicator updated on every scroll: "Sessions (drv) N/total" when session row selected, "Sessions (drv) total" on Driver/New row, plain "Sessions (drv)" when empty
  - Session row title fallback: title -> cwd_name -> "(untitled)" (fixes the "(untit" truncation bug)
  - Session row suffix uses cwd_name when available; falls back to raw cwd path only when cwd_name absent (old adapter compat)

## Testing

- go test ./... in adapter/ — all pass including new TestHandleAgentSessionsLogical_CwdName
- Firmware: no serial device available in CI — manual verification needed with multiple CwdPool entries configured