### PR TITLE
feat: 管家会话路由 + claudecode --mcp-config + WarmPool 预热管家 (ADR-021 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CHAT 最外层长按 OK 进不了菜单**：新 PCB rev 把 OK 移到编码器按压（IO1），`bb_nav_input` 把长按 OK 改发 `BB_NAV_EVENT_BACK` 替代旧的 `OK_LONG`，但 `bb_radio_app` CHAT 状态里"进 SETTINGS"那条路径还挂在 `OK_LONG` 上，导致长按落到空 BACK case 上没反应。把进 SETTINGS 行为合并到 BACK 处理里——busy 时维持取消 in-flight turn 的旧语义，空闲时进入 SETTINGS 浮层。
 
 ### Added
+- **管家会话路由 — 设备 turn 永远路由到 workspace 管家会话 + `--mcp-config` + WarmPool 预热 (ADR-021 v1, #80)**：设备每次语音/文本 turn 不再自选 driver/session，统一路由到该设备专属的「管家」逻辑会话（`Role=butler`、`cwd=~/.bbclaw-adapter/workspace/`、`driver=claude-code`），管家靠 cwd 自动加载 workspace 的 CLAUDE.md 人设/记忆。
+  - **管家会话解析**（`logicalsession.Manager.EnsureButler`）：按 `deviceID+driver` 幂等解析/创建管家会话；首次铸造 `RoleButler`，后续复用以保留会话连续性。每设备一个管家。
+  - **路由落点**：`httpapi/agent.go handleAgentMessage`（local）与 `homeadapter/adapter.go handleChatTextViaAgent`（cloud 语音）在配置了 butler workspace 时，忽略设备请求的 driver/session，改喂管家会话走 `butler.Engine.RunTurn`。语音路径从「手撸 `drv.Start`/事件循环」统一到 butler 引擎，经 `voiceEventSink` 适配回 `voice.reply.delta`/`tool_call` 帧，云端协议帧序列不变。未配置 workspace 时（如单测）保持旧多会话行为不破。
+  - **`--mcp-config`（仅管家）**：`agent.StartOpts` 新增 `MCPConfig` 字段（契约同 `Model`/`SystemPrompt`，不支持的 driver 忽略）；claudecode `sessionFlags` 在非空时拼 `--mcp-config <path>`。`butler.Engine` 仅当解析到的会话 `Role==butler` 时注入 `Deps.ButlerMCPConfig`，worker/普通会话不带。`butlermcp.WriteConfig` 生成指向 `mcp-server` 子命令（#79）的 stdio MCP 配置文件，启动时写到 `~/.bbclaw-adapter/butler-mcp.json`。
+  - **WarmPool 预热管家**：`claudecode.WarmPool` 从单 `warmCwd` 扩成多 `warmCwds`（项目 cwd + 管家 workspace），每 cwd 独立维持 `size` 个预热条目，`Acquire(cwd)` 严格按 cwd 命中——管家每轮命中预热，避免 4-7s 冷启动。
 - **管家 MCP 派发 server — worker runner + `mcp-server` 子命令 (ADR-021 v1)**：补齐「管家 MCP 派发」最后一公里。
   - **`ClaudeWorkerRunner`**（`adapter/internal/butlermcp/runner_claude.go`）：落地 `WorkerRunner` 接口，复用 claudecode driver 在目标 cwd 起 worker（`--permission-mode acceptEdits`），消费 stream-json 累积 assistant 文本到 `EvTurnEnd`，`EvError` 透传为错误，输出超长时按头尾保留、中间省略裁剪（默认 8KB，避免把超长 transcript 回灌管家）。
   - **`bbclaw-adapter mcp-server` 子命令**（`adapter/internal/cmd/mcpserver.go`）：从 env 读 `BBCLAW_CWD_POOL`（allowlist）与 `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`，装配 `ClaudeWorkerRunner` + `butlermcp.New`，在 stdio 上 `Serve`；**stdout 仅 JSON-RPC，日志全部走 stderr**（`obs.NewLoggerTo`）。新增 `config.LoadButlerEnv` 仅加载管家所需字段，跳过 ASR/TTS 校验。

--- a/adapter/cmd/bbclaw-adapter/main.go
+++ b/adapter/cmd/bbclaw-adapter/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/daboluocc/bbclaw/adapter/internal/asr"
 	"github.com/daboluocc/bbclaw/adapter/internal/audio"
 	"github.com/daboluocc/bbclaw/adapter/internal/buildinfo"
+	"github.com/daboluocc/bbclaw/adapter/internal/butlermcp"
 	"github.com/daboluocc/bbclaw/adapter/internal/cmd"
 	"github.com/daboluocc/bbclaw/adapter/internal/config"
 	"github.com/daboluocc/bbclaw/adapter/internal/homeadapter"
@@ -96,7 +97,7 @@ func buildCloudRelay(cfg config.Config, sink pipeline.Sink, logger *obs.Logger, 
 	return homeadapter.New(homeCfg, sink, logger, metrics), nil
 }
 
-func buildLocalServer(cfg config.Config, sink pipeline.Sink, cloudRelay *homeadapter.Adapter, agentRouter *agent.Router, sessionMgr *logicalsession.Manager, driverStateStore *driverstate.Store, logger *obs.Logger, metrics *obs.Metrics) (*http.Server, *httpapi.Server, error) {
+func buildLocalServer(cfg config.Config, sink pipeline.Sink, cloudRelay *homeadapter.Adapter, agentRouter *agent.Router, sessionMgr *logicalsession.Manager, driverStateStore *driverstate.Store, butlerWorkspace, butlerMCPConfig string, logger *obs.Logger, metrics *obs.Metrics) (*http.Server, *httpapi.Server, error) {
 	streams := audio.NewManager(cfg.MaxAudioBytes, cfg.MaxStreamSeconds, cfg.MaxConcurrentStreams)
 	var asrProvider asr.Provider
 	switch strings.ToLower(strings.TrimSpace(cfg.ASRProvider)) {
@@ -169,6 +170,8 @@ func buildLocalServer(cfg config.Config, sink pipeline.Sink, cloudRelay *homeada
 	server.SetAgentRouter(agentRouter)
 	if sessionMgr != nil {
 		server.SetSessionManager(sessionMgr)
+		// Route local agent turns to the per-device butler session (ADR-021).
+		server.SetButlerWorkspace(butlerWorkspace, butlerMCPConfig)
 	}
 	if driverStateStore != nil {
 		server.SetDriverState(driverStateStore)
@@ -226,11 +229,20 @@ var k_driver_registry = []driverReg{
 			if warmCwd == "" && len(cfg.CwdPool) > 0 {
 				warmCwd = cfg.CwdPool[0].Path
 			}
+			// Butler workspace (ADR-021 §3): warm it alongside the project cwd
+			// so the per-device butler session, which always runs cwd=workspace,
+			// hits a pre-warmed claude session every round. Best-effort — a
+			// resolution failure just disables butler pre-warming.
+			butlerCwd := ""
+			if dir, derr := workspace.Dir(); derr == nil {
+				butlerCwd = dir
+			}
 			opts := claudecode.Options{
-				PoolSize:    cfg.ClaudePoolSize,
-				PoolIdleTTL: cfg.ClaudePoolIdleTTL,
-				ExtraArgs:   parseArgList(os.Getenv("AGENT_CLAUDE_CODE_EXTRA_ARGS")),
-				WarmCwd:     warmCwd,
+				PoolSize:           cfg.ClaudePoolSize,
+				PoolIdleTTL:        cfg.ClaudePoolIdleTTL,
+				ExtraArgs:          parseArgList(os.Getenv("AGENT_CLAUDE_CODE_EXTRA_ARGS")),
+				WarmCwd:            warmCwd,
+				ButlerWorkspaceCwd: butlerCwd,
 			}
 			if cfg.ClaudeBaseURL != "" || cfg.ClaudeAuthToken != "" {
 				opts.Env = make(map[string]string)
@@ -506,6 +518,37 @@ func parseArgList(raw string) []string {
 	return out
 }
 
+// butlerMCPEnv collects the environment the butler's --mcp-config server entry
+// embeds so the spawned `mcp-server` subprocess sees a deterministic project
+// allowlist + credentials regardless of how the parent claude process scrubs
+// its environment (ADR-021 §2). Returns nil when nothing needs embedding (the
+// subprocess then relies purely on inherited env).
+func butlerMCPEnv(cfg config.Config) map[string]string {
+	env := map[string]string{}
+	if v := strings.TrimSpace(os.Getenv("BBCLAW_CWD_POOL")); v != "" {
+		env["BBCLAW_CWD_POOL"] = v
+	}
+	if cfg.DefaultCwd != "" {
+		env["BBCLAW_DEFAULT_CWD"] = cfg.DefaultCwd
+	}
+	if cfg.ClaudeBaseURL != "" {
+		env["ANTHROPIC_BASE_URL"] = cfg.ClaudeBaseURL
+	}
+	if cfg.ClaudeAuthToken != "" {
+		env["ANTHROPIC_AUTH_TOKEN"] = cfg.ClaudeAuthToken
+	}
+	if v := strings.TrimSpace(os.Getenv("AGENT_CLAUDE_CODE_EXTRA_ARGS")); v != "" {
+		env["AGENT_CLAUDE_CODE_EXTRA_ARGS"] = v
+	}
+	if v := strings.TrimSpace(os.Getenv("AGENT_CLAUDE_CODE_BIN")); v != "" {
+		env["AGENT_CLAUDE_CODE_BIN"] = v
+	}
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}
+
 // probeTCP dials addr with the given timeout and returns whether the dial
 // succeeded. Immediately closes the connection on success.
 func probeTCP(addr string, timeout time.Duration) bool {
@@ -528,10 +571,33 @@ func run(cfg config.Config, logger *obs.Logger, metrics *obs.Metrics) {
 	// butler session runs with cwd=workspace so Claude loads this persona +
 	// long-term memory natively. Non-fatal: degrade like driverstate if the
 	// scaffold can't be written.
+	butlerWorkspace := ""
 	if dir, err := workspace.EnsureScaffold(); err != nil {
 		logger.Warnf("workspace: scaffold failed, butler CLAUDE.md unavailable: %v", err)
 	} else {
+		butlerWorkspace = dir
 		logger.Infof("workspace: ready dir=%s", dir)
+	}
+
+	// Write the butler's --mcp-config so its session can dispatch coding work to
+	// worker agents through the `mcp-server` subcommand (ADR-021 §2). Only the
+	// per-device butler session is spawned with this config; worker sessions
+	// don't get it. Non-fatal: degrade to a butler without dispatch.
+	butlerMCPConfig := ""
+	if butlerWorkspace != "" {
+		if self, err := os.Executable(); err != nil {
+			logger.Warnf("butler-mcp: resolve executable failed, dispatch disabled: %v", err)
+		} else if dataDir, derr := workspace.DataDir(); derr != nil {
+			logger.Warnf("butler-mcp: resolve data dir failed, dispatch disabled: %v", derr)
+		} else {
+			cfgPath := filepath.Join(dataDir, "butler-mcp.json")
+			if p, werr := butlermcp.WriteConfig(cfgPath, self, butlerMCPEnv(cfg)); werr != nil {
+				logger.Warnf("butler-mcp: write config failed, dispatch disabled: %v", werr)
+			} else {
+				butlerMCPConfig = p
+				logger.Infof("butler-mcp: config ready path=%s", p)
+			}
+		}
 	}
 
 	if len(cfg.CwdPool) > 0 {
@@ -561,6 +627,8 @@ func run(cfg config.Config, logger *obs.Logger, metrics *obs.Metrics) {
 		cloudRelay.SetRouter(agentRouter)
 		if sessionMgr != nil {
 			cloudRelay.SetSessionManager(sessionMgr)
+			// Route cloud voice turns to the per-device butler session (ADR-021).
+			cloudRelay.SetButlerWorkspace(butlerWorkspace, butlerMCPConfig)
 		}
 		if driverStateStore != nil {
 			cloudRelay.SetDriverState(driverStateStore)
@@ -597,7 +665,7 @@ func run(cfg config.Config, logger *obs.Logger, metrics *obs.Metrics) {
 
 	if cfg.EnableLocalIngress() {
 		active++
-		httpSrv, agentSrv, err := buildLocalServer(cfg, sink, cloudRelay, agentRouter, sessionMgr, driverStateStore, logger, metrics)
+		httpSrv, agentSrv, err := buildLocalServer(cfg, sink, cloudRelay, agentRouter, sessionMgr, driverStateStore, butlerWorkspace, butlerMCPConfig, logger, metrics)
 		if err != nil {
 			logger.Errorf("%v", err)
 			os.Exit(1)

--- a/adapter/internal/agent/claudecode/driver.go
+++ b/adapter/internal/agent/claudecode/driver.go
@@ -75,6 +75,12 @@ type Options struct {
 	// cwd", which is the legacy behaviour and only safe when CWD_POOL is
 	// unset.
 	WarmCwd string
+	// ButlerWorkspaceCwd is the per-device butler workspace directory (ADR-021
+	// §3). When non-empty it is warmed alongside WarmCwd so the butler session,
+	// which always runs with cwd=workspace, hits a pre-warmed session every
+	// round instead of paying the cold-start penalty. Empty disables butler
+	// pre-warming (the butler still works, just cold the first turn).
+	ButlerWorkspaceCwd string
 }
 
 // New constructs a Driver. The logger is required; pass obs.NewLogger() if
@@ -108,9 +114,17 @@ func New(opts Options, log *obs.Logger) *Driver {
 	for k, v := range opts.Env {
 		driverEnv[k] = v
 	}
-	pool := NewWarmPool(bin, extra, driverEnv, opts.WarmCwd, opts.PoolSize, idleTTL, log)
+	// Warm the configured project cwd plus the butler workspace (ADR-021 §3) so
+	// both a regular session and the per-device butler session hit a pre-warmed
+	// claude session. dedupeCwds (inside NewWarmPool) collapses overlaps and
+	// falls back to a single inherited-cwd slot when both are empty.
+	warmCwds := []string{opts.WarmCwd}
+	if opts.ButlerWorkspaceCwd != "" {
+		warmCwds = append(warmCwds, opts.ButlerWorkspaceCwd)
+	}
+	pool := NewWarmPool(bin, extra, driverEnv, warmCwds, opts.PoolSize, idleTTL, log)
 	if opts.PoolSize > 0 {
-		log.Infof("claude-code: warm pool enabled size=%d idle_ttl=%s warm_cwd=%q", opts.PoolSize, idleTTL, opts.WarmCwd)
+		log.Infof("claude-code: warm pool enabled size=%d idle_ttl=%s warm_cwd=%q butler_cwd=%q", opts.PoolSize, idleTTL, opts.WarmCwd, opts.ButlerWorkspaceCwd)
 	}
 	if baseURL, ok := driverEnv["ANTHROPIC_BASE_URL"]; ok {
 		log.Infof("claude-code: ANTHROPIC_BASE_URL=%s", baseURL)
@@ -165,6 +179,7 @@ func (d *Driver) Start(ctx context.Context, opts agent.StartOpts) (agent.Session
 		env:          opts.Env,
 		model:        strings.TrimSpace(opts.Model),
 		systemPrompt: strings.TrimSpace(opts.SystemPrompt),
+		mcpConfig:    strings.TrimSpace(opts.MCPConfig),
 		rootCtx:      ctx,
 	}
 	d.mu.Lock()
@@ -363,6 +378,7 @@ type session struct {
 	env          map[string]string
 	model        string // empty = use driver/operator default
 	systemPrompt string // empty = no --append-system-prompt
+	mcpConfig    string // empty = no --mcp-config (butler session only)
 	rootCtx      context.Context
 
 	seq uint64
@@ -387,6 +403,11 @@ func (s *session) sessionFlags(driverExtra []string) []string {
 	}
 	if s.systemPrompt != "" {
 		out = append(out, "--append-system-prompt", s.systemPrompt)
+	}
+	// --mcp-config wires the butler dispatch MCP server (ADR-021 §2). Only the
+	// per-device butler session carries it; worker sessions leave it empty.
+	if s.mcpConfig != "" {
+		out = append(out, "--mcp-config", s.mcpConfig)
 	}
 	return append(out, driverExtra...)
 }

--- a/adapter/internal/agent/claudecode/driver_test.go
+++ b/adapter/internal/agent/claudecode/driver_test.go
@@ -239,21 +239,24 @@ func TestSessionFlags(t *testing.T) {
 		name         string
 		model        string
 		systemPrompt string
+		mcpConfig    string
 		extra        []string
 		want         []string
 	}{
-		{"empty", "", "", nil, nil},
-		{"model only", "claude-opus-4-8", "", nil,
+		{"empty", "", "", "", nil, nil},
+		{"model only", "claude-opus-4-8", "", "", nil,
 			[]string{"--model", "claude-opus-4-8"}},
-		{"system prompt only", "", "be brief", nil,
+		{"system prompt only", "", "be brief", "", nil,
 			[]string{"--append-system-prompt", "be brief"}},
-		{"model+prompt+extra", "m", "p", []string{"--foo", "bar"},
-			[]string{"--model", "m", "--append-system-prompt", "p", "--foo", "bar"}},
-		{"extra only", "", "", []string{"--model", "x"}, []string{"--model", "x"}},
+		{"mcp-config only (butler)", "", "", "/cfg/butler-mcp.json", nil,
+			[]string{"--mcp-config", "/cfg/butler-mcp.json"}},
+		{"model+prompt+mcp+extra", "m", "p", "/cfg.json", []string{"--foo", "bar"},
+			[]string{"--model", "m", "--append-system-prompt", "p", "--mcp-config", "/cfg.json", "--foo", "bar"}},
+		{"extra only", "", "", "", []string{"--model", "x"}, []string{"--model", "x"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			s := session{model: tc.model, systemPrompt: tc.systemPrompt}
+			s := session{model: tc.model, systemPrompt: tc.systemPrompt, mcpConfig: tc.mcpConfig}
 			got := s.sessionFlags(tc.extra)
 			if join(got) != join(tc.want) {
 				t.Errorf("sessionFlags = %v, want %v", got, tc.want)

--- a/adapter/internal/agent/claudecode/pool.go
+++ b/adapter/internal/agent/claudecode/pool.go
@@ -29,23 +29,28 @@ type warmEntry struct {
 // Send() calls Acquire() to pull a matching entry and resumes it with
 // `--resume <id>`, cutting first-response latency from 4-7s to ~0.5s.
 //
-// Entries are bound to a specific working directory (warmCwd) so the
-// pre-warmed claude-code subprocess records its session JSONL under the
-// same project directory that the real Send() spawn will inherit. Acquire
-// strict-matches the entry cwd against the request cwd; mismatched
-// requests fall through to cold spawn.
+// Entries are bound to a specific working directory so the pre-warmed
+// claude-code subprocess records its session JSONL under the same project
+// directory that the real Send() spawn will inherit. Acquire strict-matches
+// the entry cwd against the request cwd; mismatched requests fall through to
+// cold spawn.
+//
+// The pool warms several cwds independently (warmCwds): the configured
+// default project plus the per-device butler workspace (ADR-021 §3), each
+// kept topped up to `size` idle entries so a butler turn hits a warm session
+// every round instead of paying the 4-7s cold-start.
 //
 // The pool is safe for concurrent use. Pool size and TTL are controlled by
-// BBCLAW_CLAUDE_POOL_SIZE and BBCLAW_CLAUDE_POOL_IDLE_TTL. The cwd is
+// BBCLAW_CLAUDE_POOL_SIZE and BBCLAW_CLAUDE_POOL_IDLE_TTL. The cwds are
 // passed in at construction (see NewWarmPool).
 type WarmPool struct {
-	bin     string
-	extra   []string
-	env     map[string]string // driver-level env overrides injected into warm spawns
-	warmCwd string            // working directory for spawnWarm; also the cwd stamped on each entry
-	size    int
-	idleTTL time.Duration
-	log     *obs.Logger
+	bin      string
+	extra    []string
+	env      map[string]string // driver-level env overrides injected into warm spawns
+	warmCwds []string          // working directories warmed independently; each entry is stamped with its cwd
+	size     int               // target idle entries PER cwd
+	idleTTL  time.Duration
+	log      *obs.Logger
 
 	mu      sync.Mutex
 	entries []warmEntry
@@ -62,17 +67,19 @@ type WarmPool struct {
 // NewWarmPool creates a WarmPool and starts its background replenish goroutine.
 // size=0 disables the pool entirely (Acquire always returns "", false).
 //
-// warmCwd is the working directory that spawnWarm uses and that each entry's
-// cwd is stamped with. Acquire strict-matches against this. Pass the canonical
-// project path (e.g. BBCLAW_DEFAULT_CWD or CwdPool[0].Path) — passing an
-// empty string makes the warm process inherit the adapter's own cwd, which
-// is rarely what callers want when CWD_POOL is configured.
-func NewWarmPool(bin string, extra []string, env map[string]string, warmCwd string, size int, idleTTL time.Duration, log *obs.Logger) *WarmPool {
+// warmCwds are the working directories spawnWarm uses; each entry is stamped
+// with the cwd it was warmed in and Acquire strict-matches against it. Pass the
+// canonical project path(s) (e.g. BBCLAW_DEFAULT_CWD / CwdPool[0].Path plus the
+// butler workspace) — an empty entry makes that warm process inherit the
+// adapter's own cwd, which is rarely what callers want when CWD_POOL is
+// configured. Duplicate and blank-only entries are de-duplicated; if none
+// remain the pool warms a single inherited-cwd ("") slot for legacy parity.
+func NewWarmPool(bin string, extra []string, env map[string]string, warmCwds []string, size int, idleTTL time.Duration, log *obs.Logger) *WarmPool {
 	p := &WarmPool{
 		bin:         bin,
 		extra:       extra,
 		env:         env,
-		warmCwd:     warmCwd,
+		warmCwds:    dedupeCwds(warmCwds),
 		size:        size,
 		idleTTL:     idleTTL,
 		log:         log,
@@ -186,39 +193,53 @@ func (p *WarmPool) evictExpired() {
 	p.entries = kept
 }
 
-// fill spawns no-op claude processes until the pool reaches its target size.
-// Each spawn is sequential to avoid hammering the API on startup.
+// fill spawns no-op claude processes until every warm cwd has `size` idle
+// entries. Each spawn is sequential to avoid hammering the API on startup.
 func (p *WarmPool) fill() {
-	for {
-		p.mu.Lock()
-		need := p.size - len(p.entries)
-		p.mu.Unlock()
-		if need <= 0 {
-			return
-		}
+	for _, cwd := range p.warmCwds {
+		for {
+			p.mu.Lock()
+			have := p.countForCwd(cwd)
+			p.mu.Unlock()
+			if have >= p.size {
+				break
+			}
 
-		// Check if we've been asked to stop.
-		select {
-		case <-p.done:
-			return
-		default:
-		}
+			// Check if we've been asked to stop.
+			select {
+			case <-p.done:
+				return
+			default:
+			}
 
-		entry, err := p.spawnWarm()
-		if err != nil {
-			p.log.Warnf("claude-code: pool warm failed: %v (will retry on next signal)", err)
-			return // back off; next signal or ticker will retry
-		}
+			entry, err := p.spawnWarm(cwd)
+			if err != nil {
+				p.log.Warnf("claude-code: pool warm failed cwd=%q: %v (will retry on next signal)", cwd, err)
+				break // back off this cwd; next signal or ticker will retry
+			}
 
-		p.mu.Lock()
-		// Re-check size under lock in case Drain() was called concurrently.
-		if len(p.entries) < p.size {
-			p.entries = append(p.entries, entry)
-			p.log.Infof("claude-code: pool warmed cliSession=%s cwd=%q pool=%d/%d",
-				entry.cliSessionID, entry.cwd, len(p.entries), p.size)
+			p.mu.Lock()
+			// Re-check size under lock in case Drain() was called concurrently.
+			if p.countForCwd(cwd) < p.size {
+				p.entries = append(p.entries, entry)
+				p.log.Infof("claude-code: pool warmed cliSession=%s cwd=%q pool=%d/%d",
+					entry.cliSessionID, entry.cwd, p.countForCwd(cwd), p.size)
+			}
+			p.mu.Unlock()
 		}
-		p.mu.Unlock()
 	}
+}
+
+// countForCwd returns the number of idle entries stamped with cwd. Caller must
+// hold p.mu.
+func (p *WarmPool) countForCwd(cwd string) int {
+	n := 0
+	for _, e := range p.entries {
+		if e.cwd == cwd {
+			n++
+		}
+	}
+	return n
 }
 
 // noopPrompt is the prompt used to pre-warm a session. It must be:
@@ -228,9 +249,9 @@ func (p *WarmPool) fill() {
 const noopPrompt = "respond with the single word: ready"
 
 // spawnWarm runs `claude -p <noopPrompt> --output-format stream-json --verbose`
-// and extracts the cli_session_id from the init event. The process runs to
-// completion; only the session ID is retained.
-func (p *WarmPool) spawnWarm() (warmEntry, error) {
+// in cwd and extracts the cli_session_id from the init event. The process runs
+// to completion; only the session ID is retained.
+func (p *WarmPool) spawnWarm(cwd string) (warmEntry, error) {
 	args := []string{"-p", noopPrompt, "--output-format", "stream-json", "--verbose"}
 	args = append(args, p.extra...)
 
@@ -249,11 +270,11 @@ func (p *WarmPool) spawnWarm() (warmEntry, error) {
 	} else {
 		cmd.Env = os.Environ()
 	}
-	// Pin the warm spawn to the configured cwd so its session JSONL lands in
-	// the same project directory that real Send() spawns will inherit. Empty
-	// warmCwd falls back to Go's "inherit parent cwd" behaviour, which is
-	// fine for deployments that haven't configured CWD_POOL.
-	cmd.Dir = p.warmCwd
+	// Pin the warm spawn to the requested cwd so its session JSONL lands in
+	// the same project directory that real Send() spawns will inherit. An empty
+	// cwd falls back to Go's "inherit parent cwd" behaviour, which is fine for
+	// deployments that haven't configured CWD_POOL.
+	cmd.Dir = cwd
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -305,9 +326,28 @@ func (p *WarmPool) spawnWarm() (warmEntry, error) {
 
 	return warmEntry{
 		cliSessionID: cliSessionID,
-		cwd:          p.warmCwd,
+		cwd:          cwd,
 		createdAt:    time.Now(),
 	}, nil
+}
+
+// dedupeCwds removes duplicate working directories while preserving order. When
+// the input is empty it returns a single inherited-cwd ("") slot so the pool
+// keeps the legacy "warm one entry in the adapter's own cwd" behaviour.
+func dedupeCwds(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, c := range in {
+		if _, ok := seen[c]; ok {
+			continue
+		}
+		seen[c] = struct{}{}
+		out = append(out, c)
+	}
+	if len(out) == 0 {
+		return []string{""}
+	}
+	return out
 }
 
 // Size returns the configured pool capacity.
@@ -325,10 +365,4 @@ func (p *WarmPool) injectEntry(e warmEntry) {
 	p.mu.Lock()
 	p.entries = append(p.entries, e)
 	p.mu.Unlock()
-}
-
-// poolFromEnv is a helper used by the driver to read pool config from env vars
-// and construct a WarmPool. Extracted here so driver.go stays clean.
-func poolFromEnv(bin string, extra []string, env map[string]string, warmCwd string, size int, idleTTL time.Duration, log *obs.Logger) *WarmPool {
-	return NewWarmPool(bin, extra, env, warmCwd, size, idleTTL, log)
 }

--- a/adapter/internal/agent/claudecode/pool_test.go
+++ b/adapter/internal/agent/claudecode/pool_test.go
@@ -248,3 +248,71 @@ func TestLenAndSize(t *testing.T) {
 		t.Errorf("Len after inject: want 1, got %d", p.Len())
 	}
 }
+
+// TestDedupeCwds verifies cwd de-duplication and the empty→[""] legacy fallback.
+func TestDedupeCwds(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty falls back to inherited", nil, []string{""}},
+		{"dedup preserves order", []string{"/a", "/b", "/a"}, []string{"/a", "/b"}},
+		{"project plus butler", []string{"/proj", "/ws"}, []string{"/proj", "/ws"}},
+		{"butler equals project collapses", []string{"/ws", "/ws"}, []string{"/ws"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dedupeCwds(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("dedupeCwds(%v)=%v want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("dedupeCwds(%v)=%v want %v", tc.in, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestAcquireMultiCwd verifies that entries warmed under different cwds (the
+// project cwd and the butler workspace) are acquired independently and that a
+// hit in one cwd doesn't consume the other's entry.
+func TestAcquireMultiCwd(t *testing.T) {
+	p := newTestPool(1, 10*time.Minute)
+	p.injectEntry(warmEntry{cliSessionID: "proj-sid", cwd: "/proj", createdAt: time.Now()})
+	p.injectEntry(warmEntry{cliSessionID: "butler-sid", cwd: "/ws", createdAt: time.Now()})
+
+	id, ok := p.Acquire("/ws")
+	if !ok || id != "butler-sid" {
+		t.Fatalf("butler acquire: got id=%q ok=%v want butler-sid", id, ok)
+	}
+	// The project entry must still be present after the butler hit.
+	id, ok = p.Acquire("/proj")
+	if !ok || id != "proj-sid" {
+		t.Fatalf("project acquire: got id=%q ok=%v want proj-sid", id, ok)
+	}
+	if p.Len() != 0 {
+		t.Fatalf("pool len=%d want 0 after both acquired", p.Len())
+	}
+}
+
+// TestCountForCwd verifies per-cwd accounting used by fill() to keep each warm
+// cwd topped up to `size` independently.
+func TestCountForCwd(t *testing.T) {
+	p := newTestPool(2, 10*time.Minute)
+	p.injectEntry(warmEntry{cliSessionID: "a", cwd: "/proj", createdAt: time.Now()})
+	p.injectEntry(warmEntry{cliSessionID: "b", cwd: "/proj", createdAt: time.Now()})
+	p.injectEntry(warmEntry{cliSessionID: "c", cwd: "/ws", createdAt: time.Now()})
+
+	if n := p.countForCwd("/proj"); n != 2 {
+		t.Errorf("countForCwd(/proj)=%d want 2", n)
+	}
+	if n := p.countForCwd("/ws"); n != 1 {
+		t.Errorf("countForCwd(/ws)=%d want 1", n)
+	}
+	if n := p.countForCwd("/none"); n != 0 {
+		t.Errorf("countForCwd(/none)=%d want 0", n)
+	}
+}

--- a/adapter/internal/agent/driver.go
+++ b/adapter/internal/agent/driver.go
@@ -87,6 +87,14 @@ type StartOpts struct {
 	// claudecode passes it as --append-system-prompt. Drivers that can't inject
 	// a system prompt just ignore it (same contract as Model).
 	SystemPrompt string
+
+	// MCPConfig, when non-empty, is the path to a Model Context Protocol config
+	// file the backend should load for this session. It is set only for the
+	// per-device "butler" session (ADR-021 §2) so the conversational butler can
+	// dispatch coding work to worker agents through the `mcp-server` subcommand;
+	// worker sessions never get it. claudecode passes it as --mcp-config. Drivers
+	// that can't load MCP servers just ignore it (same contract as Model).
+	MCPConfig string
 }
 
 // Driver is the contract every per-CLI implementation must satisfy.

--- a/adapter/internal/agent/logicalsession/ensure_butler_test.go
+++ b/adapter/internal/agent/logicalsession/ensure_butler_test.go
@@ -1,0 +1,90 @@
+package logicalsession
+
+import "testing"
+
+// EnsureButler mints a Role=butler session on first call and returns the same
+// session (idempotent) on subsequent calls for the same device+driver.
+func TestEnsureButlerIdempotent(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	first, err := m.EnsureButler("dev-1", "claude-code", "/ws")
+	if err != nil {
+		t.Fatalf("EnsureButler first: %v", err)
+	}
+	if first.Role != RoleButler {
+		t.Fatalf("role=%q want %q", first.Role, RoleButler)
+	}
+	if first.Cwd != "/ws" {
+		t.Fatalf("cwd=%q want /ws", first.Cwd)
+	}
+	if first.DeviceID != "dev-1" || first.Driver != "claude-code" {
+		t.Fatalf("device/driver mismatch: %+v", first)
+	}
+
+	// A later call with a different cwd must reuse the existing butler (cwd is
+	// only honoured at creation time), not mint a second one.
+	second, err := m.EnsureButler("dev-1", "claude-code", "/other")
+	if err != nil {
+		t.Fatalf("EnsureButler second: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("second id=%s want same as first=%s", second.ID, first.ID)
+	}
+	if second.Cwd != "/ws" {
+		t.Fatalf("second cwd=%q want /ws (creation cwd preserved)", second.Cwd)
+	}
+
+	// Only one butler should exist for the device.
+	butlers := 0
+	for _, s := range m.List("dev-1", "claude-code", 0) {
+		if s.Role == RoleButler {
+			butlers++
+		}
+	}
+	if butlers != 1 {
+		t.Fatalf("butler count=%d want 1", butlers)
+	}
+}
+
+// Each device gets its own butler session.
+func TestEnsureButlerPerDevice(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	a, err := m.EnsureButler("dev-a", "claude-code", "/ws")
+	if err != nil {
+		t.Fatalf("EnsureButler a: %v", err)
+	}
+	b, err := m.EnsureButler("dev-b", "claude-code", "/ws")
+	if err != nil {
+		t.Fatalf("EnsureButler b: %v", err)
+	}
+	if a.ID == b.ID {
+		t.Fatalf("devices share a butler session id=%s", a.ID)
+	}
+}
+
+// The butler is excluded from worker-only listings but visible to device-facing
+// listings (it is a device-facing session, just a special one).
+func TestEnsureButlerIsDeviceFacing(t *testing.T) {
+	m, _ := newTestManager(t)
+	bsess, err := m.EnsureButler("dev-1", "claude-code", "/ws")
+	if err != nil {
+		t.Fatalf("EnsureButler: %v", err)
+	}
+	found := false
+	for _, s := range m.ListDeviceFacing("dev-1", "claude-code", 0) {
+		if s.ID == bsess.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("butler %s missing from device-facing listing", bsess.ID)
+	}
+}
+
+func TestEnsureButlerRejectsEmptyDriver(t *testing.T) {
+	m, _ := newTestManager(t)
+	if _, err := m.EnsureButler("dev-1", "", "/ws"); err == nil {
+		t.Fatalf("EnsureButler with empty driver: want error, got nil")
+	}
+}

--- a/adapter/internal/agent/logicalsession/manager.go
+++ b/adapter/internal/agent/logicalsession/manager.go
@@ -44,8 +44,8 @@ const dirMode = 0o700
 // fileShape is the on-disk JSON layout. The map key duplicates the inner
 // LogicalSession.ID for O(1) lookup on load.
 type fileShape struct {
-	Version  int                        `json:"version"`
-	Sessions map[ID]*LogicalSession     `json:"sessions"`
+	Version  int                    `json:"version"`
+	Sessions map[ID]*LogicalSession `json:"sessions"`
 }
 
 // Manager owns the in-memory logical session table and its persistence.
@@ -205,6 +205,35 @@ func (m *Manager) CreateWithRole(deviceID, driver, cwd, title, role string) (*Lo
 	// Return a copy so callers can't mutate the stored session by accident.
 	out := *s
 	return &out, nil
+}
+
+// EnsureButler returns the per-device butler logical session, creating it on
+// first use (ADR-021 §1). The butler is the single session every device
+// voice/text turn routes to: Role=RoleButler, a fixed cwd (the butler
+// workspace), and a stable driver. It is idempotent — repeated calls for the
+// same deviceID+driver return the existing butler session instead of minting a
+// new one, so the conversation (and its CLI session continuity) is preserved
+// across turns. cwd is only used when the session is created the first time;
+// later calls return the stored session verbatim.
+func (m *Manager) EnsureButler(deviceID, driver, cwd string) (*LogicalSession, error) {
+	if driver == "" {
+		return nil, errors.New("logicalsession: driver must not be empty")
+	}
+	m.mu.RLock()
+	for _, s := range m.sessions {
+		if s.Role == RoleButler && s.DeviceID == deviceID && s.Driver == driver {
+			out := *s
+			m.mu.RUnlock()
+			return &out, nil
+		}
+	}
+	m.mu.RUnlock()
+	// Not found — mint one. The (astronomically rare) race where two concurrent
+	// callers both miss the scan and create a butler is benign: both sessions
+	// are valid butlers for the device and the next EnsureButler returns
+	// whichever the scan finds first. Device turns are serialized per-device in
+	// practice, so this effectively never happens.
+	return m.CreateWithRole(deviceID, driver, cwd, "butler", RoleButler)
 }
 
 // Get returns the session by id, or (nil, false) if not found.

--- a/adapter/internal/butler/butler_routing_test.go
+++ b/adapter/internal/butler/butler_routing_test.go
@@ -1,0 +1,115 @@
+package butler
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/agent/logicalsession"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
+)
+
+func newTestManager(t *testing.T, defaultCwd string) *logicalsession.Manager {
+	t.Helper()
+	mgr, err := logicalsession.NewManager(filepath.Join(t.TempDir(), "sessions.json"), defaultCwd, obs.NewLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	return mgr
+}
+
+func okScript() [][]agent.Event {
+	return [][]agent.Event{{{Type: agent.EvText, Text: "hi"}, {Type: agent.EvTurnEnd}}}
+}
+
+// A butler logical session (Role=butler) must get StartOpts.MCPConfig wired and
+// run in its workspace cwd (ADR-021 §1/§2).
+func TestRunTurn_InjectsMCPConfigForButlerRole(t *testing.T) {
+	mgr := newTestManager(t, "/default/cwd")
+	bsess, err := mgr.EnsureButler("dev-1", ButlerDriver, "/ws")
+	if err != nil {
+		t.Fatalf("EnsureButler: %v", err)
+	}
+
+	drv := newScriptedDriver(ButlerDriver, okScript()...)
+	deps := baseDeps(routerWith(t, drv), newFakeSink(), newFakeRegistry(), Policy{})
+	deps.Sessions = mgr
+	deps.ButlerMCPConfig = "/cfg/butler-mcp.json"
+	eng := NewEngine(deps)
+
+	_, err = eng.RunTurn(context.Background(), Request{
+		Text:             "hello",
+		RequestedDriver:  ButlerDriver,
+		RequestedSession: string(bsess.ID),
+		DeviceID:         "dev-1",
+	})
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if len(drv.mcpConfigs) != 1 || drv.mcpConfigs[0] != "/cfg/butler-mcp.json" {
+		t.Fatalf("mcpConfigs=%v want [/cfg/butler-mcp.json]", drv.mcpConfigs)
+	}
+	if len(drv.cwds) != 1 || drv.cwds[0] != "/ws" {
+		t.Fatalf("cwds=%v want [/ws] (butler workspace)", drv.cwds)
+	}
+}
+
+// A non-butler logical session (Role=none) must NOT get --mcp-config even when
+// the engine has a ButlerMCPConfig configured (worker/regular sessions never
+// dispatch).
+func TestRunTurn_NoMCPConfigForNonButlerRole(t *testing.T) {
+	mgr := newTestManager(t, "/default/cwd")
+	sess, err := mgr.Create("dev-1", ButlerDriver, "/proj", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	drv := newScriptedDriver(ButlerDriver, okScript()...)
+	deps := baseDeps(routerWith(t, drv), newFakeSink(), newFakeRegistry(), Policy{})
+	deps.Sessions = mgr
+	deps.ButlerMCPConfig = "/cfg/butler-mcp.json"
+	eng := NewEngine(deps)
+
+	_, err = eng.RunTurn(context.Background(), Request{
+		Text:             "hello",
+		RequestedDriver:  ButlerDriver,
+		RequestedSession: string(sess.ID),
+		DeviceID:         "dev-1",
+	})
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if len(drv.mcpConfigs) != 1 || drv.mcpConfigs[0] != "" {
+		t.Fatalf("mcpConfigs=%v want [\"\"] (non-butler must not get --mcp-config)", drv.mcpConfigs)
+	}
+}
+
+// Butler role but no ButlerMCPConfig configured → still no --mcp-config (dispatch
+// disabled gracefully).
+func TestRunTurn_NoMCPConfigWhenUnconfigured(t *testing.T) {
+	mgr := newTestManager(t, "/default/cwd")
+	bsess, err := mgr.EnsureButler("dev-1", ButlerDriver, "/ws")
+	if err != nil {
+		t.Fatalf("EnsureButler: %v", err)
+	}
+
+	drv := newScriptedDriver(ButlerDriver, okScript()...)
+	deps := baseDeps(routerWith(t, drv), newFakeSink(), newFakeRegistry(), Policy{})
+	deps.Sessions = mgr
+	deps.ButlerMCPConfig = "" // not configured
+	eng := NewEngine(deps)
+
+	_, err = eng.RunTurn(context.Background(), Request{
+		Text:             "hello",
+		RequestedDriver:  ButlerDriver,
+		RequestedSession: string(bsess.ID),
+		DeviceID:         "dev-1",
+	})
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if len(drv.mcpConfigs) != 1 || drv.mcpConfigs[0] != "" {
+		t.Fatalf("mcpConfigs=%v want [\"\"]", drv.mcpConfigs)
+	}
+}

--- a/adapter/internal/butler/engine.go
+++ b/adapter/internal/butler/engine.go
@@ -8,6 +8,10 @@ import (
 	"github.com/daboluocc/bbclaw/adapter/internal/agent/logicalsession"
 )
 
+// ButlerDriver 是管家会话固定使用的 agent driver(ADR-021 §1):管家是 per-device 的
+// 编排者,跑在 claude-code 上以便加载 workspace 的 CLAUDE.md 人设并经 --mcp-config 派发。
+const ButlerDriver = "claude-code"
+
 // Request 是 caller 把自己的 transport 入参规整后传给 butler 的纯数据。
 // 差异 #10:deviceId 来源由 caller 决定(LOCAL=URL query;CLOUD=env.DeviceID)。
 type Request struct {
@@ -41,6 +45,12 @@ type Deps struct {
 	//   LOCAL  = s.agentCtx(长生命周期)
 	//   CLOUD  = 请求 ctx
 	StartCtx context.Context
+
+	// ButlerMCPConfig 是管家会话的 --mcp-config 文件路径(ADR-021 §2)。仅当本轮解析到的
+	// logical session 的 Role 为 logicalsession.RoleButler 时,才经 StartOpts.MCPConfig
+	// 下达给 driver(claudecode → --mcp-config),让管家可派发 worker。worker 会话不带。
+	// "" = 不注入(非管家路径或未配置 mcp-server)。
+	ButlerMCPConfig string
 }
 
 // Engine 持有不变的依赖;RunTurn 每次调用驱动一个完整 turn。
@@ -147,6 +157,7 @@ func (e *Engine) RunTurn(turnCtx context.Context, req Request) (*Result, error) 
 		logicalID         logicalsession.ID
 		resumeFromLogical string
 		logicalCwd        string
+		logicalRole       string
 		usingLogical      bool
 
 		sid   agent.SessionID
@@ -165,6 +176,7 @@ func (e *Engine) RunTurn(turnCtx context.Context, req Request) (*Result, error) 
 			logicalID = ls.ID
 			resumeFromLogical = ls.CLISessionID
 			logicalCwd = ls.Cwd
+			logicalRole = ls.Role
 			usingLogical = true
 			if resumeFromLogical != "" {
 				if dn, esid, found := d.Registry.Get(resumeFromLogical); found {
@@ -200,6 +212,7 @@ func (e *Engine) RunTurn(turnCtx context.Context, req Request) (*Result, error) 
 					logicalID = recent.ID
 					resumeFromLogical = recent.CLISessionID
 					logicalCwd = recent.Cwd
+					logicalRole = recent.Role
 					usingLogical = true
 					if resumeFromLogical != "" {
 						if dn, esid, found := d.Registry.Get(resumeFromLogical); found {
@@ -310,6 +323,11 @@ func (e *Engine) RunTurn(turnCtx context.Context, req Request) (*Result, error) 
 			}
 			startOpts.Model = d.resolveModel(drv.Name())
 			startOpts.SystemPrompt = d.buildSystemPrompt(logicalCwd)
+			// 仅管家会话(Role=butler)带 --mcp-config,让它能派发 worker(ADR-021 §2);
+			// worker / 普通会话不带。driver 不支持 MCP 时忽略(契约同 Model)。
+			if logicalRole == logicalsession.RoleButler && d.ButlerMCPConfig != "" {
+				startOpts.MCPConfig = d.ButlerMCPConfig
+			}
 			isResumeAttempt := false
 			if attempt == 0 {
 				switch {

--- a/adapter/internal/butler/engine_test.go
+++ b/adapter/internal/butler/engine_test.go
@@ -90,6 +90,8 @@ type scriptedDriver struct {
 	startN        int
 	resumeIDs     []string
 	systemPrompts []string
+	mcpConfigs    []string
+	cwds          []string
 	sendTexts     []string
 	scripts       [][]agent.Event // per-Send event scripts
 	sendCalls     int
@@ -107,6 +109,8 @@ func (d *scriptedDriver) Start(_ context.Context, opts agent.StartOpts) (agent.S
 	d.startN++
 	d.resumeIDs = append(d.resumeIDs, opts.ResumeID)
 	d.systemPrompts = append(d.systemPrompts, opts.SystemPrompt)
+	d.mcpConfigs = append(d.mcpConfigs, opts.MCPConfig)
+	d.cwds = append(d.cwds, opts.Cwd)
 	return agent.SessionID(d.name + "-sid"), nil
 }
 func (d *scriptedDriver) Send(_ agent.SessionID, text string) error {

--- a/adapter/internal/butlermcp/config.go
+++ b/adapter/internal/butlermcp/config.go
@@ -1,0 +1,67 @@
+package butlermcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ServerName is the key the butler dispatch MCP server is registered under in
+// the generated --mcp-config file. The butler addresses its tools as
+// `mcp__bbclaw__dispatch`, etc.
+const ServerName = "bbclaw"
+
+// mcpServerEntry is one server entry in a claude `--mcp-config` file.
+type mcpServerEntry struct {
+	Type    string            `json:"type"`
+	Command string            `json:"command"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// mcpConfigFile is the top-level shape claude reads from `--mcp-config <path>`.
+type mcpConfigFile struct {
+	MCPServers map[string]mcpServerEntry `json:"mcpServers"`
+}
+
+// WriteConfig writes the butler's `--mcp-config` JSON file at path, pointing the
+// stdio dispatch server at `<command> mcp-server` (ADR-021 §2). The butler
+// session is spawned with `claude --mcp-config <path>` so it can dispatch coding
+// work to worker agents through the mcp-server subcommand.
+//
+// env is embedded into the server entry so the spawned subprocess sees a
+// deterministic project allowlist (BBCLAW_CWD_POOL / credentials) regardless of
+// how the parent claude process scrubs its environment. Pass nil to rely purely
+// on inherited env.
+//
+// The file is written atomically-enough for a single-process daemon (truncate +
+// write, 0600 since it can carry auth tokens). Returns the path on success.
+func WriteConfig(path, command string, env map[string]string) (string, error) {
+	if command == "" {
+		return "", fmt.Errorf("butlermcp: command must not be empty")
+	}
+	cfg := mcpConfigFile{
+		MCPServers: map[string]mcpServerEntry{
+			ServerName: {
+				Type:    "stdio",
+				Command: command,
+				Args:    []string{"mcp-server"},
+				Env:     env,
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("butlermcp: marshal mcp-config: %w", err)
+	}
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return "", fmt.Errorf("butlermcp: mkdir mcp-config dir %s: %w", dir, err)
+		}
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", fmt.Errorf("butlermcp: write mcp-config %s: %w", path, err)
+	}
+	return path, nil
+}

--- a/adapter/internal/butlermcp/config_test.go
+++ b/adapter/internal/butlermcp/config_test.go
@@ -1,0 +1,70 @@
+package butlermcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "butler-mcp.json")
+
+	got, err := WriteConfig(path, "/opt/bbclaw-adapter", map[string]string{
+		"BBCLAW_CWD_POOL": "proj:/p",
+	})
+	if err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	if got != path {
+		t.Fatalf("returned path=%q want %q", got, path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg mcpConfigFile
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	entry, ok := cfg.MCPServers[ServerName]
+	if !ok {
+		t.Fatalf("missing %q server entry; servers=%v", ServerName, cfg.MCPServers)
+	}
+	if entry.Type != "stdio" {
+		t.Errorf("type=%q want stdio", entry.Type)
+	}
+	if entry.Command != "/opt/bbclaw-adapter" {
+		t.Errorf("command=%q want /opt/bbclaw-adapter", entry.Command)
+	}
+	if len(entry.Args) != 1 || entry.Args[0] != "mcp-server" {
+		t.Errorf("args=%v want [mcp-server]", entry.Args)
+	}
+	if entry.Env["BBCLAW_CWD_POOL"] != "proj:/p" {
+		t.Errorf("env BBCLAW_CWD_POOL=%q want proj:/p", entry.Env["BBCLAW_CWD_POOL"])
+	}
+}
+
+func TestWriteConfigRejectsEmptyCommand(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.json")
+	if _, err := WriteConfig(path, "", nil); err == nil {
+		t.Fatalf("WriteConfig with empty command: want error, got nil")
+	}
+}
+
+func TestWriteConfigPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "butler-mcp.json")
+	if _, err := WriteConfig(path, "/bin/adapter", nil); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// The config can carry auth tokens, so it must not be world-readable.
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("perm=%o want 600", perm)
+	}
+}

--- a/adapter/internal/homeadapter/adapter.go
+++ b/adapter/internal/homeadapter/adapter.go
@@ -61,6 +61,15 @@ type Adapter struct {
 	// driverState persists user-mutable driver preferences. Optional: when
 	// nil the agent proxy uses router defaults. Set via SetDriverState.
 	driverState *driverstate.Store
+
+	// butlerWorkspace is the per-device butler workspace cwd (ADR-021 §1). When
+	// non-empty (wired by main.go), the voice transcript path routes every turn
+	// to the device's butler logical session via the butler engine instead of
+	// the legacy one-shot driver spawn. Empty keeps the legacy voice path.
+	butlerWorkspace string
+	// butlerMCPConfig is the path to the butler's --mcp-config file (ADR-021
+	// §2), passed to the engine so the butler session can dispatch workers.
+	butlerMCPConfig string
 }
 
 type Status struct {
@@ -146,6 +155,18 @@ func (a *Adapter) defaultStartCwd() string {
 		return a.cwdPool[0].Path
 	}
 	return ""
+}
+
+// SetButlerWorkspace enables butler routing for the cloud voice path (ADR-021
+// §1): when workspaceCwd is non-empty, the voice transcript fan-out routes
+// every turn to the calling device's butler logical session (cwd=workspaceCwd,
+// Role=butler, driver=claude-code) through the butler engine instead of the
+// legacy one-shot driver spawn. mcpConfig is the butler's --mcp-config path
+// (ADR-021 §2); empty disables dispatch. Empty workspaceCwd leaves the legacy
+// voice path untouched.
+func (a *Adapter) SetButlerWorkspace(workspaceCwd, mcpConfig string) {
+	a.butlerWorkspace = strings.TrimSpace(workspaceCwd)
+	a.butlerMCPConfig = strings.TrimSpace(mcpConfig)
 }
 
 // SetDriverState attaches the persistent driver-preference store, mirrored
@@ -599,6 +620,15 @@ func (a *Adapter) handleChatTextViaAgent(
 	text, sessionKey, streamID, driverName string,
 	routeStart time.Time,
 ) error {
+	// Butler routing (ADR-021 §1): when a butler workspace is configured, route
+	// the voice turn to the device's butler logical session through the shared
+	// butler engine (cwd=workspace, --mcp-config, warm-pool hit) instead of the
+	// legacy one-shot spawn below. Falls back to the legacy path when the butler
+	// can't be resolved so a transient session-store error never drops a turn.
+	if a.butlerWorkspace != "" && a.sessions != nil {
+		return a.handleChatTextViaButler(ctx, write, env, text, sessionKey, streamID, routeStart)
+	}
+
 	drv, ok := a.router.Get(driverName)
 	if !ok {
 		return fmt.Errorf("agent driver %q not registered", driverName)
@@ -671,6 +701,146 @@ loop:
 		Kind:       "voice.reply",
 		Payload:    map[string]any{"ok": true, "text": replyText},
 	})
+}
+
+// handleChatTextViaButler runs one voice turn through the shared butler engine
+// (ADR-021 §1). It resolves the device's butler logical session, runs the turn
+// via butler.Engine.RunTurn, and re-emits the agent events as the same cloud
+// frames the legacy voice path produced (voice.reply.delta / tool_call) so the
+// cloud relay protocol is byte-for-byte compatible. The accumulated assistant
+// text is sent as the final voice.reply envelope, exactly like before.
+func (a *Adapter) handleChatTextViaButler(
+	ctx context.Context,
+	write func(CloudEnvelope) error,
+	env CloudEnvelope,
+	text, sessionKey, streamID string,
+	routeStart time.Time,
+) error {
+	if a.agentSessions == nil {
+		a.agentSessions = newAgentProxyRegistry()
+	}
+
+	requestedDriver := butler.ButlerDriver
+	requestedSession := ""
+	if bsess, err := a.sessions.EnsureButler(env.DeviceID, butler.ButlerDriver, a.butlerWorkspace); err != nil {
+		// Non-fatal: without a butler session the engine still runs a fresh
+		// claude-code turn in the workspace, just without session continuity.
+		a.log.Warnf("butler: ensure failed device=%q err=%v; running butler turn without logical session", env.DeviceID, err)
+	} else {
+		requestedDriver = bsess.Driver
+		requestedSession = string(bsess.ID)
+	}
+
+	sink := &voiceEventSink{a: a, write: write, env: env, streamID: streamID, sessionKey: sessionKey, routeStart: routeStart}
+
+	eng := butler.NewEngine(butler.Deps{
+		Router:   a.router,
+		Sessions: a.sessions,
+		Registry: &cloudSessionRegistry{r: a.agentSessions},
+		Sink:     sink,
+		Policy: butler.Policy{
+			ReuseWindow:          0,
+			AllowBareCLIID:       true,
+			AutoTitle:            false,
+			EmitTurnEndFrame:     false,
+			EmitStartFailedFrame: false,
+			MaxAttempts:          2,
+		},
+		Metrics:            &cloudMetrics{m: a.metrics},
+		Log:                a.log,
+		ResolveActiveModel: a.resolveActiveModel,
+		SystemPrompt:       butler.DeviceSystemPrompt,
+		ButlerMCPConfig:    a.butlerMCPConfig,
+		StartCtx:           ctx,
+	})
+
+	_, runErr := eng.RunTurn(ctx, butler.Request{
+		Text:             text,
+		RequestedDriver:  requestedDriver,
+		RequestedSession: requestedSession,
+		DeviceID:         env.DeviceID,
+	})
+	if runErr != nil {
+		// ctx cancellation or a coded error after the stream committed: surface a
+		// failed voice.reply so the cloud (and device) don't hang on the turn.
+		a.log.Warnf("phase=voice_butler_failed device=%s session=%s elapsed_s=%.3f err=%v",
+			env.DeviceID, strings.TrimSpace(sessionKey), time.Since(routeStart).Seconds(), runErr)
+		return write(CloudEnvelope{
+			Type:       "reply",
+			MessageID:  env.MessageID,
+			HomeSiteID: a.cfg.HomeSiteID,
+			Kind:       "voice.reply",
+			Payload:    map[string]any{"ok": false, "error": runErr.Error()},
+		})
+	}
+
+	replyText := sink.replyText()
+	a.log.Infof("phase=chat_text_request_done driver=%s session=%s elapsed_s=%.3f reply_chars=%d butler=true",
+		requestedDriver, sessionKey, time.Since(routeStart).Seconds(), utf8.RuneCountInString(replyText))
+	return write(CloudEnvelope{
+		Type:       "reply",
+		MessageID:  env.MessageID,
+		HomeSiteID: a.cfg.HomeSiteID,
+		Kind:       "voice.reply",
+		Payload:    map[string]any{"ok": true, "text": replyText},
+	})
+}
+
+// voiceEventSink adapts butler.EventSink to the cloud voice protocol frames.
+// It maps EvText → voice.reply.delta and EvToolCall → tool_call (the exact
+// kinds the legacy handleChatTextViaAgent loop emitted) and accumulates the
+// assistant text for the final voice.reply envelope. Session frames are not
+// part of the voice protocol, so EmitSession is a no-op. All methods return
+// true: cloud streaming is best-effort and never aborts the turn on a dropped
+// write (matching the legacy writeEvent behaviour). The engine calls these
+// methods sequentially from its consume loop, so no locking is needed.
+type voiceEventSink struct {
+	a          *Adapter
+	write      func(CloudEnvelope) error
+	env        CloudEnvelope
+	streamID   string
+	sessionKey string
+	routeStart time.Time
+
+	parts    []string
+	deltaSeq int
+}
+
+func (v *voiceEventSink) EmitSession(string, bool, string) bool { return true }
+
+func (v *voiceEventSink) EmitEvent(ev agent.Event) bool {
+	switch ev.Type {
+	case agent.EvText:
+		if t := strings.TrimSpace(ev.Text); t != "" {
+			v.parts = append(v.parts, ev.Text)
+			v.deltaSeq++
+			v.a.log.Infof("phase=reply_delta_recv device=%s session=%s stream=%s delta_seq=%d text_chars=%d elapsed_s=%.3f",
+				v.env.DeviceID, strings.TrimSpace(v.sessionKey), strings.TrimSpace(v.streamID), v.deltaSeq,
+				utf8.RuneCountInString(ev.Text), time.Since(v.routeStart).Seconds())
+			v.writeEvent("voice.reply.delta", map[string]any{"text": ev.Text})
+		}
+	case agent.EvToolCall:
+		if ev.Tool != nil {
+			v.writeEvent("tool_call", map[string]any{"name": ev.Tool.Tool})
+		}
+	}
+	return true
+}
+
+func (v *voiceEventSink) EmitError(code, text string, _ bool) bool {
+	v.a.log.Warnf("phase=voice_butler_error device=%s session=%s code=%s detail=%.120s",
+		v.env.DeviceID, strings.TrimSpace(v.sessionKey), code, text)
+	return true
+}
+
+func (v *voiceEventSink) writeEvent(kind string, payload map[string]any) {
+	if err := v.a.writeStreamEvent(v.write, v.env, kind, payload); err != nil {
+		v.a.log.Warnf("writeEvent failed kind=%s device=%s err=%v", kind, v.env.DeviceID, err)
+	}
+}
+
+func (v *voiceEventSink) replyText() string {
+	return strings.TrimSpace(strings.Join(v.parts, ""))
 }
 
 func (a *Adapter) writeStreamEvent(write func(CloudEnvelope) error, env CloudEnvelope, kind string, payload map[string]any) error {

--- a/adapter/internal/homeadapter/butler_voice_test.go
+++ b/adapter/internal/homeadapter/butler_voice_test.go
@@ -1,0 +1,129 @@
+package homeadapter
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/agent/logicalsession"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
+)
+
+// When a butler workspace is configured, the cloud voice path routes the turn
+// through the butler engine: it re-emits agent text as voice.reply.delta frames,
+// finishes with a voice.reply envelope, and creates the device's butler logical
+// session (Role=butler, cwd=workspace). ADR-021 §1.
+func TestHandleChatTextViaAgent_ButlerRouting(t *testing.T) {
+	drv := newFakeAgentDriver("claude-code") // butler.ButlerDriver
+	r := agent.NewRouter()
+	r.Register(drv, obs.NewLogger())
+
+	mgr, err := logicalsession.NewManager(filepath.Join(t.TempDir(), "sessions.json"), "/tmp/default", obs.NewLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	a := &Adapter{
+		cfg:     Config{HomeSiteID: "home-1"},
+		log:     obs.NewLogger(),
+		metrics: obs.NewMetrics(),
+	}
+	a.SetRouter(r)
+	a.SetSessionManager(mgr)
+	a.SetButlerWorkspace("/ws", "/cfg/butler-mcp.json")
+
+	var got []CloudEnvelope
+	write := func(env CloudEnvelope) error {
+		got = append(got, env)
+		return nil
+	}
+	env := CloudEnvelope{Type: "request", MessageID: "m-1", DeviceID: "dev-1", Kind: "voice.transcript"}
+
+	// driverName "mock2" is what the legacy path would have used; butler routing
+	// must override it to claude-code regardless.
+	if err := a.handleChatTextViaAgent(context.Background(), write, env, "hello", "sk-1", "st-1", "mock2", time.Now()); err != nil {
+		t.Fatalf("handleChatTextViaAgent: %v", err)
+	}
+
+	// Expect a voice.reply.delta event for "hi" followed by a final voice.reply.
+	var sawDelta bool
+	var final *CloudEnvelope
+	for i := range got {
+		e := got[i]
+		if e.Type == "event" && e.Kind == "voice.reply.delta" && e.Payload["text"] == "hi" {
+			sawDelta = true
+		}
+		if e.Type == "reply" && e.Kind == "voice.reply" {
+			final = &got[i]
+		}
+	}
+	if !sawDelta {
+		t.Fatalf("missing voice.reply.delta frame: %+v", got)
+	}
+	if final == nil {
+		t.Fatalf("missing final voice.reply: %+v", got)
+	}
+	if final.Payload["ok"] != true || final.Payload["text"] != "hi" {
+		t.Fatalf("final reply payload=%v want ok=true text=hi", final.Payload)
+	}
+
+	// The butler driver must have received the user text.
+	if len(drv.sentTo) != 1 || drv.sentTo[0] != "hello" {
+		t.Fatalf("butler driver sentTo=%v want [hello]", drv.sentTo)
+	}
+
+	// A Role=butler session must exist for the device.
+	butlers := 0
+	for _, s := range mgr.List("dev-1", "claude-code", 0) {
+		if s.Role == logicalsession.RoleButler {
+			butlers++
+			if s.Cwd != "/ws" {
+				t.Errorf("butler cwd=%q want /ws", s.Cwd)
+			}
+		}
+	}
+	if butlers != 1 {
+		t.Fatalf("butler session count=%d want 1", butlers)
+	}
+}
+
+// Without a configured butler workspace the legacy one-shot voice path is used
+// unchanged (the requested driver runs directly, no butler session is created).
+func TestHandleChatTextViaAgent_LegacyWhenButlerUnconfigured(t *testing.T) {
+	drv := newFakeAgentDriver("mock2")
+	r := agent.NewRouter()
+	r.Register(drv, obs.NewLogger())
+
+	mgr, err := logicalsession.NewManager(filepath.Join(t.TempDir(), "sessions.json"), "/tmp/default", obs.NewLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	a := &Adapter{
+		cfg:     Config{HomeSiteID: "home-1"},
+		log:     obs.NewLogger(),
+		metrics: obs.NewMetrics(),
+	}
+	a.SetRouter(r)
+	a.SetSessionManager(mgr)
+	// No SetButlerWorkspace → legacy path.
+
+	var got []CloudEnvelope
+	write := func(env CloudEnvelope) error {
+		got = append(got, env)
+		return nil
+	}
+	env := CloudEnvelope{Type: "request", MessageID: "m-1", DeviceID: "dev-1", Kind: "voice.transcript"}
+	if err := a.handleChatTextViaAgent(context.Background(), write, env, "hello", "sk-1", "st-1", "mock2", time.Now()); err != nil {
+		t.Fatalf("handleChatTextViaAgent: %v", err)
+	}
+	if len(drv.sentTo) != 1 || drv.sentTo[0] != "hello" {
+		t.Fatalf("legacy driver sentTo=%v want [hello]", drv.sentTo)
+	}
+	// Legacy path must not create any logical session.
+	if sessions := mgr.List("dev-1", "", 0); len(sessions) != 0 {
+		t.Fatalf("legacy path created %d logical sessions, want 0", len(sessions))
+	}
+}

--- a/adapter/internal/httpapi/agent.go
+++ b/adapter/internal/httpapi/agent.go
@@ -130,6 +130,17 @@ func (s *Server) SetSessionManager(m *logicalsession.Manager) { s.sessions = m }
 // router's first-registered-wins default applies as before).
 func (s *Server) SetDriverState(store *driverstate.Store) { s.driverState = store }
 
+// SetButlerWorkspace enables butler routing (ADR-021 §1): when workspaceCwd is
+// non-empty, every /v1/agent/message turn is routed to the calling device's
+// butler logical session (cwd=workspaceCwd, Role=butler, driver=claude-code)
+// instead of honouring the device-requested driver/session. mcpConfig is the
+// path to the butler's --mcp-config file (ADR-021 §2); empty disables dispatch.
+// Passing an empty workspaceCwd leaves the legacy multi-session path untouched.
+func (s *Server) SetButlerWorkspace(workspaceCwd, mcpConfig string) {
+	s.butlerWorkspace = strings.TrimSpace(workspaceCwd)
+	s.butlerMCPConfig = strings.TrimSpace(mcpConfig)
+}
+
 // resolveActiveDriver picks the driver name to use when the request didn't
 // specify one. Priority: 1) persisted driverState.ActiveDriver, 2) router's
 // own default. Both fall back gracefully to "" when neither resolves.
@@ -629,6 +640,21 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 	requestedSession := strings.TrimSpace(req.SessionId)
 	deviceID := strings.TrimSpace(r.URL.Query().Get("deviceId"))
 
+	// Butler routing (ADR-021 §1): when a butler workspace is configured, the
+	// device no longer picks a driver/session — every turn is routed to this
+	// device's butler logical session (cwd=workspace, Role=butler). We resolve
+	// (or create) it here and override the requested driver/session before the
+	// engine runs; RunTurn's ls- path then loads its cwd, and the butler role
+	// tells the engine to inject --mcp-config so dispatch works.
+	if s.butlerWorkspace != "" && s.sessions != nil {
+		if bsess, err := s.sessions.EnsureButler(deviceID, butler.ButlerDriver, s.butlerWorkspace); err != nil {
+			s.log.Warnf("butler: ensure failed device=%q err=%v; falling back to requested driver/session", deviceID, err)
+		} else {
+			requestedDriver = bsess.Driver
+			requestedSession = string(bsess.ID)
+		}
+	}
+
 	// Lazily-built stream writer. The parse phase may return a PreStream
 	// CodedError before any frame is written, in which case we reply with a
 	// plain JSON 4xx. Once RunTurn touches the Sink the response is committed
@@ -666,6 +692,7 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 		Log:                s.log,
 		ResolveActiveModel: s.resolveActiveModel,
 		SystemPrompt:       butler.DeviceSystemPrompt,
+		ButlerMCPConfig:    s.butlerMCPConfig,
 		StartCtx:           s.agentCtx,
 	})
 

--- a/adapter/internal/httpapi/agent_test.go
+++ b/adapter/internal/httpapi/agent_test.go
@@ -596,3 +596,68 @@ func TestHandleAgentMessage_VoiceCommand(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleAgentMessage_ButlerRouting verifies ADR-021 §1: when a butler
+// workspace is configured, the device's requested driver/session is ignored and
+// the turn is routed to the device's butler logical session (driver=claude-code,
+// Role=butler), which is created on first use.
+func TestHandleAgentMessage_ButlerRouting(t *testing.T) {
+	butlerMock := newNamedMockDriver("claude-code") // butler.ButlerDriver
+	otherMock := newNamedMockDriver("mock2")
+	srv := NewServer(AppConfig{}, nil, nil, nil, nil, obs.NewLogger(), obs.NewMetrics())
+	r := agent.NewRouter()
+	r.Register(butlerMock, obs.NewLogger())
+	r.Register(otherMock, obs.NewLogger())
+	srv.SetAgentRouter(r)
+
+	mgr, err := logicalsession.NewManager(filepath.Join(t.TempDir(), "sessions.json"), "/tmp/default", obs.NewLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	srv.SetSessionManager(mgr)
+	srv.SetButlerWorkspace("/ws", "/cfg/butler-mcp.json")
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// Device asks for mock2, but butler routing must override to claude-code.
+	resp, err := http.Post(ts.URL+"/v1/agent/message?deviceId=dev-1", "application/json",
+		bytes.NewBufferString(`{"text":"hello","driver":"mock2"}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	frames := readNDJSONFrames(t, resp.Body)
+	if len(frames) == 0 || frames[0]["type"] != "session" {
+		t.Fatalf("missing session frame: %+v", frames)
+	}
+	if frames[0]["driver"] != "claude-code" {
+		t.Fatalf("session driver=%v want claude-code (butler), not the requested mock2", frames[0]["driver"])
+	}
+	sid, _ := frames[0]["sessionId"].(string)
+	if !strings.HasPrefix(sid, "ls-") {
+		t.Fatalf("session id=%q want ls- butler logical id", sid)
+	}
+
+	// The butler driver must have received the text; the requested driver must not.
+	if got := butlerMock.receivedTexts(); len(got) != 1 || got[0] != "hello" {
+		t.Fatalf("butler driver received=%v want [hello]", got)
+	}
+	if got := otherMock.receivedTexts(); len(got) != 0 {
+		t.Fatalf("requested driver mock2 received=%v want none (butler routing overrides)", got)
+	}
+
+	// A Role=butler session must now exist for the device.
+	butlers := 0
+	for _, s := range mgr.List("dev-1", "claude-code", 0) {
+		if s.Role == logicalsession.RoleButler && string(s.ID) == sid {
+			butlers++
+			if s.Cwd != "/ws" {
+				t.Errorf("butler cwd=%q want /ws", s.Cwd)
+			}
+		}
+	}
+	if butlers != 1 {
+		t.Fatalf("butler session count=%d want 1", butlers)
+	}
+}

--- a/adapter/internal/httpapi/server.go
+++ b/adapter/internal/httpapi/server.go
@@ -37,8 +37,8 @@ type AppConfig struct {
 	AudioInDir           string
 	AudioOutDir          string
 	ASRTranscribeTimeout time.Duration
-	SessionReuseWindow   time.Duration // 0 disables reuse
-	SessionMaxAge        time.Duration // 0 disables sweep
+	SessionReuseWindow   time.Duration     // 0 disables reuse
+	SessionMaxAge        time.Duration     // 0 disables sweep
 	CwdPool              []config.CwdEntry // populated from BBCLAW_CWD_POOL / BBCLAW_DEFAULT_CWD
 }
 
@@ -92,6 +92,15 @@ type Server struct {
 	// is the router's default and active_model falls back to driver-default.
 	// Set via SetDriverState from main.go.
 	driverState *driverstate.Store
+
+	// butlerWorkspace is the per-device butler workspace cwd (ADR-021 §1). When
+	// non-empty (wired by main.go), every /v1/agent/message turn is routed to
+	// the device's butler logical session instead of honouring the device's
+	// requested driver/session. Empty keeps the legacy multi-session behaviour.
+	butlerWorkspace string
+	// butlerMCPConfig is the path to the butler's --mcp-config file (ADR-021
+	// §2), passed to the engine so the butler session can dispatch workers.
+	butlerMCPConfig string
 
 	// WebSocket hub for local_home device connections + notification queue.
 	wsHub      *WSHub


### PR DESCRIPTION
Fixes #80

## 目标
设备每次语音/文本 turn 不再自选 driver/session，统一路由到该设备专属的「管家」逻辑会话（`Role=butler`、`cwd=~/.bbclaw-adapter/workspace/`、`driver=claude-code`）。管家靠 cwd 自动加载 workspace 的 CLAUDE.md 人设/记忆（零代码）。

## 改了什么 / 为什么

### 1. 管家会话解析（落点定死在 `logicalsession.Manager`）
- 新增 `Manager.EnsureButler(deviceID, driver, cwd)`：按 `deviceID+driver` 幂等解析/创建管家会话，首次铸造 `RoleButler`，后续复用以保留会话连续性。每设备一个管家。两处路由共用，避免各写一份（回应上轮 evaluation 的 open question）。

### 2. 路由落点
- **`httpapi/agent.go handleAgentMessage`（local）**：`handleAgentMessage` 本就走 `butler.Engine.RunTurn`，只在解析阶段把设备请求的 driver/session 覆盖为管家会话（`requestedSession=ls-butler`、`requestedDriver=claude-code`），增量极小。
- **`homeadapter/adapter.go handleChatTextViaAgent`（cloud 语音，scope 主块）**：废弃手撸 `drv.Start`/事件循环/自发 `voice.reply.delta`，统一到 `butler.Engine.RunTurn`，经新增 `voiceEventSink` 把 agent 事件适配回**完全相同**的云端帧（`voice.reply.delta` / `tool_call`）+ 末尾 `voice.reply` envelope。逐帧守住 Cloud relay 协议（对照 CLAUDE.md「Cross-Component Protocol Sync」）。
- **门控（feature-flag）**：路由仅在配置了 butler workspace 时生效（`SetButlerWorkspace`，由 main.go 装配，生产恒开）。未配置时（现有单测）保持旧多会话 / 旧语音直发行为——**httpapi/homeadapter 现有测试零破坏**。

### 3. claudecode `--mcp-config`（仅管家）
- `agent.StartOpts` 新增 `MCPConfig`（契约同 `Model`/`SystemPrompt`，不支持的 driver 忽略）。
- claudecode `session.mcpConfig` + `sessionFlags` 非空时拼 `--mcp-config <path>`。
- `butler.Engine` 捕获解析到的会话 `Role`，**仅 `Role==butler`** 时把 `Deps.ButlerMCPConfig` 注入 `StartOpts.MCPConfig`；worker/普通会话不带。
- 新增 `butlermcp.WriteConfig`：生成指向 #79 `mcp-server` 子命令的 stdio MCP 配置，启动时写到 `~/.bbclaw-adapter/butler-mcp.json`（0600，可带 token），env 内嵌 `BBCLAW_CWD_POOL` 等保证 worker 项目 allowlist 确定。

### 4. WarmPool 预热管家
- `claudecode.WarmPool` 从单 `warmCwd` 扩成多 `warmCwds`（项目 cwd + 管家 workspace），`fill()` 对每个 cwd 独立维持 `size` 个预热条目；`Acquire(cwd)` 已按 cwd 严格匹配。管家会话 cwd=workspace 每轮命中预热，避免 4-7s 冷启动。`dedupeCwds` 折叠重叠并在全空时回退单 `""` 槽（保持旧行为）。

## 验收
- `go build ./...` / `go vet ./...` 绿。
- `go test ./...` 全绿，httpapi/homeadapter/agent_proxy 现有测试不破。
- 新增测试：`EnsureButler` 幂等/每设备/角色；`sessionFlags` 拼 `--mcp-config`；引擎仅管家注入 MCPConfig（+ 负例）；`WarmPool` 多 cwd `Acquire`/`countForCwd`/`dedupeCwds`；`butlermcp.WriteConfig` JSON 形状/权限；httpapi 管家路由覆盖请求 driver；homeadapter 语音管家路由 + 未配置走旧路径。

## 备注 / 未覆盖
- **未硬件验证**：本改动均为 adapter（Go）服务端逻辑，无固件/串口依赖；testing.md SOP 的设备端链路（PTT→ASR→管家）未在本机硬件上跑，留待集成验证。端到端「管家调 dispatch」需配合 #79 的真实 `claude --mcp-config` 链路。
- **范围聚焦**：按 issue 明确点名修改 `handleAgentMessage` 与语音直发路径；cloud `agent.message` 多会话代理（`handleAgentMessageRequest`，设备 CHAT 会话列表 UI）未纳入本 issue，保持原多会话行为。
- ADR-019 device driver 菜单在管家模式下的隐藏/降级（「管家用哪个模型」）属独立 UI 改动，本 issue 未覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)