### PR TITLE
feat: 管家 MCP 派发 server — worker runner + mcp-server 子命令 (ADR-021 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CHAT 最外层长按 OK 进不了菜单**：新 PCB rev 把 OK 移到编码器按压（IO1），`bb_nav_input` 把长按 OK 改发 `BB_NAV_EVENT_BACK` 替代旧的 `OK_LONG`，但 `bb_radio_app` CHAT 状态里"进 SETTINGS"那条路径还挂在 `OK_LONG` 上，导致长按落到空 BACK case 上没反应。把进 SETTINGS 行为合并到 BACK 处理里——busy 时维持取消 in-flight turn 的旧语义，空闲时进入 SETTINGS 浮层。
 
 ### Added
+- **管家 MCP 派发 server — worker runner + `mcp-server` 子命令 (ADR-021 v1)**：补齐「管家 MCP 派发」最后一公里。
+  - **`ClaudeWorkerRunner`**（`adapter/internal/butlermcp/runner_claude.go`）：落地 `WorkerRunner` 接口，复用 claudecode driver 在目标 cwd 起 worker（`--permission-mode acceptEdits`），消费 stream-json 累积 assistant 文本到 `EvTurnEnd`，`EvError` 透传为错误，输出超长时按头尾保留、中间省略裁剪（默认 8KB，避免把超长 transcript 回灌管家）。
+  - **`bbclaw-adapter mcp-server` 子命令**（`adapter/internal/cmd/mcpserver.go`）：从 env 读 `BBCLAW_CWD_POOL`（allowlist）与 `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`，装配 `ClaudeWorkerRunner` + `butlermcp.New`，在 stdio 上 `Serve`；**stdout 仅 JSON-RPC，日志全部走 stderr**（`obs.NewLoggerTo`）。新增 `config.LoadButlerEnv` 仅加载管家所需字段，跳过 ASR/TTS 校验。
+  - **e2e 冒烟**（`adapter/scripts/butler-mcp-smoke.sh` + `butler-mcp-config.example.json`）：协议层冒烟无需真实 claude；`BBCLAW_BUTLER_LIVE=1` 时跑 `claude -p --mcp-config` 真链路（claude 不在 PATH 时自动跳过，CI 不依赖）。
 - **TTS 阅读模式 + Chat 本地 tail 缓存 (ADR-017)**：解决两个 UX 痛点。
   - **阅读模式**：TTS 播报中按 UP 翻看历史不再被下一句 chunk 拉回底部 — chat transcript 加了 `follow_tail` 锁存，UP 即进入阅读模式，DOWN 滚回底部自动恢复 follow，期间底栏显示 "● 阅读中 (DOWN 到底回到实时)" 提示。
   - **Chat tail 缓存**：每个 driver 在 NVS 里维护一个 1.5KB 的最近消息环（key `cc/<驱动短码>`），睡眠/唤醒回到 chat 时先用本地 cache 渲染最近几条消息，再 fire adapter fetch；adapter 不在线也能看到刚才的对话。Fetch 成功后清缓存重写以保持远端为 SoT。

--- a/adapter/internal/butlermcp/runner_claude.go
+++ b/adapter/internal/butlermcp/runner_claude.go
@@ -1,0 +1,175 @@
+package butlermcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/agent/claudecode"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
+)
+
+// defaultMaxOutputBytes caps the worker result text the runner hands back to
+// the butler. A worker turn can emit a long transcript; the butler only needs
+// the final answer, and a multi-KB blob bloats the butler's own context window
+// (ADR-021 §2). Beyond this size the middle is elided with a marker.
+const defaultMaxOutputBytes = 8000
+
+const truncationMarker = "\n…[output truncated]…\n"
+
+// claudeDriver is the subset of agent.Driver the runner needs. claudecode.Driver
+// satisfies it; tests inject a fake so Run can be exercised without spawning the
+// real `claude` CLI.
+type claudeDriver interface {
+	Start(ctx context.Context, opts agent.StartOpts) (agent.SessionID, error)
+	Send(sid agent.SessionID, text string) error
+	Events(sid agent.SessionID) <-chan agent.Event
+	Stop(sid agent.SessionID) error
+}
+
+// ClaudeWorkerRunner implements WorkerRunner by spawning a claude-code worker
+// session in the target cwd with `--permission-mode acceptEdits`, consuming its
+// stream-json event stream, and returning the accumulated assistant text.
+type ClaudeWorkerRunner struct {
+	driver         claudeDriver
+	maxOutputBytes int
+}
+
+// ClaudeRunnerOptions configure a ClaudeWorkerRunner.
+type ClaudeRunnerOptions struct {
+	// Bin is the path to the `claude` binary; empty resolves "claude" on PATH.
+	Bin string
+	// BaseURL / AuthToken map to ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN for
+	// the worker subprocess. Empty values are not injected.
+	BaseURL   string
+	AuthToken string
+	// ExtraArgs are appended after the fixed worker args (e.g. "--model", "…").
+	// "--permission-mode acceptEdits" is always prepended by the runner so the
+	// worker can edit files without an interactive approval round-trip.
+	ExtraArgs []string
+	// MaxOutputBytes caps the result text. <=0 uses defaultMaxOutputBytes.
+	MaxOutputBytes int
+	// Logger is the obs logger for the underlying claudecode driver. It MUST
+	// write to stderr (obs.NewLoggerTo(os.Stderr)) — never stdout, which is the
+	// MCP JSON-RPC channel. nil falls back to a stdout logger (tests only).
+	Logger *obs.Logger
+}
+
+// NewClaudeWorkerRunner builds a production runner backed by the claudecode
+// driver.
+func NewClaudeWorkerRunner(opts ClaudeRunnerOptions) *ClaudeWorkerRunner {
+	logger := opts.Logger
+	if logger == nil {
+		logger = obs.NewLogger()
+	}
+	// acceptEdits lets the worker apply file edits without blocking on an
+	// approval prompt (ADR-021 §2: workers run unattended). Prepended so an
+	// operator-supplied --permission-mode in ExtraArgs still wins (last-flag).
+	extra := append([]string{"--permission-mode", "acceptEdits"}, opts.ExtraArgs...)
+	var env map[string]string
+	if opts.BaseURL != "" || opts.AuthToken != "" {
+		env = make(map[string]string, 2)
+		if opts.BaseURL != "" {
+			env["ANTHROPIC_BASE_URL"] = opts.BaseURL
+		}
+		if opts.AuthToken != "" {
+			env["ANTHROPIC_AUTH_TOKEN"] = opts.AuthToken
+		}
+	}
+	d := claudecode.New(claudecode.Options{
+		Bin:       opts.Bin,
+		ExtraArgs: extra,
+		Env:       env,
+	}, logger)
+	return newRunnerWithDriver(d, opts.MaxOutputBytes)
+}
+
+// newRunnerWithDriver is the testable constructor: it takes an already-built
+// driver (real or fake) so unit tests can inject a mock.
+func newRunnerWithDriver(d claudeDriver, maxOutputBytes int) *ClaudeWorkerRunner {
+	if maxOutputBytes <= 0 {
+		maxOutputBytes = defaultMaxOutputBytes
+	}
+	return &ClaudeWorkerRunner{driver: d, maxOutputBytes: maxOutputBytes}
+}
+
+// Run starts a worker session in cwd, sends task, and returns the worker's
+// final text once the turn ends. Honours ctx cancellation.
+func (r *ClaudeWorkerRunner) Run(ctx context.Context, cwd, task string) (string, error) {
+	sid, err := r.driver.Start(ctx, agent.StartOpts{Cwd: cwd})
+	if err != nil {
+		return "", fmt.Errorf("butlermcp: start worker: %w", err)
+	}
+	// Always tear the session down so the driver doesn't leak it and any
+	// in-flight subprocess is cancelled.
+	defer func() { _ = r.driver.Stop(sid) }()
+
+	events := r.driver.Events(sid)
+
+	// Send blocks until the worker subprocess exits, so run it in a goroutine
+	// while we drain events. The buffered channel keeps the goroutine from
+	// leaking if we return early on ctx cancellation.
+	sendErr := make(chan error, 1)
+	go func() { sendErr <- r.driver.Send(sid, task) }()
+
+	var sb strings.Builder
+	var turnErr error
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case ev, ok := <-events:
+			if !ok {
+				// Channel closed before EvTurnEnd — surface whatever Send
+				// reported, else a generic error.
+				if turnErr != nil {
+					return "", turnErr
+				}
+				if se := drainSendErr(sendErr); se != nil {
+					return "", se
+				}
+				return clampOutput(sb.String(), r.maxOutputBytes), nil
+			}
+			switch ev.Type {
+			case agent.EvText:
+				sb.WriteString(ev.Text)
+			case agent.EvError:
+				if turnErr == nil && strings.TrimSpace(ev.Text) != "" {
+					turnErr = errors.New(ev.Text)
+				}
+			case agent.EvTurnEnd:
+				if turnErr != nil {
+					return "", turnErr
+				}
+				return clampOutput(sb.String(), r.maxOutputBytes), nil
+			}
+		}
+	}
+}
+
+// drainSendErr does a non-blocking read of the Send result.
+func drainSendErr(ch <-chan error) error {
+	select {
+	case err := <-ch:
+		return err
+	default:
+		return nil
+	}
+}
+
+// clampOutput truncates s to at most max bytes, eliding the middle (the head
+// carries context, the tail carries the final answer) with a marker.
+func clampOutput(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= len(truncationMarker) {
+		return s[:max]
+	}
+	keep := max - len(truncationMarker)
+	head := keep / 2
+	tail := keep - head
+	return s[:head] + truncationMarker + s[len(s)-tail:]
+}

