### PR TITLE
feat(adapter): claudecode 驱动暴露 dispatch_status 事件 + /v1/butler/dispatch/recent API

### DIFF
--- a/adapter/cmd/bbclaw-adapter/main.go
+++ b/adapter/cmd/bbclaw-adapter/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/daboluocc/bbclaw/adapter/internal/asr"
 	"github.com/daboluocc/bbclaw/adapter/internal/audio"
 	"github.com/daboluocc/bbclaw/adapter/internal/buildinfo"
+	"github.com/daboluocc/bbclaw/adapter/internal/butler"
 	"github.com/daboluocc/bbclaw/adapter/internal/butler/memory"
 	"github.com/daboluocc/bbclaw/adapter/internal/butlermcp"
 	"github.com/daboluocc/bbclaw/adapter/internal/cmd"
@@ -187,6 +188,9 @@ func buildLocalServer(cfg config.Config, sink pipeline.Sink, cloudRelay *homeada
 	if driverStateStore != nil {
 		server.SetDriverState(driverStateStore)
 	}
+	// Wire the process-level dispatch recorder for GET /v1/butler/dispatch/recent.
+	dispatchRecorder := butler.NewDispatchRecorder()
+	server.SetDispatchRecorder(dispatchRecorder)
 	return &http.Server{
 		Addr:    cfg.Addr,
 		Handler: server.Handler(),

--- a/adapter/internal/agent/claudecode/dispatch_test.go
+++ b/adapter/internal/agent/claudecode/dispatch_test.go
@@ -1,0 +1,153 @@
+package claudecode
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
+)
+
+// TestParseStreamJSON_MCPDispatch_Done verifies that a mcp__bbclaw__dispatch
+// tool_use followed by a done tool_result emits two EvDispatchStatus events
+// (started, done) and does NOT emit EvToolCall.
+func TestParseStreamJSON_MCPDispatch_Done(t *testing.T) {
+	transcript := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01","name":"mcp__bbclaw__dispatch","input":{"project":"bbclaw","task":"重构 auth 模块"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"{\"status\":\"done\",\"result\":\"ok\"}"}]}}
+`
+	s := newTestSession()
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+
+	// Expect exactly 2 EvDispatchStatus events
+	if len(evs) != 2 {
+		t.Fatalf("want 2 events (started + done), got %d: %+v", len(evs), evs)
+	}
+	if evs[0].Type != agent.EvDispatchStatus {
+		t.Errorf("event 0: want EvDispatchStatus, got %s", evs[0].Type)
+	}
+	if evs[0].Dispatch == nil || evs[0].Dispatch.Phase != "started" {
+		t.Errorf("event 0: want phase=started, got %+v", evs[0].Dispatch)
+	}
+	if evs[0].Dispatch.TaskID != "toolu_01" {
+		t.Errorf("event 0: want taskId=toolu_01, got %q", evs[0].Dispatch.TaskID)
+	}
+	if evs[0].Dispatch.Cwd != "bbclaw" {
+		t.Errorf("event 0: want cwd=bbclaw, got %q", evs[0].Dispatch.Cwd)
+	}
+	if evs[0].Dispatch.Title == "" {
+		t.Errorf("event 0: want non-empty title")
+	}
+
+	if evs[1].Type != agent.EvDispatchStatus {
+		t.Errorf("event 1: want EvDispatchStatus, got %s", evs[1].Type)
+	}
+	if evs[1].Dispatch == nil || evs[1].Dispatch.Phase != "done" {
+		t.Errorf("event 1: want phase=done, got %+v", evs[1].Dispatch)
+	}
+}
+
+// TestParseStreamJSON_MCPDispatch_Async verifies the async (running→async) phase.
+func TestParseStreamJSON_MCPDispatch_Async(t *testing.T) {
+	transcript := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_02","name":"mcp__bbclaw__dispatch","input":{"cwd":"/home/user/proj","task":"lint all files"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_02","content":"{\"status\":\"running\",\"taskId\":\"task-abc\"}"}]}}
+`
+	s := newTestSession()
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	if len(evs) != 2 {
+		t.Fatalf("want 2 events, got %d: %+v", len(evs), evs)
+	}
+	if evs[1].Dispatch == nil || evs[1].Dispatch.Phase != "async" {
+		t.Errorf("event 1: want phase=async, got %+v", evs[1].Dispatch)
+	}
+	// taskId should come from butlermcp result, not tool_use.id
+	if evs[1].Dispatch.TaskID != "task-abc" {
+		t.Errorf("event 1: want taskId=task-abc, got %q", evs[1].Dispatch.TaskID)
+	}
+}
+
+// TestParseStreamJSON_MCPDispatch_Error verifies the error phase.
+func TestParseStreamJSON_MCPDispatch_Error(t *testing.T) {
+	transcript := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_03","name":"mcp__bbclaw__dispatch","input":{"project":"docs","task":"update ADR"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_03","is_error":true,"content":"{\"status\":\"error\",\"taskId\":\"task-xyz\",\"error\":\"timeout\"}"}]}}
+`
+	s := newTestSession()
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	if len(evs) != 2 {
+		t.Fatalf("want 2 events, got %d: %+v", len(evs), evs)
+	}
+	if evs[1].Dispatch == nil || evs[1].Dispatch.Phase != "error" {
+		t.Errorf("event 1: want phase=error, got %+v", evs[1].Dispatch)
+	}
+	if evs[1].Dispatch.Error != "timeout" {
+		t.Errorf("event 1: want error=timeout, got %q", evs[1].Dispatch.Error)
+	}
+}
+
+// TestParseStreamJSON_NonMCPToolUse_StillEmitsEvToolCall verifies that
+// non-mcp__bbclaw__ tool_use frames still emit EvToolCall (no regression).
+func TestParseStreamJSON_NonMCPToolUse_StillEmitsEvToolCall(t *testing.T) {
+	transcript := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_bash","name":"Bash","input":{"command":"ls -la"}}]}}
+`
+	s := newTestSession()
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("want 1 event, got %d: %+v", len(evs), evs)
+	}
+	if evs[0].Type != agent.EvToolCall {
+		t.Errorf("want EvToolCall for Bash, got %s", evs[0].Type)
+	}
+	if evs[0].Tool == nil || evs[0].Tool.Tool != "Bash" {
+		t.Errorf("want tool=Bash, got %+v", evs[0].Tool)
+	}
+}
+
+// TestParseStreamJSON_NonMCPToolResult_Discarded verifies that tool_results
+// not matching a tracked mcp dispatch are silently discarded.
+func TestParseStreamJSON_NonMCPToolResult_Discarded(t *testing.T) {
+	transcript := `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_unknown","content":"some result"}]}}
+`
+	s := newTestSession()
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	if len(evs) != 0 {
+		t.Errorf("want 0 events for non-MCP tool_result, got %d: %+v", len(evs), evs)
+	}
+}
+
+func newTestSession() *session {
+	return &session{
+		id:      "sid-test",
+		events:  make(chan agent.Event, 32),
+		rootCtx: context.Background(),
+	}
+}

