### PR TITLE
feat: butler workspace scaffold + persona CLAUDE.md (ADR-021 v1)

### DIFF
--- a/adapter/cmd/bbclaw-adapter/main.go
+++ b/adapter/cmd/bbclaw-adapter/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/daboluocc/bbclaw/adapter/internal/openclaw"
 	"github.com/daboluocc/bbclaw/adapter/internal/pipeline"
 	"github.com/daboluocc/bbclaw/adapter/internal/tts"
+	"github.com/daboluocc/bbclaw/adapter/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -522,6 +523,16 @@ func run(cfg config.Config, logger *obs.Logger, metrics *obs.Metrics) {
 	sessionMgr := buildSessionManager(logger)
 	driverStateStore := buildDriverState(logger)
 	applyDriverStateDefault(agentRouter, driverStateStore, logger)
+
+	// Ensure the butler workspace + default CLAUDE.md exist (ADR-021 §4). The
+	// butler session runs with cwd=workspace so Claude loads this persona +
+	// long-term memory natively. Non-fatal: degrade like driverstate if the
+	// scaffold can't be written.
+	if dir, err := workspace.EnsureScaffold(); err != nil {
+		logger.Warnf("workspace: scaffold failed, butler CLAUDE.md unavailable: %v", err)
+	} else {
+		logger.Infof("workspace: ready dir=%s", dir)
+	}
 
 	if len(cfg.CwdPool) > 0 {
 		names := make([]string, len(cfg.CwdPool))

--- a/adapter/internal/workspace/persona.go
+++ b/adapter/internal/workspace/persona.go
@@ -1,0 +1,47 @@
+package workspace
+
+// DefaultClaudeMD is the factory persona written to a fresh workspace
+// CLAUDE.md (ADR-021 §4). It is the butler's persona — an orchestrator that
+// dispatches coding tasks to worker agents — plus the device constraints of
+// the walkie-talkie form factor, followed by an empty managed memory block
+// that the memory pipeline appends into.
+//
+// Keep this short and speakable: it is loaded as the butler's standing
+// instructions, and the device can only voice short answers. The persona is
+// modelled on the openclaw-style preset and aligned with the butlermcp tool
+// surface (list_projects / dispatch / task_status / task_result).
+//
+// The trailing managed block MUST stay in sync with ManagedBegin / ManagedEnd
+// so EnsureScaffold recognises freshly written files as already having a block.
+const DefaultClaudeMD = `# BBClaw 管家
+
+你是 **BBClaw 管家**。用户通过一台对讲机式的硬件语音外设（1.47 寸小屏、PTT 按键、语音播报）跟你对话。你不是亲自敲代码的工人，而是**调度器 / 主管**：听懂用户意图，搞清楚要在哪个项目目录做什么，把复杂任务**派给 worker 子代理**去跑，然后盯进展、用一句话把结果讲给用户。
+
+## 你的工具（MCP）
+
+- ` + "`list_projects`" + ` —— 列出你可以派发任务的项目目录（名字 + 路径）。不确定有哪些工程时先调它。
+- ` + "`dispatch`" + ` —— 在某个项目目录里起一个 worker 子代理跑编码任务。用 ` + "`project`" + `（list_projects 里的名字）或 ` + "`cwd`" + `（必须在白名单内）指定目录，` + "`task`" + ` 写清要做什么。短任务内联返回 ` + "`{status:\"done\", result}`" + `；长任务返回 ` + "`{status:\"running\", taskId}`" + `，之后用 task_status / task_result 追踪。
+- ` + "`task_status`" + ` —— 查异步任务状态（running | done | error）。
+- ` + "`task_result`" + ` —— 取已完成异步任务的结果。
+
+## 工作方式
+
+- **自己能直接答的就直接答**（闲聊、解释、简单问题），不必凡事都 dispatch。
+- **真正的编码 / 多步骤任务派给 worker**：选对项目目录，` + "`dispatch`" + ` 出去，worker 会自主跑完整的 agentic 流程。
+- **切换项目用说的**：用户说“切到项目 X”“在 Y 上做……”，你据此选 cwd，不要让用户翻菜单。
+- **盯任务、讲进展**：派发后把“在做什么 / 好了没 / 结果是什么”用人话讲给用户；长任务用户追问时再 task_status。
+
+## 设备约束（必须遵守）
+
+- 回答**简短、可朗读**：先用 1–3 句话给结论；避免长代码块、表格、大段列表（小屏放不下，也无法朗读）。
+- 必须展示代码或长输出时，先一句话口述要点，再给最小必要片段。
+- **用用户的语言**回答。
+- 记住：用户通常不在电脑前，只能靠语音和小屏跟你交互。
+
+## 长期记忆
+
+以下区块由 BBClaw 自动维护（记录用户长期偏好、最近在做的项目、关键决策），请勿手动编辑；你在此区块之外写的内容会被完整保留。
+
+` + ManagedBegin + `
+` + ManagedEnd + `
+`

--- a/adapter/internal/workspace/workspace.go
+++ b/adapter/internal/workspace/workspace.go
@@ -1,0 +1,167 @@
+// Package workspace owns the BBClaw butler's home directory —
+// ~/.bbclaw-adapter/workspace/ — and the CLAUDE.md inside it (ADR-021 §4).
+//
+// That CLAUDE.md is the butler's persona (an orchestrator that dispatches
+// coding tasks to worker agents, constrained by the walkie-talkie form
+// factor) plus its long-term memory. When the butler session runs with
+// cwd=workspace, Claude loads this CLAUDE.md natively (the ADR-021 spike
+// confirmed cwd-implicit loading, not --add-dir).
+//
+// The package centralises the workspace path constants so the butler router
+// (#80) and the memory pipeline can reuse them instead of re-deriving the
+// data directory. It also owns the managed-marker block helpers: a
+// BEGIN/END region the adapter may rewrite for long-term memory while
+// leaving everything the user hand-wrote untouched.
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// dataDirEnv overrides the default data directory. Mirrors the resolution
+	// used by driverstate / logicalsession so all adapter state lives together.
+	dataDirEnv     = "BBCLAW_DATA_DIR"
+	defaultDataDir = ".bbclaw-adapter"
+	workspaceName  = "workspace"
+	claudeMDName   = "CLAUDE.md"
+
+	// ManagedBegin / ManagedEnd delimit the adapter-managed region inside
+	// CLAUDE.md. Anything between them is owned by the adapter (long-term
+	// memory); anything outside is the user's and is never touched.
+	ManagedBegin = "<!-- BEGIN BBClaw-managed -->"
+	ManagedEnd   = "<!-- END BBClaw-managed -->"
+)
+
+// DataDir resolves the adapter data directory: $BBCLAW_DATA_DIR when set,
+// otherwise ~/.bbclaw-adapter. Shared with driverstate and logicalsession.
+func DataDir() (string, error) {
+	if d := strings.TrimSpace(os.Getenv(dataDirEnv)); d != "" {
+		return d, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, defaultDataDir), nil
+}
+
+// Dir returns the butler workspace directory (DataDir()/workspace).
+func Dir() (string, error) {
+	dataDir, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dataDir, workspaceName), nil
+}
+
+// ClaudeMDPath returns the path to the workspace CLAUDE.md.
+func ClaudeMDPath() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, claudeMDName), nil
+}
+
+// EnsureScaffold guarantees the workspace directory exists and that its
+// CLAUDE.md is usable. It is idempotent and conservative:
+//
+//   - missing directory      → created (0755)
+//   - missing CLAUDE.md       → factory default written (0644)
+//   - existing CLAUDE.md      → never clobbered; only a managed marker block
+//     is appended when none is present, so the memory pipeline has an anchor.
+//
+// It returns the workspace directory path on success. Callers should treat a
+// non-nil error as non-fatal (log + degrade), matching the driverstate /
+// logicalsession "run without persistence" style.
+func EnsureScaffold() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create workspace dir %s: %w", dir, err)
+	}
+
+	path := filepath.Join(dir, claudeMDName)
+	existing, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		if err := os.WriteFile(path, []byte(DefaultClaudeMD), 0o644); err != nil {
+			return "", fmt.Errorf("write default CLAUDE.md %s: %w", path, err)
+		}
+		return dir, nil
+	case err != nil:
+		return "", fmt.Errorf("read CLAUDE.md %s: %w", path, err)
+	}
+
+	// CLAUDE.md exists: respect the user's content entirely. Only ensure a
+	// managed block exists so memory appends have a home.
+	if !HasManagedBlock(string(existing)) {
+		updated := ensureTrailingNewline(string(existing)) + "\n" + emptyManagedBlock() + "\n"
+		if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+			return "", fmt.Errorf("append managed block to %s: %w", path, err)
+		}
+	}
+	return dir, nil
+}
+
+// HasManagedBlock reports whether content contains a well-formed managed block.
+func HasManagedBlock(content string) bool {
+	_, _, ok := findManagedBlock(content)
+	return ok
+}
+
+// ManagedBlock returns the inner text between the managed markers (trimmed of
+// the surrounding newlines), and whether a block was found.
+func ManagedBlock(content string) (inner string, ok bool) {
+	start, end, found := findManagedBlock(content)
+	if !found {
+		return "", false
+	}
+	inner = content[start+len(ManagedBegin) : end-len(ManagedEnd)]
+	return strings.Trim(inner, "\n"), true
+}
+
+// ReplaceManagedBlock returns content with the managed block's inner text set
+// to inner. If no managed block exists yet, a fresh one is appended at the end.
+// This is the entry point the memory pipeline uses to persist long-term notes.
+func ReplaceManagedBlock(content, inner string) string {
+	block := ManagedBegin + "\n" + inner + "\n" + ManagedEnd
+	start, end, ok := findManagedBlock(content)
+	if !ok {
+		return ensureTrailingNewline(content) + "\n" + block + "\n"
+	}
+	return content[:start] + block + content[end:]
+}
+
+// findManagedBlock locates the managed block, returning the index of
+// ManagedBegin and the index just past ManagedEnd. ok is false when either
+// marker is missing or they appear out of order.
+func findManagedBlock(content string) (start, end int, ok bool) {
+	b := strings.Index(content, ManagedBegin)
+	if b < 0 {
+		return 0, 0, false
+	}
+	rel := strings.Index(content[b+len(ManagedBegin):], ManagedEnd)
+	if rel < 0 {
+		return 0, 0, false
+	}
+	return b, b + len(ManagedBegin) + rel + len(ManagedEnd), true
+}
+
+func emptyManagedBlock() string {
+	return ManagedBegin + "\n" + ManagedEnd
+}
+
+func ensureTrailingNewline(s string) string {
+	if s == "" || strings.HasSuffix(s, "\n") {
+		return s
+	}
+	return s + "\n"
+}