--- a/adapter/internal/butlermcp/runner_claude_test.go
+++ b/adapter/internal/butlermcp/runner_claude_test.go
@@ -1,0 +1,170 @@
+package butlermcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+)
+
+// fakeDriver is an injectable claudeDriver. Send replays a scripted event
+// sequence onto the session channel, then returns sendErr. It mirrors the real
+// driver's invariant: emits are guarded by a stop signal so Stop can never race
+// a write onto a closed channel.
+type fakeDriver struct {
+	events  []agent.Event
+	sendErr error
+
+	startErr error
+	startCwd string // captured Cwd from StartOpts
+
+	gate           chan struct{} // if non-nil, Send waits for it before emitting
+	closeAfterSend bool          // if true, Send closes ch after emitting (no concurrent writer)
+
+	ch   chan agent.Event
+	stop chan struct{}
+
+	stopped bool
+}
+
+func (f *fakeDriver) Start(ctx context.Context, opts agent.StartOpts) (agent.SessionID, error) {
+	if f.startErr != nil {
+		return "", f.startErr
+	}
+	f.startCwd = opts.Cwd
+	f.ch = make(chan agent.Event, 64)
+	f.stop = make(chan struct{})
+	return agent.SessionID("fake-sid"), nil
+}
+
+func (f *fakeDriver) Send(sid agent.SessionID, text string) error {
+	if f.gate != nil {
+		select {
+		case <-f.gate:
+		case <-f.stop:
+			return f.sendErr
+		}
+	}
+	for _, ev := range f.events {
+		select {
+		case f.ch <- ev:
+		case <-f.stop:
+			return f.sendErr
+		}
+	}
+	if f.closeAfterSend {
+		close(f.ch) // Send is the sole writer here — safe to close.
+	}
+	return f.sendErr
+}
+
+func (f *fakeDriver) Events(sid agent.SessionID) <-chan agent.Event { return f.ch }
+
+func (f *fakeDriver) Stop(sid agent.SessionID) error {
+	f.stopped = true
+	if f.stop != nil {
+		select {
+		case <-f.stop: // already closed
+		default:
+			close(f.stop)
+		}
+	}
+	return nil
+}
+
+func TestRunnerCollectsText(t *testing.T) {
+	d := &fakeDriver{events: []agent.Event{
+		{Type: agent.EvSessionInit, Text: "cli-sid"},
+		{Type: agent.EvText, Text: "Hello "},
+		{Type: agent.EvText, Text: "world"},
+		{Type: agent.EvTokens},
+		{Type: agent.EvTurnEnd},
+	}}
+	r := newRunnerWithDriver(d, 0)
+	out, err := r.Run(context.Background(), "/p/proj", "do x")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out != "Hello world" {
+		t.Fatalf("out=%q", out)
+	}
+	if d.startCwd != "/p/proj" {
+		t.Errorf("cwd not propagated: %q", d.startCwd)
+	}
+	if !d.stopped {
+		t.Error("session not stopped")
+	}
+}
+
+func TestRunnerSurfacesError(t *testing.T) {
+	d := &fakeDriver{events: []agent.Event{
+		{Type: agent.EvText, Text: "partial"},
+		{Type: agent.EvError, Text: "claude-code exit: 1"},
+		{Type: agent.EvTurnEnd},
+	}}
+	r := newRunnerWithDriver(d, 0)
+	_, err := r.Run(context.Background(), "/p/proj", "do x")
+	if err == nil || !strings.Contains(err.Error(), "claude-code exit: 1") {
+		t.Fatalf("want EvError surfaced, got %v", err)
+	}
+}
+
+func TestRunnerCtxCancel(t *testing.T) {
+	gate := make(chan struct{}) // Send blocks forever
+	d := &fakeDriver{gate: gate, events: []agent.Event{{Type: agent.EvTurnEnd}}}
+	r := newRunnerWithDriver(d, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	_, err := r.Run(ctx, "/p/proj", "long task")
+	if err == nil {
+		t.Fatal("expected ctx cancellation error")
+	}
+	close(gate)
+}
+
+func TestRunnerStartError(t *testing.T) {
+	d := &fakeDriver{startErr: context.DeadlineExceeded}
+	r := newRunnerWithDriver(d, 0)
+	if _, err := r.Run(context.Background(), "/p/proj", "x"); err == nil {
+		t.Fatal("expected start error")
+	}
+}
+
+func TestRunnerChannelClosedWithoutTurnEnd(t *testing.T) {
+	// No EvTurnEnd: the driver closes the event channel after emitting. The
+	// runner must return the accumulated text rather than hang or panic.
+	d := &fakeDriver{
+		events:         []agent.Event{{Type: agent.EvText, Text: "abc"}},
+		closeAfterSend: true,
+	}
+	r := newRunnerWithDriver(d, 0)
+	out, err := r.Run(context.Background(), "/p/proj", "x")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out != "abc" {
+		t.Fatalf("out=%q want abc", out)
+	}
+}
+
+func TestClampOutput(t *testing.T) {
+	if got := clampOutput("short", 100); got != "short" {
+		t.Errorf("no-trim: %q", got)
+	}
+	long := strings.Repeat("x", 100) + strings.Repeat("y", 100)
+	got := clampOutput(long, 60)
+	if len(got) > 60 {
+		t.Errorf("clamped len=%d > 60", len(got))
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("missing truncation marker: %q", got)
+	}
+	if !strings.HasPrefix(got, "x") || !strings.HasSuffix(got, "y") {
+		t.Errorf("head/tail not preserved: %q", got)
+	}
+}

--- a/adapter/internal/cmd/mcpserver.go
+++ b/adapter/internal/cmd/mcpserver.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/butlermcp"
+	"github.com/daboluocc/bbclaw/adapter/internal/config"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
+	"github.com/spf13/cobra"
+)
+
+// NewMcpServerCmd creates the `mcp-server` subcommand: the stdio MCP server the
+// conversational orchestrator butler talks to (ADR-021). It is launched by the
+// butler as `claude -p --mcp-config <cfg>`, where <cfg> points the command at
+// this subcommand. stdout carries ONLY JSON-RPC; all logs go to stderr.
+func NewMcpServerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "mcp-server",
+		Short: "Run the butler dispatch MCP server on stdio (ADR-021)",
+		Long: `Run the stdio MCP server the conversational butler dispatches through.
+
+Exposes list_projects / dispatch / task_status / task_result over newline-
+delimited JSON-RPC 2.0 on stdin/stdout. Worker tasks run as claude-code
+sessions in the allow-listed project directories from BBCLAW_CWD_POOL.
+
+stdout is reserved for JSON-RPC — all logging is emitted to stderr.
+
+Configuration (env):
+  BBCLAW_CWD_POOL          name:path,name:path,…  allow-listed projects
+  BBCLAW_DEFAULT_CWD       single-project fallback when CWD_POOL is unset
+  ANTHROPIC_BASE_URL       custom API base for worker claude sessions
+  ANTHROPIC_AUTH_TOKEN     auth token for the custom endpoint
+  AGENT_CLAUDE_CODE_BIN    path to the claude binary (default: PATH lookup)
+  AGENT_CLAUDE_CODE_EXTRA_ARGS  extra args appended to the worker invocation`,
+		RunE: runMcpServer,
+	}
+}
+
+func runMcpServer(cmd *cobra.Command, args []string) error {
+	// The butler MCP server only dispatches coding workers — it never touches
+	// the ASR/TTS pipeline — so it reads just the project allowlist + claude
+	// credentials and skips the full adapter's voice-path validation.
+	cfg := config.LoadButlerEnv()
+
+	// Logger MUST write to stderr — stdout is the JSON-RPC channel.
+	logger := obs.NewLoggerTo(os.Stderr)
+
+	projects := cwdPoolToProjects(cfg.CwdPool)
+	if len(projects) == 0 {
+		logger.Warnf("mcp-server: no projects configured (set BBCLAW_CWD_POOL or BBCLAW_DEFAULT_CWD); dispatch will reject all calls")
+	}
+
+	runner := butlermcp.NewClaudeWorkerRunner(butlermcp.ClaudeRunnerOptions{
+		Bin:       os.Getenv("AGENT_CLAUDE_CODE_BIN"),
+		BaseURL:   cfg.ClaudeBaseURL,
+		AuthToken: cfg.ClaudeAuthToken,
+		ExtraArgs: parseArgList(os.Getenv("AGENT_CLAUDE_CODE_EXTRA_ARGS")),
+		Logger:    logger,
+	})
+
+	srv := butlermcp.New(butlermcp.Options{
+		Projects: projects,
+		Runner:   runner,
+		Log:      logger,
+	})
+
+	logger.Infof("mcp-server: serving %d project(s) on stdio", len(projects))
+	return srv.Serve(os.Stdin, os.Stdout)
+}
+
+// cwdPoolToProjects maps the parsed CWD pool into butlermcp projects. The two
+// types carry the same data under different field names (CwdEntry{Name,Path} vs
+// Project{Name,Cwd}); this is the single adapter point.
+func cwdPoolToProjects(pool []config.CwdEntry) []butlermcp.Project {
+	if len(pool) == 0 {
+		return nil
+	}
+	out := make([]butlermcp.Project, 0, len(pool))
+	for _, e := range pool {
+		out = append(out, butlermcp.Project{Name: e.Name, Cwd: e.Path})
+	}
+	return out
+}
+
+// parseArgList splits a comma-separated arg string into a slice, mirroring the
+// behaviour the main binary uses for AGENT_*_EXTRA_ARGS. Empty input yields nil.
+func parseArgList(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/adapter/internal/cmd/mcpserver_test.go
+++ b/adapter/internal/cmd/mcpserver_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/config"
+)
+
+func TestCwdPoolToProjects(t *testing.T) {
+	if got := cwdPoolToProjects(nil); got != nil {
+		t.Fatalf("empty pool should yield nil, got %v", got)
+	}
+	pool := []config.CwdEntry{
+		{Name: "alpha", Path: "/p/alpha"},
+		{Name: "beta", Path: "/p/beta"},
+	}
+	got := cwdPoolToProjects(pool)
+	if len(got) != 2 {
+		t.Fatalf("len=%d want 2", len(got))
+	}
+	if got[0].Name != "alpha" || got[0].Cwd != "/p/alpha" {
+		t.Errorf("entry 0 = %+v", got[0])
+	}
+	if got[1].Name != "beta" || got[1].Cwd != "/p/beta" {
+		t.Errorf("entry 1 = %+v", got[1])
+	}
+}
+
+func TestParseArgList(t *testing.T) {
+	if got := parseArgList(""); got != nil {
+		t.Errorf("empty => %v", got)
+	}
+	if got := parseArgList("  "); got != nil {
+		t.Errorf("blank => %v", got)
+	}
+	got := parseArgList("--model, claude-sonnet-4-6 ,")
+	if len(got) != 2 || got[0] != "--model" || got[1] != "claude-sonnet-4-6" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestMcpServerCmdWiring(t *testing.T) {
+	root := NewRootCmd()
+	var found bool
+	for _, c := range root.Commands() {
+		if c.Name() == "mcp-server" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("mcp-server subcommand not registered on root")
+	}
+}

--- a/adapter/internal/cmd/root.go
+++ b/adapter/internal/cmd/root.go
@@ -19,6 +19,7 @@ func NewRootCmd() *cobra.Command {
 	// Add subcommands
 	cmd.AddCommand(NewDoctorCmd())
 	cmd.AddCommand(NewVersionCmd())
+	cmd.AddCommand(NewMcpServerCmd())
 
 	return cmd
 }

--- a/adapter/internal/config/config.go
+++ b/adapter/internal/config/config.go
@@ -202,6 +202,29 @@ func LoadFromEnv() (Config, error) {
 	return cfg, nil
 }
 
+// ButlerConfig is the minimal configuration the butler dispatch MCP server
+// (ADR-021, `bbclaw-adapter mcp-server`) needs: the project allowlist plus the
+// credentials for the worker claude-code sessions. It deliberately omits the
+// ASR/TTS/OpenClaw settings — and their validation — that the full adapter
+// service requires, because the MCP server only dispatches coding workers and
+// never touches the voice pipeline.
+type ButlerConfig struct {
+	CwdPool         []CwdEntry
+	ClaudeBaseURL   string
+	ClaudeAuthToken string
+}
+
+// LoadButlerEnv reads only the env vars the butler MCP server needs. Unlike
+// LoadFromEnv it performs no validation, so the server starts cleanly without
+// ASR/TTS configuration.
+func LoadButlerEnv() ButlerConfig {
+	return ButlerConfig{
+		CwdPool:         parseCwdPool(os.Getenv("BBCLAW_CWD_POOL"), strings.TrimSpace(os.Getenv("BBCLAW_DEFAULT_CWD"))),
+		ClaudeBaseURL:   strings.TrimSpace(os.Getenv("ANTHROPIC_BASE_URL")),
+		ClaudeAuthToken: strings.TrimSpace(os.Getenv("ANTHROPIC_AUTH_TOKEN")),
+	}
+}
+
 func (c Config) Validate() error {
 	switch c.normalizedMode() {
 	case "auto", "local", "cloud":

--- a/adapter/internal/obs/obs.go
+++ b/adapter/internal/obs/obs.go
@@ -2,6 +2,7 @@ package obs
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -16,6 +17,16 @@ type Logger struct {
 func NewLogger() *Logger {
 	return &Logger{
 		base:   log.New(os.Stdout, "", 0),
+		prefix: "bbclaw-adapter",
+	}
+}
+
+// NewLoggerTo builds a Logger that writes to w instead of stdout. The
+// `mcp-server` subcommand uses this with os.Stderr because its stdout is the
+// MCP JSON-RPC channel and must never carry log lines (ADR-021 §前置闸门).
+func NewLoggerTo(w io.Writer) *Logger {
+	return &Logger{
+		base:   log.New(w, "", 0),
 		prefix: "bbclaw-adapter",
 	}
 }

--- a/adapter/scripts/butler-mcp-config.example.json
+++ b/adapter/scripts/butler-mcp-config.example.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "bbclaw-butler": {
+      "command": "bbclaw-adapter",
+      "args": ["mcp-server"],
+      "env": {
+        "BBCLAW_CWD_POOL": "demo:/tmp/bbclaw-demo-project"
+      }
+    }
+  }
+}

--- a/adapter/scripts/butler-mcp-smoke.sh
+++ b/adapter/scripts/butler-mcp-smoke.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# butler-mcp-smoke.sh — e2e smoke for the butler dispatch MCP server (ADR-021).
+#
+# Two layers:
+#   1. Protocol smoke (NO real claude needed): pipe initialize + tools/list +
+#      list_projects into `bbclaw-adapter mcp-server` over stdio and assert the
+#      JSON-RPC replies. Runs anywhere; used to sanity-check the subcommand.
+#   2. Live butler smoke (requires a working `claude` CLI on PATH): start a real
+#      butler `claude -p --mcp-config <cfg>` that lists projects and dispatches a
+#      trivial task into the demo project. Skipped automatically when `claude`
+#      is absent so CI never depends on it.
+#
+# Usage:
+#   adapter/scripts/butler-mcp-smoke.sh            # protocol smoke only
+#   BBCLAW_BUTLER_LIVE=1 adapter/scripts/butler-mcp-smoke.sh   # + live butler
+set -euo pipefail
+
+ADAPTER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN="${BBCLAW_ADAPTER_BIN:-}"
+
+if [[ -z "$BIN" ]]; then
+  BIN="$(mktemp -d)/bbclaw-adapter"
+  echo "› building bbclaw-adapter → $BIN"
+  (cd "$ADAPTER_DIR" && go build -o "$BIN" ./cmd/bbclaw-adapter)
+fi
+
+DEMO_DIR="$(mktemp -d)/bbclaw-demo-project"
+mkdir -p "$DEMO_DIR"
+echo "# demo" > "$DEMO_DIR/README.md"
+
+echo "› layer 1: protocol smoke over stdio (no claude required)"
+OUT="$(printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_projects","arguments":{}}}' \
+  | BBCLAW_CWD_POOL="demo:$DEMO_DIR" "$BIN" mcp-server 2>/dev/null)"
+
+echo "$OUT" | grep -q '"name":"bbclaw-butler"' || { echo "FAIL: no initialize reply"; exit 1; }
+echo "$OUT" | grep -q '"name":"dispatch"'      || { echo "FAIL: tools/list missing dispatch"; exit 1; }
+echo "$OUT" | grep -q "$DEMO_DIR"               || { echo "FAIL: list_projects missing demo cwd"; exit 1; }
+echo "  ✓ initialize + tools/list + list_projects OK"
+
+if [[ "${BBCLAW_BUTLER_LIVE:-0}" != "1" ]]; then
+  echo "› layer 2 skipped (set BBCLAW_BUTLER_LIVE=1 to run the live butler smoke)"
+  echo "PASS (protocol smoke)"
+  exit 0
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "› layer 2 skipped: claude CLI not on PATH"
+  echo "PASS (protocol smoke; live skipped)"
+  exit 0
+fi
+
+echo "› layer 2: live butler via claude -p --mcp-config"
+CFG="$(mktemp).json"
+cat > "$CFG" <<JSON
+{
+  "mcpServers": {
+    "bbclaw-butler": {
+      "command": "$BIN",
+      "args": ["mcp-server"],
+      "env": { "BBCLAW_CWD_POOL": "demo:$DEMO_DIR" }
+    }
+  }
+}
+JSON
+
+claude -p "Use the bbclaw-butler MCP tools: call list_projects, then dispatch a task to the 'demo' project that just replies with the word READY. Report what the worker returned." \
+  --mcp-config "$CFG" \
+  --permission-mode acceptEdits
+echo "PASS (protocol + live butler)"