--- a/adapter/internal/agent/claudecode/driver.go
+++ b/adapter/internal/agent/claudecode/driver.go
@@ -370,6 +370,15 @@ func (d *Driver) Shutdown() {
 
 // ─── session ────────────────────────────────────────────────────────────
 
+// pendingDispatch tracks an in-flight mcp__bbclaw__dispatch tool call so we
+// can correlate the tool_result back to the original tool_use.id.
+type pendingDispatch struct {
+	toolUseID string
+	cwd       string
+	title     string
+	startedAt time.Time
+}
+
 type session struct {
 	id           agent.SessionID
 	events       chan agent.Event
@@ -382,6 +391,12 @@ type session struct {
 	rootCtx      context.Context
 
 	seq uint64
+
+	// pendingDispatches maps tool_use_id → pendingDispatch for mcp__bbclaw__
+	// dispatch tool calls that have been started but not yet resolved. Keyed by
+	// claude's tool_use.id (e.g. "toolu_01…"). Access is single-threaded within
+	// parseStreamJSON so no mutex is needed.
+	pendingDispatches map[string]*pendingDispatch
 
 	mu     sync.Mutex
 	cancel context.CancelFunc
@@ -463,11 +478,14 @@ type streamMessage struct {
 }
 
 type streamContent struct {
-	Type  string          `json:"type"`
-	Text  string          `json:"text,omitempty"`
-	Name  string          `json:"name,omitempty"`
-	ID    string          `json:"id,omitempty"`
-	Input json.RawMessage `json:"input,omitempty"`
+	Type       string          `json:"type"`
+	Text       string          `json:"text,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	ID         string          `json:"id,omitempty"`
+	Input      json.RawMessage `json:"input,omitempty"`
+	ToolUseID  string          `json:"tool_use_id,omitempty"` // present in tool_result blocks
+	Content    string          `json:"content,omitempty"`     // tool_result text payload
+	IsError    bool            `json:"is_error,omitempty"`    // tool_result error flag
 }
 
 type streamUsage struct {
@@ -508,24 +526,119 @@ func parseStreamJSON(r io.Reader, s *session, log *obs.Logger) {
 						s.emit(agent.Event{Type: agent.EvText, Text: c.Text})
 					}
 				case "tool_use":
-					// Display-only: we surface tool_use frames as EvToolCall
-					// so the playground / device UI can render them, but
-					// Capabilities().ToolApproval stays false because the
-					// approval round-trip is not yet implemented (Phase 2).
-					hint := summarizeToolInput(c.Name, c.Input)
-					log.Infof("claude-code: tool_use sid=%s tool=%s id=%s hint=%q", s.id, c.Name, c.ID, hint)
-					s.emit(agent.Event{
-						Type: agent.EvToolCall,
-						Tool: &agent.ToolCall{
-							ID:   agent.ToolID(c.ID),
-							Tool: c.Name,
-							Hint: hint,
-						},
-					})
+					if strings.HasPrefix(c.Name, "mcp__bbclaw__") {
+						// MCP butler dispatch: emit EvDispatchStatus(started) and
+						// track in pendingDispatches for tool_result correlation.
+						var inp struct {
+							Project string `json:"project"`
+							Cwd     string `json:"cwd"`
+							Task    string `json:"task"`
+						}
+						_ = json.Unmarshal(c.Input, &inp)
+						cwd := inp.Cwd
+						if cwd == "" {
+							cwd = inp.Project
+						}
+						title := truncateDispatchTitle(inp.Task)
+						log.Infof("claude-code: mcp dispatch started sid=%s tool=%s id=%s cwd=%q title=%q", s.id, c.Name, c.ID, cwd, title)
+						if s.pendingDispatches == nil {
+							s.pendingDispatches = make(map[string]*pendingDispatch)
+						}
+						s.pendingDispatches[c.ID] = &pendingDispatch{
+							toolUseID: c.ID,
+							cwd:       cwd,
+							title:     title,
+							startedAt: time.Now(),
+						}
+						s.emit(agent.Event{
+							Type: agent.EvDispatchStatus,
+							Dispatch: &agent.DispatchStatus{
+								Phase:  "started",
+								TaskID: c.ID,
+								Cwd:    cwd,
+								Title:  title,
+							},
+						})
+					} else {
+						// Display-only: we surface tool_use frames as EvToolCall
+						// so the playground / device UI can render them, but
+						// Capabilities().ToolApproval stays false because the
+						// approval round-trip is not yet implemented (Phase 2).
+						hint := summarizeToolInput(c.Name, c.Input)
+						log.Infof("claude-code: tool_use sid=%s tool=%s id=%s hint=%q", s.id, c.Name, c.ID, hint)
+						s.emit(agent.Event{
+							Type: agent.EvToolCall,
+							Tool: &agent.ToolCall{
+								ID:   agent.ToolID(c.ID),
+								Tool: c.Name,
+								Hint: hint,
+							},
+						})
+					}
 				}
 			}
 		case "user":
-			// tool_result frames — ignored for Phase 1 (no approval loop).
+			// tool_result frames: parse mcp__bbclaw__ dispatch results into
+			// EvDispatchStatus events. Other tool_results are still discarded.
+			if env.Message == nil {
+				continue
+			}
+			for _, c := range env.Message.Content {
+				if c.Type != "tool_result" {
+					continue
+				}
+				pd, ok := s.pendingDispatches[c.ToolUseID]
+				if !ok {
+					// not a tracked mcp dispatch — discard (Phase 1 behaviour preserved)
+					continue
+				}
+				elapsed := time.Since(pd.startedAt).Milliseconds()
+				delete(s.pendingDispatches, c.ToolUseID)
+
+				// Parse the butlermcp dispatch result JSON.
+				// Schema: {"status":"done"|"running"|"error", "taskId":"…", "error":"…"}
+				// "running" means the worker degraded to async.
+				var result struct {
+					Status string `json:"status"`
+					TaskID string `json:"taskId"`
+					Error  string `json:"error"`
+				}
+				_ = json.Unmarshal([]byte(c.Content), &result)
+
+				phase := result.Status
+				switch phase {
+				case "done":
+					// inline completion
+				case "running":
+					phase = "async"
+				case "error":
+					// keep as-is
+				default:
+					if c.IsError {
+						phase = "error"
+					} else {
+						phase = "done"
+					}
+				}
+
+				taskID := result.TaskID
+				if taskID == "" {
+					taskID = pd.toolUseID
+				}
+				errMsg := result.Error
+				log.Infof("claude-code: mcp dispatch result sid=%s id=%s phase=%s elapsed=%dms", s.id, taskID, phase, elapsed)
+				s.emit(agent.Event{
+					Type: agent.EvDispatchStatus,
+					Dispatch: &agent.DispatchStatus{
+						Phase:     phase,
+						TaskID:    taskID,
+						Cwd:       pd.cwd,
+						Title:     pd.title,
+						ElapsedMs: elapsed,
+						Error:     errMsg,
+					},
+				})
+			}
 		case "result":
 			if env.Usage != nil {
 				s.emit(agent.Event{
@@ -687,4 +800,31 @@ func summarizeToolInput(name string, raw json.RawMessage) string {
 	default:
 		return ""
 	}
+}
+
+// truncateDispatchTitle truncates a dispatch task description to at most 24
+// Unicode code points or 48 bytes, whichever limit is hit first, appending "…"
+// when truncation occurs. This keeps the title safe for the 1.47" display.
+func truncateDispatchTitle(s string) string {
+	const maxRunes = 24
+	const maxBytes = 48
+	if len(s) <= maxBytes {
+		r := []rune(s)
+		if len(r) <= maxRunes {
+			return s
+		}
+		return string(r[:maxRunes]) + "…"
+	}
+	// byte limit: walk rune-by-rune to stay valid UTF-8
+	n := 0
+	runeCount := 0
+	for i, r := range s {
+		if runeCount >= maxRunes || i >= maxBytes {
+			_ = i
+			break
+		}
+		n += len(string(r))
+		runeCount++
+	}
+	return s[:n] + "…"
 }

--- a/adapter/internal/agent/driver.go
+++ b/adapter/internal/agent/driver.go
@@ -28,13 +28,14 @@ const (
 type EventType string
 
 const (
-	EvText        EventType = "text"         // assistant text fragment
-	EvToolCall    EventType = "tool_call"    // permission request (Capabilities.ToolApproval)
-	EvStatus      EventType = "status"       // running/waiting/idle/offline
-	EvTokens      EventType = "tokens"       // usage stats
-	EvError       EventType = "error"        // driver-level error
-	EvTurnEnd     EventType = "turn_end"     // one assistant turn finished
-	EvSessionInit EventType = "session_init" // CLI reported its real session id (Text field)
+	EvText           EventType = "text"            // assistant text fragment
+	EvToolCall       EventType = "tool_call"       // permission request (Capabilities.ToolApproval)
+	EvStatus         EventType = "status"          // running/waiting/idle/offline
+	EvTokens         EventType = "tokens"          // usage stats
+	EvError          EventType = "error"           // driver-level error
+	EvTurnEnd        EventType = "turn_end"        // one assistant turn finished
+	EvSessionInit    EventType = "session_init"    // CLI reported its real session id (Text field)
+	EvDispatchStatus EventType = "dispatch_status" // mcp__bbclaw__ tool dispatch progress (ADR-021 §1.2)
 )
 
 // Event is the single type every driver emits on its Events channel.
@@ -44,8 +45,25 @@ type Event struct {
 
 	Text string // text / status / error payload
 
-	Tool   *ToolCall
-	Tokens *Tokens
+	Tool     *ToolCall
+	Tokens   *Tokens
+	Dispatch *DispatchStatus // set when Type == EvDispatchStatus
+}
+
+// DispatchStatus carries butler dispatch progress for mcp__bbclaw__* tool calls
+// (ADR-021-firmware-ui §1.2). Phase transitions:
+//
+//	started → running (implicit, via startedAt tracking) → done | async | error
+//
+// ElapsedMs is the wall-clock duration from started to the final phase.
+// For "async" it equals the inline-wait timeout in milliseconds.
+type DispatchStatus struct {
+	Phase     string // "started" | "done" | "async" | "error"
+	TaskID    string // claude tool_use.id for started; butlermcp taskId for done/async/error
+	Cwd       string // resolved working directory (basename)
+	Title     string // task description, truncated to 24 CJK chars / 48 bytes
+	ElapsedMs int64  // 0 for "started"; wall-clock ms for terminal phases
+	Error     string // non-empty on phase="error"
 }
 
 type ToolCall struct {

--- a/adapter/internal/butler/dispatch_recorder.go
+++ b/adapter/internal/butler/dispatch_recorder.go
@@ -1,0 +1,119 @@
+package butler
+
+import (
+	"sync"
+	"time"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+)
+
+const dispatchRingCap = 50
+
+// DispatchEntry is one recorded dispatch task, surfaced by
+// GET /v1/butler/dispatch/recent (ADR-021-firmware-ui §1.4).
+type DispatchEntry struct {
+	TaskID    string    `json:"taskId"`
+	Cwd       string    `json:"cwd"`
+	Title     string    `json:"title"`
+	Status    string    `json:"status"`    // "started" | "done" | "async" | "error"
+	StartedAt time.Time `json:"startedAt"`
+	ElapsedMs int64     `json:"elapsedMs,omitempty"`
+	Error     string    `json:"error,omitempty"`
+}
+
+// DispatchRecorder is a process-level in-memory ring buffer that tracks
+// mcp__bbclaw__ dispatch events consumed from EvDispatchStatus events.
+// It is safe for concurrent use (HTTP handler reads, driver goroutine writes).
+//
+// The recorder is intentionally a singleton per adapter process; it is reset
+// on restart (v1 limitation — see ADR-021 §1.4).
+type DispatchRecorder struct {
+	mu      sync.RWMutex
+	entries []*DispatchEntry        // ring: newest appended to tail
+	byID    map[string]*DispatchEntry // taskId → entry for fast update
+}
+
+// NewDispatchRecorder creates an empty recorder.
+func NewDispatchRecorder() *DispatchRecorder {
+	return &DispatchRecorder{
+		byID: make(map[string]*DispatchEntry, dispatchRingCap),
+	}
+}
+
+// Record updates the ring buffer from an EvDispatchStatus event.
+// "started" phase creates a new entry keyed by TaskID (the claude tool_use.id).
+// Terminal phases (done/async/error) look up by TaskID and update status.
+func (r *DispatchRecorder) Record(ev agent.Event) {
+	if ev.Type != agent.EvDispatchStatus || ev.Dispatch == nil {
+		return
+	}
+	d := ev.Dispatch
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	switch d.Phase {
+	case "started":
+		entry := &DispatchEntry{
+			TaskID:    d.TaskID,
+			Cwd:       d.Cwd,
+			Title:     d.Title,
+			Status:    "started",
+			StartedAt: time.Now(),
+		}
+		r.entries = append(r.entries, entry)
+		r.byID[d.TaskID] = entry
+		// evict oldest when over capacity
+		if len(r.entries) > dispatchRingCap {
+			oldest := r.entries[0]
+			r.entries = r.entries[1:]
+			delete(r.byID, oldest.TaskID)
+		}
+	default:
+		// terminal phase: update existing entry
+		if entry, ok := r.byID[d.TaskID]; ok {
+			entry.Status = d.Phase
+			entry.ElapsedMs = d.ElapsedMs
+			entry.Error = d.Error
+		}
+		// If no existing entry (e.g. recorder started after started event),
+		// create a minimal entry so we don't lose the data entirely.
+		if _, ok := r.byID[d.TaskID]; !ok {
+			entry := &DispatchEntry{
+				TaskID:    d.TaskID,
+				Cwd:       d.Cwd,
+				Title:     d.Title,
+				Status:    d.Phase,
+				StartedAt: time.Now(),
+				ElapsedMs: d.ElapsedMs,
+				Error:     d.Error,
+			}
+			r.entries = append(r.entries, entry)
+			r.byID[d.TaskID] = entry
+			if len(r.entries) > dispatchRingCap {
+				oldest := r.entries[0]
+				r.entries = r.entries[1:]
+				delete(r.byID, oldest.TaskID)
+			}
+		}
+	}
+}
+
+// Recent returns the most recent n entries in reverse-chronological order
+// (newest first). If n <= 0 or n > len(entries), all entries are returned.
+func (r *DispatchRecorder) Recent(n int) []DispatchEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	total := len(r.entries)
+	if total == 0 {
+		return []DispatchEntry{}
+	}
+	if n <= 0 || n > total {
+		n = total
+	}
+	// entries is chronological (oldest first); return newest-first slice
+	out := make([]DispatchEntry, n)
+	for i := 0; i < n; i++ {
+		out[i] = *r.entries[total-1-i]
+	}
+	return out
+}

--- a/adapter/internal/butler/dispatch_recorder_test.go
+++ b/adapter/internal/butler/dispatch_recorder_test.go
@@ -1,0 +1,118 @@
+package butler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+)
+
+func makeStarted(taskID, cwd, title string) agent.Event {
+	return agent.Event{
+		Type: agent.EvDispatchStatus,
+		Dispatch: &agent.DispatchStatus{
+			Phase:  "started",
+			TaskID: taskID,
+			Cwd:    cwd,
+			Title:  title,
+		},
+	}
+}
+
+func makeDone(taskID string, elapsedMs int64) agent.Event {
+	return agent.Event{
+		Type: agent.EvDispatchStatus,
+		Dispatch: &agent.DispatchStatus{
+			Phase:     "done",
+			TaskID:    taskID,
+			ElapsedMs: elapsedMs,
+		},
+	}
+}
+
+// TestDispatchRecorder_Empty verifies that Recent returns [] when empty.
+func TestDispatchRecorder_Empty(t *testing.T) {
+	r := NewDispatchRecorder()
+	got := r.Recent(20)
+	if len(got) != 0 {
+		t.Errorf("want empty slice, got %d entries", len(got))
+	}
+}
+
+// TestDispatchRecorder_FiveEntries_ReverseChrono verifies newest-first ordering.
+func TestDispatchRecorder_FiveEntries_ReverseChrono(t *testing.T) {
+	r := NewDispatchRecorder()
+	for i := 1; i <= 5; i++ {
+		r.Record(makeStarted(fmt.Sprintf("task-%d", i), "proj", fmt.Sprintf("task %d", i)))
+	}
+	got := r.Recent(5)
+	if len(got) != 5 {
+		t.Fatalf("want 5 entries, got %d", len(got))
+	}
+	// Newest first: task-5 should be index 0
+	if got[0].TaskID != "task-5" {
+		t.Errorf("want task-5 first, got %q", got[0].TaskID)
+	}
+	if got[4].TaskID != "task-1" {
+		t.Errorf("want task-1 last, got %q", got[4].TaskID)
+	}
+}
+
+// TestDispatchRecorder_RingEvictsOldest verifies that entries beyond cap 50
+// evict the oldest entry.
+func TestDispatchRecorder_RingEvictsOldest(t *testing.T) {
+	r := NewDispatchRecorder()
+	// Insert 51 entries
+	for i := 1; i <= 51; i++ {
+		r.Record(makeStarted(fmt.Sprintf("task-%d", i), "proj", "t"))
+	}
+	// ring should hold exactly 50
+	got := r.Recent(0) // 0 = all
+	if len(got) != 50 {
+		t.Fatalf("want 50 entries after cap eviction, got %d", len(got))
+	}
+	// oldest evicted should be task-1; task-2 should be the oldest remaining
+	// (Recent returns newest-first, so last element is the oldest)
+	oldest := got[len(got)-1]
+	if oldest.TaskID != "task-2" {
+		t.Errorf("want task-2 as oldest remaining, got %q", oldest.TaskID)
+	}
+	// task-1 should not be in the map
+	r.mu.RLock()
+	_, exists := r.byID["task-1"]
+	r.mu.RUnlock()
+	if exists {
+		t.Error("task-1 should have been evicted from byID map")
+	}
+}
+
+// TestDispatchRecorder_UpdateTerminalPhase verifies that done/async/error
+// updates the status of an existing started entry.
+func TestDispatchRecorder_UpdateTerminalPhase(t *testing.T) {
+	r := NewDispatchRecorder()
+	r.Record(makeStarted("task-x", "proj", "my task"))
+	r.Record(makeDone("task-x", 3200))
+
+	got := r.Recent(1)
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+	if got[0].Status != "done" {
+		t.Errorf("want status=done, got %q", got[0].Status)
+	}
+	if got[0].ElapsedMs != 3200 {
+		t.Errorf("want elapsedMs=3200, got %d", got[0].ElapsedMs)
+	}
+}
+
+// TestDispatchRecorder_LimitCap verifies that Recent respects the n limit.
+func TestDispatchRecorder_LimitCap(t *testing.T) {
+	r := NewDispatchRecorder()
+	for i := 1; i <= 30; i++ {
+		r.Record(makeStarted(fmt.Sprintf("task-%d", i), "proj", "t"))
+	}
+	got := r.Recent(20)
+	if len(got) != 20 {
+		t.Errorf("want 20 with limit=20, got %d", len(got))
+	}
+}

--- a/adapter/internal/butler/engine.go
+++ b/adapter/internal/butler/engine.go
@@ -32,6 +32,12 @@ type Deps struct {
 	Metrics  MetricsSink
 	Log      Logger
 
+	// DispatchRecorder is the process-level ring buffer for mcp__bbclaw__
+	// dispatch events (ADR-021-firmware-ui §1.4). Optional: when nil dispatch
+	// events are still forwarded to the device but not recorded for the
+	// GET /v1/butler/dispatch/recent API. Wired by main.go.
+	DispatchRecorder *DispatchRecorder
+
 	// ResolveActiveModel 注入:两 caller 各传自己的。driver 为驱动名,返回持久化
 	// active_model 或 ""。butler 不缓存其结果以保留 ADR-016 mid-session 语义。
 	ResolveActiveModel func(driver string) string
@@ -440,6 +446,11 @@ func (e *Engine) RunTurn(turnCtx context.Context, req Request) (*Result, error) 
 					}
 				case agent.EvTurnEnd:
 					turnEnded = true
+				case agent.EvDispatchStatus:
+					// Record into ring buffer (non-driver layer, ADR-021 §1.4).
+					if d.DispatchRecorder != nil {
+						d.DispatchRecorder.Record(ev)
+					}
 				}
 
 				// EvSessionInit 一律不外发(两边一致)。

--- a/adapter/internal/httpapi/agent.go
+++ b/adapter/internal/httpapi/agent.go
@@ -699,6 +699,7 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 		SystemPrompt:       butler.DeviceSystemPrompt,
 		ButlerMCPConfig:    s.butlerMCPConfig,
 		Memory:             s.memoryWriter,
+		DispatchRecorder:   s.dispatchRecorder,
 		StartCtx:           s.agentCtx,
 	})
 
@@ -1184,6 +1185,24 @@ func (s *Server) writeAgentEvent(sw *finishStreamWriter, ev agent.Event) bool {
 	case agent.EvSessionInit:
 		// Internal event — not forwarded to the device.
 		return true
+	case agent.EvDispatchStatus:
+		if ev.Dispatch != nil {
+			d := ev.Dispatch
+			dispatchFrame := map[string]any{
+				"phase":  d.Phase,
+				"taskId": d.TaskID,
+			}
+			if d.Cwd != "" {
+				dispatchFrame["cwd"] = d.Cwd
+			}
+			if d.ElapsedMs > 0 {
+				dispatchFrame["elapsedMs"] = d.ElapsedMs
+			}
+			if d.Error != "" {
+				dispatchFrame["error"] = d.Error
+			}
+			frame["dispatch"] = dispatchFrame
+		}
 	}
 	if err := sw.write(frame); err != nil {
 		s.log.Warnf("agent: write frame failed: %v", err)

--- a/adapter/internal/httpapi/agent_butler_dispatch.go
+++ b/adapter/internal/httpapi/agent_butler_dispatch.go
@@ -1,0 +1,42 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/butler"
+)
+
+// SetDispatchRecorder wires the process-level dispatch ring buffer into the
+// server so GET /v1/butler/dispatch/recent has data to serve.
+func (s *Server) SetDispatchRecorder(r *butler.DispatchRecorder) {
+	s.dispatchRecorder = r
+}
+
+// handleButlerDispatchRecent serves GET /v1/butler/dispatch/recent.
+// Returns up to 20 recent dispatch entries (newest first).
+// Query param: ?limit=N to override the default cap (max 50).
+//
+// Response: JSON array of DispatchEntry. Empty ring buffer → [].
+func (s *Server) handleButlerDispatchRecent(w http.ResponseWriter, r *http.Request) {
+	limit := 20
+	if q := r.URL.Query().Get("limit"); q != "" {
+		if n, err := strconv.Atoi(q); err == nil && n > 0 {
+			if n > 50 {
+				n = 50
+			}
+			limit = n
+		}
+	}
+
+	var entries []butler.DispatchEntry
+	if s.dispatchRecorder != nil {
+		entries = s.dispatchRecorder.Recent(limit)
+	} else {
+		entries = []butler.DispatchEntry{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(entries)
+}

--- a/adapter/internal/httpapi/agent_butler_dispatch_test.go
+++ b/adapter/internal/httpapi/agent_butler_dispatch_test.go
@@ -1,0 +1,153 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/butler"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
+)
+
+func newDispatchTestServer(rec *butler.DispatchRecorder) (*Server, *httptest.Server) {
+	srv := NewServer(AppConfig{}, nil, nil, nil, nil, obs.NewLogger(), obs.NewMetrics())
+	if rec != nil {
+		srv.SetDispatchRecorder(rec)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	return srv, ts
+}
+
+// TestHandleButlerDispatchRecent_Empty verifies that an empty ring buffer
+// returns a JSON array (not null).
+func TestHandleButlerDispatchRecent_Empty(t *testing.T) {
+	rec := butler.NewDispatchRecorder()
+	_, ts := newDispatchTestServer(rec)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/butler/dispatch/recent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var entries []butler.DispatchEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if entries == nil {
+		t.Error("want non-nil slice (empty array), got nil")
+	}
+	if len(entries) != 0 {
+		t.Errorf("want 0 entries, got %d", len(entries))
+	}
+}
+
+// TestHandleButlerDispatchRecent_HasEntries verifies that recorded entries
+// are returned newest-first and capped at 20.
+func TestHandleButlerDispatchRecent_HasEntries(t *testing.T) {
+	rec := butler.NewDispatchRecorder()
+	// Insert 5 entries
+	for i := 1; i <= 5; i++ {
+		rec.Record(agent.Event{
+			Type: agent.EvDispatchStatus,
+			Dispatch: &agent.DispatchStatus{
+				Phase:  "started",
+				TaskID: "task-" + string(rune('0'+i)),
+				Cwd:    "proj",
+				Title:  "task title",
+			},
+		})
+	}
+	_, ts := newDispatchTestServer(rec)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/butler/dispatch/recent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var entries []butler.DispatchEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("want 5 entries, got %d", len(entries))
+	}
+	// newest first: task-5 should be first
+	if entries[0].TaskID != "task-5" {
+		t.Errorf("want task-5 first, got %q", entries[0].TaskID)
+	}
+}
+
+// TestHandleButlerDispatchRecent_CapAt20 verifies that the endpoint returns
+// at most 20 entries by default.
+func TestHandleButlerDispatchRecent_CapAt20(t *testing.T) {
+	rec := butler.NewDispatchRecorder()
+	for i := 0; i < 30; i++ {
+		rec.Record(agent.Event{
+			Type: agent.EvDispatchStatus,
+			Dispatch: &agent.DispatchStatus{
+				Phase:  "started",
+				TaskID: "t",
+				Cwd:    "proj",
+				Title:  "t",
+			},
+		})
+	}
+	// Use unique IDs to avoid map collision
+	rec2 := butler.NewDispatchRecorder()
+	for i := 0; i < 30; i++ {
+		id := "task-" + string(rune('a'+i%26))
+		rec2.Record(agent.Event{
+			Type: agent.EvDispatchStatus,
+			Dispatch: &agent.DispatchStatus{Phase: "started", TaskID: id, Cwd: "proj", Title: "t"},
+		})
+	}
+
+	_, ts := newDispatchTestServer(rec2)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/butler/dispatch/recent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var entries []butler.DispatchEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(entries) > 20 {
+		t.Errorf("want at most 20 entries, got %d", len(entries))
+	}
+}
+
+// TestHandleButlerDispatchRecent_NilRecorder verifies graceful handling when
+// no recorder has been wired (returns empty array).
+func TestHandleButlerDispatchRecent_NilRecorder(t *testing.T) {
+	_, ts := newDispatchTestServer(nil)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/butler/dispatch/recent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var entries []butler.DispatchEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("want 0 entries with nil recorder, got %d", len(entries))
+	}
+}

--- a/adapter/internal/httpapi/server.go
+++ b/adapter/internal/httpapi/server.go
@@ -111,6 +111,11 @@ type Server struct {
 	// WebSocket hub for local_home device connections + notification queue.
 	wsHub      *WSHub
 	notifQueue *NotificationQueue
+
+	// dispatchRecorder is the process-level ring buffer for
+	// GET /v1/butler/dispatch/recent (ADR-021-firmware-ui §1.4).
+	// Wired via SetDispatchRecorder from main.go. Optional: nil disables the endpoint.
+	dispatchRecorder *butler.DispatchRecorder
 }
 
 func NewServer(cfg AppConfig, streams *audio.Manager, asrProvider ASRProvider, ttsProvider TTSProvider, sink OpenClawSink, logger *obs.Logger, metrics *obs.Metrics) *Server {
@@ -150,6 +155,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/agent/sessions/{id}/messages", s.withAuth(s.handleAgentSessionMessages))
 	mux.HandleFunc("POST /v1/agent/sessions/{id}/approve", s.withAuth(s.handleAgentSessionApprove))
 	mux.HandleFunc("DELETE /v1/agent/sessions/{id}", s.withAuth(s.handleAgentDeleteSession))
+	mux.HandleFunc("GET /v1/butler/dispatch/recent", s.withAuth(s.handleButlerDispatchRecent))
 	mux.HandleFunc("GET /ws", s.handleWebSocket)
 	// Playground is unauthenticated on purpose — it's a dev-only single-page
 	// UI for dogfooding agent drivers. Protect your adapter by not exposing


### PR DESCRIPTION
Fixes #102

## 变更概要

落地 ADR-021-firmware-ui §1.2 / §1.4，为 Task List 页（D）和顶部状态栏（E）提供数据源契约。

### 变更文件

**agent/driver.go**
- 新增 `EvDispatchStatus EventType`
- 新增 `DispatchStatus{Phase, TaskID, Cwd, Title, ElapsedMs, Error}` 结构体
- `Event` 添加 `Dispatch *DispatchStatus` 字段

**claudecode/driver.go**
- `streamContent` 添加 `ToolUseID`、`Content`、`IsError` 字段（解析 tool_result）
- `session` 添加 `pendingDispatches` map，用于关联 tool_use.id → started 元数据
- `tool_use` 分支：`mcp__bbclaw__` 前缀 → 发 `EvDispatchStatus(started)`，记入 pending；其余仍走 `EvToolCall`
- `case "user"`：解析 tool_result，对匹配 pending 的 dispatch 结果映射 done/async/error 三态，其余仍丢弃
- 新增 `truncateDispatchTitle()` 辅助函数（24 CJK / 48 bytes）

**butler/dispatch_recorder.go**（新文件）
- 进程级 ring buffer，容量 50，`sync.RWMutex` 保护
- `Record(ev)`：started 创建条目，terminal phase 更新状态
- `Recent(n)`：返回最近 n 条（newest-first），空时返回 `[]DispatchEntry{}`

**butler/engine.go**
- `Deps` 注入 `DispatchRecorder *DispatchRecorder`
- 事件循环添加 `case agent.EvDispatchStatus` → 调 `recorder.Record()`（非 driver 层，两者解耦）

**httpapi/agent.go**
- `writeAgentEvent` 添加 `EvDispatchStatus` case，输出 `{"type":"dispatch_status","seq":N,"dispatch":{...}}` 帧

**httpapi/agent_butler_dispatch.go**（新文件）
- `SetDispatchRecorder()` 注入方法
- `handleButlerDispatchRecent`：GET /v1/butler/dispatch/recent，默认 cap 20，最大 50，空时返回 `[]`

**httpapi/server.go**
- 注册路由 `GET /v1/butler/dispatch/recent`
- `Server` 添加 `dispatchRecorder` 字段

**main.go**
- 创建 `butler.NewDispatchRecorder()` 并调 `server.SetDispatchRecorder()`

## 测试

- `claudecode/dispatch_test.go`：done / async / error 三态 + 非 MCP tool_use 不回归 + 非 MCP tool_result 丢弃
- `butler/dispatch_recorder_test.go`：空返回 `[]`、5 条倒序、>50 条最老淘汰、terminal phase 更新、limit cap
- `httpapi/agent_butler_dispatch_test.go`：空 recorder、有条目最新排前、cap 20、nil recorder 降级
- `make test` 全包通过（27 个包，0 失败）

## 运行时验证

- 硬件（PTT + MCP dispatch 路径）需连接 ESP32-S3 设备验证，当前无硬件接入，已在 PR body 中说明
- Cloud relay pass-through 已兼容（bbclaw-reference/cloud 透传 event type，无需改动）