### PR TITLE
fix: wake from STANDBY via any nav key, not only PTT

### DIFF
--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -1650,6 +1650,17 @@ static void stream_task(void* arg) {
 
           case BBCLAW_STATE_CHAT: {
             s_last_activity_ms = bb_now_ms();
+            /* STANDBY → CHAT: any nav key wakes to chat overlay, mirroring
+             * the PTT guard above.  The first edge is consumed (not forwarded
+             * to chat internals) so the wake-up key does not double as a
+             * scroll / driver-cycle / OK event.  LOCKED state is unaffected:
+             * nav is already silently dropped in BBCLAW_STATE_LOCKED above. */
+            if (!agent_chat_is_active() && !radio_app_is_locked()) {
+              if (agent_chat_enter() != 0) {
+                ESP_LOGW(TAG, "nav: agent_chat_enter from standby failed");
+              }
+              break; /* consume the edge; do not forward to chat internals */
+            }
             int busy = agent_chat_is_busy_locked();
             int cwd_up = bb_ui_agent_chat_cwd_picker_is_visible();
             int picker_up = bb_ui_agent_chat_session_picker_is_visible();


### PR DESCRIPTION
Fixes #63

## What changed

In `firmware/src/bb_radio_app.c`, inside the `case BBCLAW_STATE_CHAT:` nav-event handler, added a STANDBY→CHAT guard that mirrors the existing PTT guard (line ~1851).

When the device is on the STANDBY view (BBClaw brand + clock), any of the 6 Flipper nav buttons (UP/DOWN/LEFT/RIGHT/OK/BACK) now calls `agent_chat_enter()` and breaks — entering the CHAT overlay without forwarding the key to scroll/driver-cycle/picker logic.

## Behavior

| Scenario | Before | After |
|---|---|---|
| STANDBY + any nav key | Fell through to scroll/cycle/picker logic (inconsistent) | Enters CHAT overlay; key consumed |
| STANDBY + PTT | Enters CHAT + starts recording | Unchanged |
| LOCKED + any nav key | Silently dropped | Unchanged |
| CHAT active + nav key | Normal scroll/cycle/picker | Unchanged |

## Testing

No firmware unit tests in this repo. Runtime verification requires flashing to hardware (ESP32-S3 + ESP-IDF toolchain not available in CI). Manual steps per the SOP:

1. Flash `local_home` profile
2. Let device idle to STANDBY (BBClaw + clock display)
3. Press UP/DOWN/LEFT/RIGHT/OK/BACK — each should enter CHAT overlay; the pressed key should not trigger scroll/driver-switch/picker
4. PTT from STANDBY should still enter CHAT and begin recording immediately
5. With cloud_saas + passphrase lock active: nav keys should remain ignored on LOCKED screen