--- a/adapter/internal/workspace/workspace_test.go
+++ b/adapter/internal/workspace/workspace_test.go
@@ -1,0 +1,178 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// redirectDataDir points DataDir() at an isolated temp dir for the test.
+func redirectDataDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("BBCLAW_DATA_DIR", dir)
+	return dir
+}
+
+func TestEnsureScaffoldFirstRunWritesDefault(t *testing.T) {
+	redirectDataDir(t)
+
+	dir, err := EnsureScaffold()
+	if err != nil {
+		t.Fatalf("EnsureScaffold: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("workspace dir missing: %v", err)
+	}
+
+	path := filepath.Join(dir, "CLAUDE.md")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("CLAUDE.md not created: %v", err)
+	}
+	content := string(body)
+
+	// Persona must carry the dispatcher identity, the MCP tools, and the
+	// device constraints (acceptance: persona content review anchors).
+	for _, want := range []string{"调度器", "list_projects", "dispatch", "task_status", "task_result", "PTT", "可朗读"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("default CLAUDE.md missing %q", want)
+		}
+	}
+	if !HasManagedBlock(content) {
+		t.Errorf("default CLAUDE.md must contain a managed marker block")
+	}
+}
+
+func TestEnsureScaffoldIdempotentDoesNotClobber(t *testing.T) {
+	redirectDataDir(t)
+
+	if _, err := EnsureScaffold(); err != nil {
+		t.Fatalf("first EnsureScaffold: %v", err)
+	}
+	path, err := ClaudeMDPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the user hand-editing CLAUDE.md, including inside the managed
+	// block — a re-run must leave every byte untouched.
+	userContent := "# my own persona\n\nhello world\n\n" + ManagedBegin + "\nkeep me\n" + ManagedEnd + "\n"
+	if err := os.WriteFile(path, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureScaffold(); err != nil {
+		t.Fatalf("second EnsureScaffold: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != userContent {
+		t.Errorf("EnsureScaffold clobbered user content:\nwant %q\ngot  %q", userContent, string(got))
+	}
+}
+
+func TestEnsureScaffoldAppendsMissingMarker(t *testing.T) {
+	redirectDataDir(t)
+
+	if _, err := EnsureScaffold(); err != nil {
+		t.Fatalf("first EnsureScaffold: %v", err)
+	}
+	path, err := ClaudeMDPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// User replaced CLAUDE.md with content that has NO managed block.
+	userContent := "# only my stuff\n"
+	if err := os.WriteFile(path, []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureScaffold(); err != nil {
+		t.Fatalf("re-run EnsureScaffold: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotStr := string(got)
+	if !strings.HasPrefix(gotStr, userContent) {
+		t.Errorf("user content must be preserved as prefix, got:\n%s", gotStr)
+	}
+	if !HasManagedBlock(gotStr) {
+		t.Errorf("missing managed block should have been appended, got:\n%s", gotStr)
+	}
+}
+
+func TestFindAndReplaceManagedBlock(t *testing.T) {
+	base := "intro\n" + ManagedBegin + "\nold note\n" + ManagedEnd + "\noutro\n"
+
+	inner, ok := ManagedBlock(base)
+	if !ok {
+		t.Fatal("expected to find managed block")
+	}
+	if inner != "old note" {
+		t.Errorf("inner = %q, want %q", inner, "old note")
+	}
+
+	updated := ReplaceManagedBlock(base, "new note")
+	gotInner, ok := ManagedBlock(updated)
+	if !ok || gotInner != "new note" {
+		t.Errorf("after replace inner = %q (ok=%v), want %q", gotInner, ok, "new note")
+	}
+	// Content outside the block must survive replacement.
+	if !strings.HasPrefix(updated, "intro\n") || !strings.HasSuffix(updated, "outro\n") {
+		t.Errorf("replacement disturbed surrounding content:\n%s", updated)
+	}
+}
+
+func TestReplaceManagedBlockAppendsWhenAbsent(t *testing.T) {
+	base := "no markers here"
+	updated := ReplaceManagedBlock(base, "first note")
+	if !HasManagedBlock(updated) {
+		t.Fatalf("expected a managed block to be appended:\n%s", updated)
+	}
+	inner, _ := ManagedBlock(updated)
+	if inner != "first note" {
+		t.Errorf("inner = %q, want %q", inner, "first note")
+	}
+	if !strings.HasPrefix(updated, "no markers here") {
+		t.Errorf("original content must be preserved:\n%s", updated)
+	}
+}
+
+func TestFindManagedBlockRejectsMalformed(t *testing.T) {
+	// END before BEGIN, or only one marker, is not a valid block.
+	for _, content := range []string{
+		ManagedEnd + "\n" + ManagedBegin,
+		ManagedBegin + " only",
+		ManagedEnd + " only",
+		"nothing",
+	} {
+		if HasManagedBlock(content) {
+			t.Errorf("content should not be a valid block: %q", content)
+		}
+	}
+}
+
+func TestDataDirHonoursEnv(t *testing.T) {
+	dir := redirectDataDir(t)
+	got, err := DataDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != dir {
+		t.Errorf("DataDir = %q, want %q", got, dir)
+	}
+	wsDir, err := Dir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wsDir != filepath.Join(dir, "workspace") {
+		t.Errorf("Dir = %q, want %q", wsDir, filepath.Join(dir, "workspace"))
+	}
+}


### PR DESCRIPTION
Fixes #81

## 改动

新增 `adapter/internal/workspace` 包，并在 adapter 启动时确保管家的家目录与默认 CLAUDE.md 存在（ADR-021 §4）。

### 1. 集中路径常量
- `DataDir()` —— 解析 `BBCLAW_DATA_DIR`（默认 `~/.bbclaw-adapter`），与 driverstate / logicalsession 同源。
- `Dir()` / `ClaudeMDPath()` —— workspace 子目录与 CLAUDE.md 路径，供 #80 路由与记忆 issue 复用，避免路径散落。

### 2. 脚手架（幂等、保守）
- `EnsureScaffold()`：缺目录则 `MkdirAll(0755)`；缺 `CLAUDE.md` 则写出厂默认（`0644`）。
- **文件已存在则完全不覆盖用户内容**，仅当缺 marker 段时追加空 marker 骨架（取评审建议的最保守语义）。
- 启动接线：`run()` 中与 driverstate 同阶段调用，失败仅 `Warnf` 不阻塞启动。

### 3. 默认人设 CLAUDE.md（openclaw 风格）
- 调度器 / 主管定位；MCP 工具说明（`list_projects` / `dispatch` / `task_status` / `task_result`，与 butlermcp 工具语义对齐）；
- 设备约束（小屏 / 语音 / PTT、简短可朗读、用用户语言、复杂任务派 worker）；
- 文末留 `<!-- BEGIN/END BBClaw-managed -->` marker 记忆段。
- 内容迁移自 `internal/butler/persona.go` 的 `DeviceSystemPrompt`，改写为 Markdown 人设正文。**完整文本见 `adapter/internal/workspace/persona.go`，请 owner 评审文案。**

### 4. marker 工具
- `HasManagedBlock` / `ManagedBlock` / `ReplaceManagedBlock`：BEGIN/END 段定位与替换，为记忆 issue 的 append 入口预留。

## 测试
- `go build ./...`、`go vet`、`gofmt` 全过。
- 新增单测覆盖：首次写默认、幂等不覆盖用户改动、缺 marker 段补骨架、marker 定位/替换、畸形 marker 拒绝、`BBCLAW_DATA_DIR` 重定向。`go test ./internal/workspace/ ./cmd/...` 通过。

## 范围说明
- 仅落 CLAUDE.md 脚手架；管家会话路由（cwd 指向 workspace）与注入层收敛留给 #80。
- 未触碰协议 / firmware / cloud。按评审建议，`persona.go` 的 `DeviceSystemPrompt`（--append-system-prompt 注入）保持不变，避免本 issue 引入双轨注入。
- 纯 adapter 内部启动逻辑，无需硬件验证；脚手架行为已由单测直接覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)