### PR TITLE
fix: synthesize default title in Manager.Create when title is empty

### DIFF
--- a/adapter/internal/agent/logicalsession/manager.go
+++ b/adapter/internal/agent/logicalsession/manager.go
@@ -128,6 +128,25 @@ func (m *Manager) Create(deviceID, driver, cwd, title string) (*LogicalSession, 
 		}
 	}
 
+	// Synthesize a default title when the caller doesn't supply one.
+	// filepath.Base("") == "." and filepath.Base("/") == "/" are both
+	// degenerate, so we treat them as "no useful cwd" and fall back to
+	// the id-based name instead.
+	if title == "" {
+		base := filepath.Base(cwd)
+		if base != "" && base != "." && base != "/" {
+			title = base
+		} else {
+			// id is "ls-<16 hex chars>"; take the last 6 chars as a short suffix.
+			idStr := string(id)
+			if len(idStr) >= 6 {
+				title = "session-" + idStr[len(idStr)-6:]
+			} else {
+				title = "session-" + idStr
+			}
+		}
+	}
+
 	s := &LogicalSession{
 		ID:         id,
 		DeviceID:   deviceID,

--- a/adapter/internal/agent/logicalsession/manager_test.go
+++ b/adapter/internal/agent/logicalsession/manager_test.go
@@ -324,6 +324,81 @@ func TestDefaultCwdFallback(t *testing.T) {
 	}
 }
 
+func TestDefaultTitleFallback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sessions.json")
+
+	m, err := NewManager(path, "", testLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	t.Run("cwd provided → filepath.Base(cwd)", func(t *testing.T) {
+		s, err := m.Create("dev-1", "claude-code", "/Users/mikas/github/bbclaw", "")
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if s.Title != "bbclaw" {
+			t.Errorf("title=%q want %q", s.Title, "bbclaw")
+		}
+	})
+
+	t.Run("cwd and defaultCwd both empty → session-<short id>", func(t *testing.T) {
+		s, err := m.Create("dev-1", "claude-code", "", "")
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if !strings.HasPrefix(s.Title, "session-") {
+			t.Errorf("title=%q want prefix %q", s.Title, "session-")
+		}
+		suffix := strings.TrimPrefix(s.Title, "session-")
+		if len(suffix) != 6 {
+			t.Errorf("title suffix %q should be 6 chars, got %d", suffix, len(suffix))
+		}
+		// Suffix must match the last 6 chars of the id.
+		idStr := string(s.ID)
+		wantSuffix := idStr[len(idStr)-6:]
+		if suffix != wantSuffix {
+			t.Errorf("title suffix %q does not match id tail %q", suffix, wantSuffix)
+		}
+	})
+
+	t.Run("explicit title is not overwritten", func(t *testing.T) {
+		s, err := m.Create("dev-1", "claude-code", "/Users/mikas/github/bbclaw", "my custom title")
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if s.Title != "my custom title" {
+			t.Errorf("title=%q want %q", s.Title, "my custom title")
+		}
+	})
+
+	t.Run("defaultCwd fallback used for title when cwd arg is empty", func(t *testing.T) {
+		m2, err := NewManager(filepath.Join(dir, "s2.json"), "/home/user/my-project", testLogger())
+		if err != nil {
+			t.Fatalf("NewManager: %v", err)
+		}
+		s, err := m2.Create("dev-1", "claude-code", "", "")
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		// cwd arg "" → falls back to defaultCwd "/home/user/my-project" → Base = "my-project"
+		if s.Title != "my-project" {
+			t.Errorf("title=%q want %q", s.Title, "my-project")
+		}
+	})
+
+	t.Run("degenerate cwd '/' falls back to session-<id>", func(t *testing.T) {
+		s, err := m.Create("dev-1", "claude-code", "/", "")
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if !strings.HasPrefix(s.Title, "session-") {
+			t.Errorf("title=%q want prefix %q for degenerate cwd", s.Title, "session-")
+		}
+	})
+}
+
 func TestSetTitle(t *testing.T) {
 	m, _ := newTestManager(t)
 	s, err := m.Create("dev-1", "claude-code", "/p", "old")


### PR DESCRIPTION
Fixes #76

## What changed

Added a title fallback inside `Manager.Create()` in `adapter/internal/agent/logicalsession/manager.go`. When the caller passes an empty title (all 4 implicit/explicit create paths do this today), the manager now synthesizes a readable default:

- `cwd != ""` → `filepath.Base(cwd)` (e.g. `"bbclaw"`, `"my-project"`)
- `cwd == ""` → `"session-" + last 6 hex chars of the logical id`

`filepath.Base` degenerate results (`"."` and `"/"`) are treated as "no useful cwd" and fall through to the id-based branch.

Explicit titles passed by callers are never overwritten. Historical sessions with empty titles are not migrated (only new sessions get the fallback).

## Files changed

- `adapter/internal/agent/logicalsession/manager.go` — title fallback logic after id mint
- `adapter/internal/agent/logicalsession/manager_test.go` — `TestDefaultTitleFallback` with 5 subtests covering: cwd-based title, empty-cwd id-based title, explicit title not overwritten, defaultCwd used for title, degenerate `/` cwd

## Testing

- All 13 tests in the `logicalsession` package pass
- Full adapter `go test ./...` passes (22 packages, 0 failures)
- Hardware PTT path not verified (no device available); the change is purely in the session creation layer with no protocol changes