### PR DESCRIPTION
Fixes #79

收尾 ADR-021「管家 MCP 派发」的最后一公里：实现真正能跑活的 worker 执行器，并把已抽象的 MCP server 暴露为 CLI 子命令。

## 改动

### 1. `ClaudeWorkerRunner`（`adapter/internal/butlermcp/runner_claude.go`）
- 落地 `WorkerRunner` 接口，复用 `claudecode` driver：`Start(cwd)` → `Send(task)` → range `Events`，累积 `EvText`，遇 `EvError` 透传为错误，遇 `EvTurnEnd` 收尾。
- 强制 `--permission-mode acceptEdits`（prepend，operator 可在 ExtraArgs 覆盖）。
- 输出裁剪：超长（默认 8KB）按头尾保留、中间 `…[output truncated]…` 省略，避免把超长 transcript 回灌管家上下文。
- 通过最小 `claudeDriver` 接口注入，单测用 fake driver 覆盖文本收集 / 错误透传 / ctx 取消 / 通道提前关闭 / 输出裁剪。

### 2. `bbclaw-adapter mcp-server` 子命令（`adapter/internal/cmd/mcpserver.go`）
- 仿 `NewDoctorCmd` 加 `NewMcpServerCmd` 并在 `root.go` 注册。
- 从 env 读 `BBCLAW_CWD_POOL`（allowlist）+ `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`，把 `CwdEntry{Name,Path}` 映射为 `butlermcp.Project{Name,Cwd}`，构造 runner + `butlermcp.New`，`Serve(os.Stdin, os.Stdout)`。
- **stdout 仅 JSON-RPC，日志全部走 stderr**：新增 `obs.NewLoggerTo(io.Writer)`，runner 与 server 共用 stderr logger。
- 新增 `config.LoadButlerEnv`：只加载管家所需字段，跳过全量 adapter 的 ASR/TTS 校验（否则 mcp-server 无 ASR 配置就起不来）。

### 3. e2e 冒烟（`adapter/scripts/butler-mcp-smoke.sh` + `butler-mcp-config.example.json`）
- Layer 1 协议冒烟：管道喂 `initialize`/`tools/list`/`list_projects`，断言 JSON-RPC 回复，**无需真实 claude**。
- Layer 2 真链路：`BBCLAW_BUTLER_LIVE=1` 时跑 `claude -p --mcp-config` dispatch demo 任务；`claude` 不在 PATH 时自动跳过，CI 不依赖。

## 验收
- ✅ `go build / vet / test ./...` 全绿（19 包通过，无 FAIL，runner 单测带 `-race`）。
- ✅ 子命令可被 stdio JSON-RPC 起来：`initialize` + `tools/list`（4 工具）+ `list_projects` 验证通过，stdout 纯 JSON-RPC、logs 在 stderr。
- ✅ worker cwd 仅限 CwdPool（server 层既有测试 + 本 PR CwdPool→Project 映射测试）。

## 未测
- Layer 2 真实 `claude` 链路本环境未跑（需本机可用 claude CLI 凭据），已在脚本里设为 opt-in/auto-skip。

## Release 说明
本改动为 adapter binary 新增 `mcp-server` 子命令，按仓库 Release Policy 合并后应配套 `v*` tag + release（与固件协同发布）。已在 CHANGELOG `[Unreleased]` 记录，未自行打 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)