### PR TITLE
feat(adapter): Sub-PR C — dispatch_status 事件 + /v1/butler/dispatch/recent API

### DIFF
--- a/adapter/cmd/bbclaw-adapter/main.go
+++ b/adapter/cmd/bbclaw-adapter/main.go
@@ -174,6 +174,13 @@ func buildLocalServer(cfg config.Config, sink pipeline.Sink, cloudRelay *homeada
 		server.SetSessionManager(sessionMgr)
 		// Route local agent turns to the per-device butler session (ADR-021).
 		server.SetButlerWorkspace(butlerWorkspace, butlerMCPConfig)
+		// Butler dispatch ring buffer (ADR-021-firmware-ui §1.4): track dispatch
+		// task progress and serve GET /v1/butler/dispatch/recent.
+		if butlerWorkspace != "" {
+			dispatchRing := butler.NewDispatchRing()
+			server.SetDispatchRing(dispatchRing)
+			logger.Infof("butler-dispatch: ring buffer enabled")
+		}
 		// Butler long-term memory (ADR-021 §4). LOCAL-only and gated off by
 		// default (BBCLAW_BUTLER_MEMORY_DISTILL); cloud relay never wires it.
 		if butlerWorkspace != "" {

--- a/adapter/internal/agent/claudecode/dispatch_test.go
+++ b/adapter/internal/agent/claudecode/dispatch_test.go
@@ -97,8 +97,8 @@ func TestParseStreamJSON_MCPDispatch_Error(t *testing.T) {
 	if evs[1].Dispatch == nil || evs[1].Dispatch.Phase != "error" {
 		t.Errorf("event 1: want phase=error, got %+v", evs[1].Dispatch)
 	}
-	if evs[1].Dispatch.Error != "timeout" {
-		t.Errorf("event 1: want error=timeout, got %q", evs[1].Dispatch.Error)
+	if evs[1].Dispatch.ErrorMsg != "timeout" {
+		t.Errorf("event 1: want error=timeout, got %q", evs[1].Dispatch.ErrorMsg)
 	}
 }
 

--- a/adapter/internal/agent/claudecode/driver.go
+++ b/adapter/internal/agent/claudecode/driver.go
@@ -482,10 +482,9 @@ type streamContent struct {
 	Text       string          `json:"text,omitempty"`
 	Name       string          `json:"name,omitempty"`
 	ID         string          `json:"id,omitempty"`
+	ToolUseID  string          `json:"tool_use_id,omitempty"` // present in tool_result frames
 	Input      json.RawMessage `json:"input,omitempty"`
-	ToolUseID  string          `json:"tool_use_id,omitempty"` // present in tool_result blocks
-	Content    string          `json:"content,omitempty"`     // tool_result text payload
-	IsError    bool            `json:"is_error,omitempty"`    // tool_result error flag
+	Content    json.RawMessage `json:"content,omitempty"` // tool_result content (string or array)
 }
 
 type streamUsage struct {
@@ -497,6 +496,10 @@ func parseStreamJSON(r io.Reader, s *session, log *obs.Logger) {
 	sc := bufio.NewScanner(r)
 	// stream-json can emit long lines (large tool_result payloads).
 	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	// toolUseNames maps tool_use.id → tool_use.name so that tool_result frames
+	// (in the "user" envelope) can look up which tool produced each result and
+	// decide whether to emit EvDispatchStatus (ADR-021-firmware-ui §1.2).
+	toolUseNames := make(map[string]string)
 	for sc.Scan() {
 		line := sc.Bytes()
 		if len(line) == 0 {
@@ -526,30 +529,14 @@ func parseStreamJSON(r io.Reader, s *session, log *obs.Logger) {
 						s.emit(agent.Event{Type: agent.EvText, Text: c.Text})
 					}
 				case "tool_use":
-					if strings.HasPrefix(c.Name, "mcp__bbclaw__") {
-						// MCP butler dispatch: emit EvDispatchStatus(started) and
-						// track in pendingDispatches for tool_result correlation.
-						var inp struct {
-							Project string `json:"project"`
-							Cwd     string `json:"cwd"`
-							Task    string `json:"task"`
-						}
-						_ = json.Unmarshal(c.Input, &inp)
-						cwd := inp.Cwd
-						if cwd == "" {
-							cwd = inp.Project
-						}
-						title := truncateDispatchTitle(inp.Task)
-						log.Infof("claude-code: mcp dispatch started sid=%s tool=%s id=%s cwd=%q title=%q", s.id, c.Name, c.ID, cwd, title)
-						if s.pendingDispatches == nil {
-							s.pendingDispatches = make(map[string]*pendingDispatch)
-						}
-						s.pendingDispatches[c.ID] = &pendingDispatch{
-							toolUseID: c.ID,
-							cwd:       cwd,
-							title:     title,
-							startedAt: time.Now(),
-						}
+					if isMCPBBClawDispatch(c.Name) {
+						// mcp__bbclaw__dispatch tool: emit EvDispatchStatus(started)
+						// so butler.Engine can record it in the ring buffer and
+						// the device can show "派发中: <cwd>…" in s_lbl_status.
+						// (ADR-021-firmware-ui §1.2)
+						toolUseNames[c.ID] = c.Name // track id→name for tool_result lookup
+						cwd, title := parseDispatchInput(c.Input)
+						log.Infof("claude-code: dispatch started sid=%s id=%s cwd=%q", s.id, c.ID, cwd)
 						s.emit(agent.Event{
 							Type: agent.EvDispatchStatus,
 							Dispatch: &agent.DispatchStatus{
@@ -560,10 +547,8 @@ func parseStreamJSON(r io.Reader, s *session, log *obs.Logger) {
 							},
 						})
 					} else {
-						// Display-only: we surface tool_use frames as EvToolCall
-						// so the playground / device UI can render them, but
-						// Capabilities().ToolApproval stays false because the
-						// approval round-trip is not yet implemented (Phase 2).
+						// All other tool_use frames: surface as EvToolCall (display-only).
+						// Capabilities().ToolApproval stays false (Phase 2).
 						hint := summarizeToolInput(c.Name, c.Input)
 						log.Infof("claude-code: tool_use sid=%s tool=%s id=%s hint=%q", s.id, c.Name, c.ID, hint)
 						s.emit(agent.Event{
@@ -578,66 +563,16 @@ func parseStreamJSON(r io.Reader, s *session, log *obs.Logger) {
 				}
 			}
 		case "user":
-			// tool_result frames: parse mcp__bbclaw__ dispatch results into
-			// EvDispatchStatus events. Other tool_results are still discarded.
-			if env.Message == nil {
-				continue
-			}
-			for _, c := range env.Message.Content {
-				if c.Type != "tool_result" {
-					continue
-				}
-				pd, ok := s.pendingDispatches[c.ToolUseID]
-				if !ok {
-					// not a tracked mcp dispatch — discard (Phase 1 behaviour preserved)
-					continue
-				}
-				elapsed := time.Since(pd.startedAt).Milliseconds()
-				delete(s.pendingDispatches, c.ToolUseID)
-
-				// Parse the butlermcp dispatch result JSON.
-				// Schema: {"status":"done"|"running"|"error", "taskId":"…", "error":"…"}
-				// "running" means the worker degraded to async.
-				var result struct {
-					Status string `json:"status"`
-					TaskID string `json:"taskId"`
-					Error  string `json:"error"`
-				}
-				_ = json.Unmarshal([]byte(c.Content), &result)
-
-				phase := result.Status
-				switch phase {
-				case "done":
-					// inline completion
-				case "running":
-					phase = "async"
-				case "error":
-					// keep as-is
-				default:
-					if c.IsError {
-						phase = "error"
-					} else {
-						phase = "done"
+			// tool_result frames: parse MCP bbclaw dispatch results and emit
+			// EvDispatchStatus. All other tool_results remain ignored (Phase 1).
+			if env.Message != nil {
+				for _, c := range env.Message.Content {
+					if c.Type == "tool_result" && isMCPBBClawDispatch(toolUseNames[c.ToolUseID]) {
+						ds := parseDispatchResult(c.ToolUseID, c.Content)
+						log.Infof("claude-code: dispatch result sid=%s id=%s phase=%s elapsed=%dms", s.id, ds.TaskID, ds.Phase, ds.ElapsedMs)
+						s.emit(agent.Event{Type: agent.EvDispatchStatus, Dispatch: ds})
 					}
 				}
-
-				taskID := result.TaskID
-				if taskID == "" {
-					taskID = pd.toolUseID
-				}
-				errMsg := result.Error
-				log.Infof("claude-code: mcp dispatch result sid=%s id=%s phase=%s elapsed=%dms", s.id, taskID, phase, elapsed)
-				s.emit(agent.Event{
-					Type: agent.EvDispatchStatus,
-					Dispatch: &agent.DispatchStatus{
-						Phase:     phase,
-						TaskID:    taskID,
-						Cwd:       pd.cwd,
-						Title:     pd.title,
-						ElapsedMs: elapsed,
-						Error:     errMsg,
-					},
-				})
 			}
 		case "result":
 			if env.Usage != nil {
@@ -802,29 +737,110 @@ func summarizeToolInput(name string, raw json.RawMessage) string {
 	}
 }
 
-// truncateDispatchTitle truncates a dispatch task description to at most 24
-// Unicode code points or 48 bytes, whichever limit is hit first, appending "…"
-// when truncation occurs. This keeps the title safe for the 1.47" display.
-func truncateDispatchTitle(s string) string {
-	const maxRunes = 24
-	const maxBytes = 48
-	if len(s) <= maxBytes {
-		r := []rune(s)
-		if len(r) <= maxRunes {
-			return s
-		}
-		return string(r[:maxRunes]) + "…"
+// ─── dispatch helpers (ADR-021-firmware-ui §1.2) ────────────────────────────
+
+// mcpBBClawDispatchTool is the exact tool name that signals a butler dispatch.
+// Only this tool emits EvDispatchStatus; other mcp__bbclaw__* tools (list_projects,
+// task_status, task_result) continue to emit EvToolCall as usual, avoiding
+// spurious "派发中…" labels for non-dispatch MCP calls.
+const mcpBBClawDispatchTool = "mcp__bbclaw__dispatch"
+
+// isMCPBBClawDispatch returns true iff name is exactly the dispatch tool.
+func isMCPBBClawDispatch(name string) bool {
+	return name == mcpBBClawDispatchTool
+}
+
+// parseDispatchInput extracts cwd and title from the dispatch tool_use input JSON.
+// Returns empty strings on any parse error (non-fatal: ring buffer just has less info).
+// Accepts both new schema (cwd/prompt) and legacy schema (project/task).
+func parseDispatchInput(raw json.RawMessage) (cwd, title string) {
+	if len(raw) == 0 {
+		return "", ""
 	}
-	// byte limit: walk rune-by-rune to stay valid UTF-8
-	n := 0
-	runeCount := 0
-	for i, r := range s {
-		if runeCount >= maxRunes || i >= maxBytes {
-			_ = i
-			break
-		}
-		n += len(string(r))
-		runeCount++
+	var in struct {
+		Cwd     string `json:"cwd"`
+		Prompt  string `json:"prompt"`
+		Project string `json:"project"` // legacy field name
+		Task    string `json:"task"`    // legacy field name
 	}
-	return s[:n] + "…"
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return "", ""
+	}
+	cwd = strings.TrimSpace(in.Cwd)
+	if cwd == "" {
+		cwd = strings.TrimSpace(in.Project)
+	}
+	prompt := strings.TrimSpace(in.Prompt)
+	if prompt == "" {
+		prompt = strings.TrimSpace(in.Task)
+	}
+	return cwd, truncateCJK(prompt, 24)
+}
+
+// dispatchResultContent is the JSON shape the MCP dispatch tool returns.
+type dispatchResultContent struct {
+	Status    string `json:"status"`    // "done" | "running" | "async" | "error"
+	TaskID    string `json:"taskId"`
+	ElapsedMs int64  `json:"elapsedMs"`
+	Error     string `json:"error"`
+}
+
+// parseDispatchResult parses a tool_result content blob from the "user" envelope.
+// toolUseID is the originating tool_use.id (used as TaskID fallback).
+// content is json.RawMessage that may be a JSON string or a JSON array of content blocks.
+func parseDispatchResult(toolUseID string, raw json.RawMessage) *agent.DispatchStatus {
+	ds := &agent.DispatchStatus{TaskID: toolUseID, Phase: "done"}
+	if len(raw) == 0 {
+		return ds
+	}
+
+	// content can be a bare JSON string or an array like [{"type":"text","text":"..."}]
+	var text string
+	if raw[0] == '"' {
+		_ = json.Unmarshal(raw, &text)
+	} else if raw[0] == '[' {
+		var blocks []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(raw, &blocks); err == nil {
+			for _, b := range blocks {
+				if b.Type == "text" {
+					text = b.Text
+					break
+				}
+			}
+		}
+	} else {
+		// Try direct object parse
+		text = string(raw)
+	}
+
+	// Try to parse the text as dispatchResultContent JSON
+	var res dispatchResultContent
+	if err := json.Unmarshal([]byte(text), &res); err == nil {
+		if res.TaskID != "" {
+			ds.TaskID = res.TaskID
+		}
+		if res.Status != "" {
+			phase := res.Status
+			if phase == "running" {
+				phase = "async"
+			}
+			ds.Phase = phase
+		}
+		ds.ElapsedMs = res.ElapsedMs
+		ds.ErrorMsg = res.Error
+	}
+	return ds
+}
+
+// truncateCJK truncates s to at most maxCJK CJK characters (or 2*maxCJK bytes
+// for ASCII-only strings), appending "…" when truncation occurs.
+func truncateCJK(s string, maxCJK int) string {
+	runes := []rune(s)
+	if len(runes) <= maxCJK {
+		return s
+	}
+	return string(runes[:maxCJK]) + "…"
 }

--- a/adapter/internal/agent/claudecode/driver_test.go
+++ b/adapter/internal/agent/claudecode/driver_test.go
@@ -288,3 +288,160 @@ func TestDefaultModelMatchesCatalog(t *testing.T) {
 		t.Errorf("default model %q is not in the catalog", def)
 	}
 }
+
+// ─── dispatch_status tests (ADR-021-firmware-ui §1.2) ───────────────────────
+
+// TestParseStreamJSONDispatchStarted verifies that mcp__bbclaw__dispatch tool_use
+// frames emit EvDispatchStatus(started) instead of EvToolCall.
+func TestParseStreamJSONDispatchStarted(t *testing.T) {
+	const transcript = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_disp1","name":"mcp__bbclaw__dispatch","input":{"cwd":"bbclaw","prompt":"重构 auth"}}]}}
+`
+	s := &session{id: "sid-test", events: make(chan agent.Event, 16), rootCtx: context.Background()}
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("want 1 event, got %d: %+v", len(evs), evs)
+	}
+	ev := evs[0]
+	if ev.Type != agent.EvDispatchStatus {
+		t.Fatalf("want EvDispatchStatus, got %v", ev.Type)
+	}
+	if ev.Dispatch == nil {
+		t.Fatal("Dispatch field is nil")
+	}
+	if ev.Dispatch.Phase != "started" {
+		t.Errorf("want phase=started, got %q", ev.Dispatch.Phase)
+	}
+	if ev.Dispatch.TaskID != "tu_disp1" {
+		t.Errorf("want taskId=tu_disp1, got %q", ev.Dispatch.TaskID)
+	}
+	if ev.Dispatch.Cwd != "bbclaw" {
+		t.Errorf("want cwd=bbclaw, got %q", ev.Dispatch.Cwd)
+	}
+}
+
+// TestParseStreamJSONNonDispatchMCPToolStillEvToolCall verifies that other
+// mcp__bbclaw__* tools (list_projects, task_status, task_result) are NOT
+// treated as dispatch and still emit EvToolCall.
+func TestParseStreamJSONNonDispatchMCPToolStillEvToolCall(t *testing.T) {
+	const transcript = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_ls","name":"mcp__bbclaw__list_projects","input":{}}]}}
+`
+	s := &session{id: "sid-test", events: make(chan agent.Event, 16), rootCtx: context.Background()}
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("want 1 event, got %d", len(evs))
+	}
+	if evs[0].Type != agent.EvToolCall {
+		t.Errorf("want EvToolCall for non-dispatch MCP tool, got %v", evs[0].Type)
+	}
+}
+
+// TestParseStreamJSONDispatchToolResult verifies that a tool_result frame for
+// mcp__bbclaw__dispatch emits EvDispatchStatus with the parsed phase/elapsedMs.
+// The transcript must contain the tool_use frame first so toolUseNames is populated.
+func TestParseStreamJSONDispatchToolResult(t *testing.T) {
+	// tool_use first so the parser maps tu_disp1 → mcp__bbclaw__dispatch
+	// tool_result content is a JSON-encoded string (quotes escaped inside the outer JSON)
+	const transcript = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_disp1","name":"mcp__bbclaw__dispatch","input":{"cwd":"bbclaw","prompt":"重构 auth"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_disp1","content":"{\"status\":\"done\",\"taskId\":\"tu_disp1\",\"elapsedMs\":3200}"}]}}
+`
+	s := &session{id: "sid-test", events: make(chan agent.Event, 16), rootCtx: context.Background()}
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	// expect: 1 EvDispatchStatus(started) + 1 EvDispatchStatus(done)
+	if len(evs) != 2 {
+		t.Fatalf("want 2 events (started+done), got %d: %+v", len(evs), evs)
+	}
+	if evs[0].Type != agent.EvDispatchStatus || evs[0].Dispatch.Phase != "started" {
+		t.Errorf("event 0: want EvDispatchStatus(started), got %+v", evs[0])
+	}
+	ev := evs[1]
+	if ev.Type != agent.EvDispatchStatus {
+		t.Fatalf("event 1: want EvDispatchStatus, got %v", ev.Type)
+	}
+	if ev.Dispatch.Phase != "done" {
+		t.Errorf("want phase=done, got %q", ev.Dispatch.Phase)
+	}
+	if ev.Dispatch.ElapsedMs != 3200 {
+		t.Errorf("want elapsedMs=3200, got %d", ev.Dispatch.ElapsedMs)
+	}
+}
+
+// TestParseStreamJSONDispatchAsyncPhase verifies the async phase parsing.
+func TestParseStreamJSONDispatchAsyncPhase(t *testing.T) {
+	const transcript = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_async1","name":"mcp__bbclaw__dispatch","input":{"cwd":"proj","prompt":"大重构"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_async1","content":"{\"status\":\"async\",\"taskId\":\"tu_async1\"}"}]}}
+`
+	s := &session{id: "sid-test", events: make(chan agent.Event, 16), rootCtx: context.Background()}
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	if len(evs) != 2 {
+		t.Fatalf("want 2 events, got %d", len(evs))
+	}
+	if evs[1].Dispatch.Phase != "async" {
+		t.Errorf("want phase=async, got %q", evs[1].Dispatch.Phase)
+	}
+}
+
+// TestParseStreamJSONDispatchErrorPhase verifies the error phase and ErrorMsg.
+func TestParseStreamJSONDispatchErrorPhase(t *testing.T) {
+	const transcript = `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu_err1","name":"mcp__bbclaw__dispatch","input":{"cwd":"proj","prompt":"lint"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu_err1","content":"{\"status\":\"error\",\"taskId\":\"tu_err1\",\"error\":\"timeout\"}"}]}}
+`
+	s := &session{id: "sid-test", events: make(chan agent.Event, 16), rootCtx: context.Background()}
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	if len(evs) != 2 {
+		t.Fatalf("want 2 events, got %d", len(evs))
+	}
+	if evs[1].Dispatch.Phase != "error" {
+		t.Errorf("want phase=error, got %q", evs[1].Dispatch.Phase)
+	}
+	if evs[1].Dispatch.ErrorMsg != "timeout" {
+		t.Errorf("want error=timeout, got %q", evs[1].Dispatch.ErrorMsg)
+	}
+}
+
+// TestParseStreamJSONNonMCPToolResultIgnored verifies that a tool_result for a
+// non-mcp__bbclaw__dispatch tool_use_id is silently ignored (no events emitted).
+func TestParseStreamJSONNonMCPToolResultIgnored(t *testing.T) {
+	const transcript = `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"bash_123","content":"exit 0"}]}}
+`
+	s := &session{id: "sid-test", events: make(chan agent.Event, 16), rootCtx: context.Background()}
+	parseStreamJSON(strings.NewReader(transcript), s, obs.NewLogger())
+	close(s.events)
+
+	var evs []agent.Event
+	for e := range s.events {
+		evs = append(evs, e)
+	}
+	if len(evs) != 0 {
+		t.Errorf("want 0 events for non-dispatch tool_result, got %d: %+v", len(evs), evs)
+	}
+}

--- a/adapter/internal/agent/driver.go
+++ b/adapter/internal/agent/driver.go
@@ -28,14 +28,14 @@ const (
 type EventType string
 
 const (
-	EvText           EventType = "text"            // assistant text fragment
-	EvToolCall       EventType = "tool_call"       // permission request (Capabilities.ToolApproval)
-	EvStatus         EventType = "status"          // running/waiting/idle/offline
-	EvTokens         EventType = "tokens"          // usage stats
-	EvError          EventType = "error"           // driver-level error
-	EvTurnEnd        EventType = "turn_end"        // one assistant turn finished
-	EvSessionInit    EventType = "session_init"    // CLI reported its real session id (Text field)
-	EvDispatchStatus EventType = "dispatch_status" // mcp__bbclaw__ tool dispatch progress (ADR-021 §1.2)
+	EvText            EventType = "text"            // assistant text fragment
+	EvToolCall        EventType = "tool_call"       // permission request (Capabilities.ToolApproval)
+	EvStatus          EventType = "status"          // running/waiting/idle/offline
+	EvTokens          EventType = "tokens"          // usage stats
+	EvError           EventType = "error"           // driver-level error
+	EvTurnEnd         EventType = "turn_end"        // one assistant turn finished
+	EvSessionInit     EventType = "session_init"    // CLI reported its real session id (Text field)
+	EvDispatchStatus  EventType = "dispatch_status" // MCP bbclaw tool dispatch progress (ADR-021-firmware-ui §1.2)
 )
 
 // Event is the single type every driver emits on its Events channel.
@@ -47,23 +47,25 @@ type Event struct {
 
 	Tool     *ToolCall
 	Tokens   *Tokens
-	Dispatch *DispatchStatus // set when Type == EvDispatchStatus
+	Dispatch *DispatchStatus // non-nil when Type == EvDispatchStatus
 }
 
-// DispatchStatus carries butler dispatch progress for mcp__bbclaw__* tool calls
-// (ADR-021-firmware-ui §1.2). Phase transitions:
-//
-//	started → running (implicit, via startedAt tracking) → done | async | error
-//
-// ElapsedMs is the wall-clock duration from started to the final phase.
-// For "async" it equals the inline-wait timeout in milliseconds.
+// DispatchStatus carries butler dispatch progress information (ADR-021-firmware-ui §1.2).
+// Emitted by the claudecode driver when it observes mcp__bbclaw__dispatch tool_use /
+// tool_result frames; consumed by butler.Engine to maintain the ring buffer.
 type DispatchStatus struct {
-	Phase     string // "started" | "done" | "async" | "error"
-	TaskID    string // claude tool_use.id for started; butlermcp taskId for done/async/error
-	Cwd       string // resolved working directory (basename)
-	Title     string // task description, truncated to 24 CJK chars / 48 bytes
-	ElapsedMs int64  // 0 for "started"; wall-clock ms for terminal phases
-	Error     string // non-empty on phase="error"
+	// Phase is one of: "started" | "done" | "running" | "async" | "error"
+	Phase string
+	// TaskID is the tool_use.id from the claude stream (or MCP-returned taskId).
+	TaskID string
+	// Cwd is the dispatch target project path (populated from tool_use input; may be empty).
+	Cwd string
+	// Title is the truncated dispatch prompt (up to 24 CJK chars / 48 bytes).
+	Title string
+	// ElapsedMs is the worker elapsed time in milliseconds (populated for done/async phases).
+	ElapsedMs int64
+	// ErrorMsg holds the failure description when Phase == "error".
+	ErrorMsg string
 }
 
 type ToolCall struct {

--- a/adapter/internal/butler/dispatch_recorder.go
+++ b/adapter/internal/butler/dispatch_recorder.go
@@ -9,18 +9,6 @@ import (
 
 const dispatchRingCap = 50
 
-// DispatchEntry is one recorded dispatch task, surfaced by
-// GET /v1/butler/dispatch/recent (ADR-021-firmware-ui §1.4).
-type DispatchEntry struct {
-	TaskID    string    `json:"taskId"`
-	Cwd       string    `json:"cwd"`
-	Title     string    `json:"title"`
-	Status    string    `json:"status"`    // "started" | "done" | "async" | "error"
-	StartedAt time.Time `json:"startedAt"`
-	ElapsedMs int64     `json:"elapsedMs,omitempty"`
-	Error     string    `json:"error,omitempty"`
-}
-
 // DispatchRecorder is a process-level in-memory ring buffer that tracks
 // mcp__bbclaw__ dispatch events consumed from EvDispatchStatus events.
 // It is safe for concurrent use (HTTP handler reads, driver goroutine writes).
@@ -73,7 +61,7 @@ func (r *DispatchRecorder) Record(ev agent.Event) {
 		if entry, ok := r.byID[d.TaskID]; ok {
 			entry.Status = d.Phase
 			entry.ElapsedMs = d.ElapsedMs
-			entry.Error = d.Error
+			entry.ErrorMsg = d.ErrorMsg
 		}
 		// If no existing entry (e.g. recorder started after started event),
 		// create a minimal entry so we don't lose the data entirely.
@@ -85,7 +73,7 @@ func (r *DispatchRecorder) Record(ev agent.Event) {
 				Status:    d.Phase,
 				StartedAt: time.Now(),
 				ElapsedMs: d.ElapsedMs,
-				Error:     d.Error,
+				ErrorMsg:  d.ErrorMsg,
 			}
 			r.entries = append(r.entries, entry)
 			r.byID[d.TaskID] = entry

--- a/adapter/internal/butler/dispatch_ring.go
+++ b/adapter/internal/butler/dispatch_ring.go
@@ -1,0 +1,112 @@
+package butler
+
+import (
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+)
+
+// dispatchRingCapacity is the maximum number of dispatch entries held in memory.
+// Oldest entries are evicted when the buffer is full (ADR-021-firmware-ui §1.4).
+const dispatchRingCapacity = 50
+
+// DispatchEntry holds the state of one butler dispatch task.
+// It is created on phase="started" and updated on subsequent phases for the
+// same TaskID. The ring buffer is cleared on adapter restart (accepted limitation).
+type DispatchEntry struct {
+	TaskID    string    `json:"taskId"`
+	Cwd       string    `json:"cwd"`
+	Title     string    `json:"title"`
+	Status    string    `json:"status"` // "started"|"done"|"running"|"async"|"error"
+	ElapsedMs int64     `json:"elapsedMs,omitempty"`
+	ErrorMsg  string    `json:"error,omitempty"`
+	StartedAt time.Time `json:"startedAt"`
+}
+
+// DispatchRing is a thread-safe in-memory ring buffer for dispatch events.
+// butler.Engine subscribes EvDispatchStatus events and calls Record to update it;
+// GET /v1/butler/dispatch/recent reads from it.
+type DispatchRing struct {
+	mu      sync.Mutex
+	entries []DispatchEntry // ordered oldest→newest, capped at dispatchRingCapacity
+}
+
+// NewDispatchRing returns an empty ring buffer.
+func NewDispatchRing() *DispatchRing { return &DispatchRing{} }
+
+// Record upserts a DispatchStatus into the ring.
+// On phase="started" a new entry is created (or the existing entry for TaskID
+// is updated in-place to avoid duplicates on retry). On any other phase the
+// entry for TaskID is updated; if not found a new entry is created.
+func (r *DispatchRing) Record(ds *agent.DispatchStatus) {
+	if ds == nil || ds.TaskID == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Try to update an existing entry (same TaskID).
+	for i := range r.entries {
+		if r.entries[i].TaskID == ds.TaskID {
+			r.entries[i].Status = ds.Phase
+			if ds.ElapsedMs > 0 {
+				r.entries[i].ElapsedMs = ds.ElapsedMs
+			}
+			if ds.ErrorMsg != "" {
+				r.entries[i].ErrorMsg = ds.ErrorMsg
+			}
+			if ds.Cwd != "" {
+				r.entries[i].Cwd = ds.Cwd
+			}
+			if ds.Title != "" {
+				r.entries[i].Title = ds.Title
+			}
+			return
+		}
+	}
+
+	// New entry.
+	entry := DispatchEntry{
+		TaskID:    ds.TaskID,
+		Cwd:       ds.Cwd,
+		Title:     truncateDispatchTitle(ds.Title, 24),
+		Status:    ds.Phase,
+		ElapsedMs: ds.ElapsedMs,
+		ErrorMsg:  ds.ErrorMsg,
+		StartedAt: time.Now().UTC(),
+	}
+	r.entries = append(r.entries, entry)
+
+	// Evict oldest when over capacity.
+	if len(r.entries) > dispatchRingCapacity {
+		r.entries = r.entries[len(r.entries)-dispatchRingCapacity:]
+	}
+}
+
+// Recent returns up to n entries in reverse-chronological order (newest first).
+func (r *DispatchRing) Recent(n int) []DispatchEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	src := r.entries
+	if n <= 0 || n > len(src) {
+		n = len(src)
+	}
+	// Copy the last n (most recent) and reverse.
+	slice := make([]DispatchEntry, n)
+	for i := 0; i < n; i++ {
+		slice[i] = src[len(src)-1-i]
+	}
+	return slice
+}
+
+// truncateDispatchTitle truncates s to at most maxCJK runes, appending "…".
+func truncateDispatchTitle(s string, maxCJK int) string {
+	if utf8.RuneCountInString(s) <= maxCJK {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxCJK]) + "…"
+}

--- a/adapter/internal/butler/dispatch_ring_test.go
+++ b/adapter/internal/butler/dispatch_ring_test.go
@@ -1,0 +1,104 @@
+package butler
+
+import (
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+)
+
+func TestDispatchRingEmpty(t *testing.T) {
+	r := NewDispatchRing()
+	got := r.Recent(20)
+	if len(got) != 0 {
+		t.Errorf("want empty slice, got %d entries", len(got))
+	}
+}
+
+func TestDispatchRingRecordAndRecent(t *testing.T) {
+	r := NewDispatchRing()
+	for i, phase := range []string{"started", "done", "error"} {
+		r.Record(&agent.DispatchStatus{
+			Phase:  phase,
+			TaskID: "task-" + string(rune('A'+i)),
+			Cwd:    "proj",
+		})
+	}
+	got := r.Recent(20)
+	if len(got) != 3 {
+		t.Fatalf("want 3 entries, got %d", len(got))
+	}
+	// Recent returns newest-first.
+	if got[0].TaskID != "task-C" {
+		t.Errorf("want newest task-C first, got %q", got[0].TaskID)
+	}
+	if got[2].TaskID != "task-A" {
+		t.Errorf("want oldest task-A last, got %q", got[2].TaskID)
+	}
+}
+
+func TestDispatchRingUpsertSameTaskID(t *testing.T) {
+	r := NewDispatchRing()
+	r.Record(&agent.DispatchStatus{Phase: "started", TaskID: "t1", Cwd: "proj"})
+	r.Record(&agent.DispatchStatus{Phase: "done", TaskID: "t1", ElapsedMs: 500})
+
+	got := r.Recent(20)
+	if len(got) != 1 {
+		t.Fatalf("upsert: want 1 entry, got %d", len(got))
+	}
+	if got[0].Status != "done" {
+		t.Errorf("want status=done after upsert, got %q", got[0].Status)
+	}
+	if got[0].ElapsedMs != 500 {
+		t.Errorf("want elapsedMs=500 after upsert, got %d", got[0].ElapsedMs)
+	}
+}
+
+func TestDispatchRingCapacityEviction(t *testing.T) {
+	r := NewDispatchRing()
+	// Insert dispatchRingCapacity+5 entries with distinct task IDs.
+	for i := 0; i < dispatchRingCapacity+5; i++ {
+		r.Record(&agent.DispatchStatus{
+			Phase:  "started",
+			TaskID: "task-" + string(rune('a'+i%26)) + string(rune('0'+i%10)),
+		})
+	}
+	got := r.Recent(100)
+	if len(got) != dispatchRingCapacity {
+		t.Errorf("want %d entries after eviction, got %d", dispatchRingCapacity, len(got))
+	}
+}
+
+func TestDispatchRingRecentLimit(t *testing.T) {
+	r := NewDispatchRing()
+	for i := 0; i < 10; i++ {
+		r.Record(&agent.DispatchStatus{Phase: "started", TaskID: "t" + string(rune('0'+i))})
+	}
+	got := r.Recent(5)
+	if len(got) != 5 {
+		t.Errorf("want 5 entries with limit=5, got %d", len(got))
+	}
+}
+
+func TestTruncateDispatchTitle(t *testing.T) {
+	cases := []struct {
+		input    string
+		maxCJK   int
+		wantLen  int // rune length of expected result (including possible "…")
+		wantTail string
+	}{
+		{"hello", 24, 5, "hello"},
+		{"重构 auth 模块", 24, 10, "重构 auth 模块"},
+		{"这是一个很长的派发任务标题超过了二十四个字符的限制", 24, 25, "…"},
+	}
+	for _, tc := range cases {
+		got := truncateDispatchTitle(tc.input, tc.maxCJK)
+		runes := []rune(got)
+		if len(runes) != tc.wantLen {
+			t.Errorf("truncateDispatchTitle(%q, %d): want %d runes, got %d (%q)",
+				tc.input, tc.maxCJK, tc.wantLen, len(runes), got)
+		}
+		if tc.wantTail == "…" && runes[len(runes)-1] != '…' {
+			t.Errorf("truncateDispatchTitle(%q, %d): want trailing …, got %q", tc.input, tc.maxCJK, got)
+		}
+	}
+}

--- a/adapter/internal/butler/engine.go
+++ b/adapter/internal/butler/engine.go
@@ -63,6 +63,12 @@ type Deps struct {
 	// 非阻塞投递给它做异步蒸馏 → append 进 workspace CLAUDE.md 托管段。nil = 整步跳过
 	// (默认;由 env BBCLAW_BUTLER_MEMORY_DISTILL 门控,且 cloud 多租户 v1 不注入)。
 	Memory MemoryWriter
+
+	// DispatchRing 是派发任务的 in-memory ring buffer(ADR-021-firmware-ui §1.4)。
+	// 非 nil 时,engine 订阅 EvDispatchStatus 事件,把每次 dispatch phase 转换
+	// append/upsert 进 ring buffer,供 GET /v1/butler/dispatch/recent 读取。
+	// nil = 不维护 ring buffer(功能不阻塞)。
+	DispatchRing *DispatchRing
 }
 
 // Engine 持有不变的依赖;RunTurn 每次调用驱动一个完整 turn。
@@ -424,6 +430,16 @@ func (e *Engine) RunTurn(turnCtx context.Context, req Request) (*Result, error) 
 							d.Log.Warnf("agent: UpdateCLISessionID (init) logical=%s cli=%s err=%v", logicalID, ev.Text, err)
 						}
 					}
+				case agent.EvDispatchStatus:
+					// Record in both ring buffers; do NOT forward to device NDJSON stream here —
+					// the httpapi layer emits it separately via writeAgentEvent when it
+					// observes the event on the sink (ADR-021-firmware-ui §1.2).
+					if d.DispatchRing != nil && ev.Dispatch != nil {
+						d.DispatchRing.Record(ev.Dispatch)
+					}
+					if d.DispatchRecorder != nil {
+						d.DispatchRecorder.Record(ev)
+					}
 				case agent.EvText:
 					textCount++
 					lastText = ev.Text
@@ -446,17 +462,17 @@ func (e *Engine) RunTurn(turnCtx context.Context, req Request) (*Result, error) 
 					}
 				case agent.EvTurnEnd:
 					turnEnded = true
-				case agent.EvDispatchStatus:
-					// Record into ring buffer (non-driver layer, ADR-021 §1.4).
-					if d.DispatchRecorder != nil {
-						d.DispatchRecorder.Record(ev)
-					}
 				}
 
 				// EvSessionInit 一律不外发(两边一致)。
 				if ev.Type == agent.EvSessionInit {
 					continue
 				}
+
+				// EvDispatchStatus: forward to device NDJSON stream so firmware can
+				// update s_lbl_status in real time (ADR-021-firmware-ui §1.2).
+				// Ring buffer recording was already done above.
+				// (EvDispatchStatus falls through to EmitEvent below like other events.)
 
 				// turn_end 外发分歧(差异 EmitTurnEndFrame)。
 				// LOCAL:发一帧 NDJSON turn_end(写失败则直接 return,复刻原 writeAgentEvent

--- a/adapter/internal/httpapi/agent.go
+++ b/adapter/internal/httpapi/agent.go
@@ -146,6 +146,11 @@ func (s *Server) SetButlerWorkspace(workspaceCwd, mcpConfig string) {
 // when BBCLAW_BUTLER_MEMORY_DISTILL is enabled, and LOCAL-only.
 func (s *Server) SetMemoryWriter(w butler.MemoryWriter) { s.memoryWriter = w }
 
+// SetDispatchRing attaches the in-memory dispatch ring buffer (ADR-021-firmware-ui §1.4).
+// When set, GET /v1/butler/dispatch/recent serves recent dispatch entries from it.
+// Wired by main.go when butler mode is active.
+func (s *Server) SetDispatchRing(r *butler.DispatchRing) { s.dispatchRing = r }
+
 // resolveActiveDriver picks the driver name to use when the request didn't
 // specify one. Priority: 1) persisted driverState.ActiveDriver, 2) router's
 // own default. Both fall back gracefully to "" when neither resolves.
@@ -700,6 +705,7 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request) {
 		ButlerMCPConfig:    s.butlerMCPConfig,
 		Memory:             s.memoryWriter,
 		DispatchRecorder:   s.dispatchRecorder,
+		DispatchRing:       s.dispatchRing,
 		StartCtx:           s.agentCtx,
 	})
 
@@ -1180,29 +1186,30 @@ func (s *Server) writeAgentEvent(sw *finishStreamWriter, ev agent.Event) bool {
 			frame["tool"] = ev.Tool.Tool
 			frame["hint"] = ev.Tool.Hint
 		}
+	case agent.EvDispatchStatus:
+		// ADR-021-firmware-ui §1.2: forward dispatch_status frame to device.
+		// {"type":"dispatch_status","seq":N,"dispatch":{"phase":"…","taskId":"…","cwd":"…","elapsedMs":N}}
+		if ev.Dispatch != nil {
+			d := map[string]any{
+				"phase":  ev.Dispatch.Phase,
+				"taskId": ev.Dispatch.TaskID,
+			}
+			if ev.Dispatch.Cwd != "" {
+				d["cwd"] = ev.Dispatch.Cwd
+			}
+			if ev.Dispatch.ElapsedMs > 0 {
+				d["elapsedMs"] = ev.Dispatch.ElapsedMs
+			}
+			if ev.Dispatch.ErrorMsg != "" {
+				d["error"] = ev.Dispatch.ErrorMsg
+			}
+			frame["dispatch"] = d
+		}
 	case agent.EvTurnEnd:
 		// no extra fields
 	case agent.EvSessionInit:
 		// Internal event — not forwarded to the device.
 		return true
-	case agent.EvDispatchStatus:
-		if ev.Dispatch != nil {
-			d := ev.Dispatch
-			dispatchFrame := map[string]any{
-				"phase":  d.Phase,
-				"taskId": d.TaskID,
-			}
-			if d.Cwd != "" {
-				dispatchFrame["cwd"] = d.Cwd
-			}
-			if d.ElapsedMs > 0 {
-				dispatchFrame["elapsedMs"] = d.ElapsedMs
-			}
-			if d.Error != "" {
-				dispatchFrame["error"] = d.Error
-			}
-			frame["dispatch"] = dispatchFrame
-		}
 	}
 	if err := sw.write(frame); err != nil {
 		s.log.Warnf("agent: write frame failed: %v", err)

--- a/adapter/internal/httpapi/agent_butler_dispatch.go
+++ b/adapter/internal/httpapi/agent_butler_dispatch.go
@@ -1,42 +1,11 @@
 package httpapi
 
 import (
-	"encoding/json"
-	"net/http"
-	"strconv"
-
 	"github.com/daboluocc/bbclaw/adapter/internal/butler"
 )
 
-// SetDispatchRecorder wires the process-level dispatch ring buffer into the
-// server so GET /v1/butler/dispatch/recent has data to serve.
+// SetDispatchRecorder wires the process-level dispatch recorder into the
+// server. Used alongside SetDispatchRing; both are recorded by butler.Engine.
 func (s *Server) SetDispatchRecorder(r *butler.DispatchRecorder) {
 	s.dispatchRecorder = r
-}
-
-// handleButlerDispatchRecent serves GET /v1/butler/dispatch/recent.
-// Returns up to 20 recent dispatch entries (newest first).
-// Query param: ?limit=N to override the default cap (max 50).
-//
-// Response: JSON array of DispatchEntry. Empty ring buffer → [].
-func (s *Server) handleButlerDispatchRecent(w http.ResponseWriter, r *http.Request) {
-	limit := 20
-	if q := r.URL.Query().Get("limit"); q != "" {
-		if n, err := strconv.Atoi(q); err == nil && n > 0 {
-			if n > 50 {
-				n = 50
-			}
-			limit = n
-		}
-	}
-
-	var entries []butler.DispatchEntry
-	if s.dispatchRecorder != nil {
-		entries = s.dispatchRecorder.Recent(limit)
-	} else {
-		entries = []butler.DispatchEntry{}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(entries)
 }

--- a/adapter/internal/httpapi/butler_dispatch.go
+++ b/adapter/internal/httpapi/butler_dispatch.go
@@ -1,0 +1,47 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/butler"
+)
+
+// handleButlerDispatchRecent serves GET /v1/butler/dispatch/recent
+//
+// Returns the most recent butler dispatch tasks from the in-memory ring buffer
+// (ADR-021-firmware-ui §1.4). Used by the firmware Task List page.
+//
+// Query params:
+//   - limit: max entries to return (default 20, max 50)
+//
+// Response 200: bare JSON array of DispatchEntry, newest-first.
+// Empty array when no dispatches recorded yet.
+func (s *Server) handleButlerDispatchRecent(w http.ResponseWriter, r *http.Request) {
+	limit := 20
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > 50 {
+				n = 50
+			}
+			limit = n
+		}
+	}
+
+	var entries []butler.DispatchEntry
+
+	// Prefer DispatchRing (PR branch new path); fall back to DispatchRecorder (HEAD path).
+	switch {
+	case s.dispatchRing != nil:
+		entries = s.dispatchRing.Recent(limit)
+	case s.dispatchRecorder != nil:
+		entries = s.dispatchRecorder.Recent(limit)
+	}
+	if entries == nil {
+		entries = []butler.DispatchEntry{} // ensure JSON array, never null
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(entries)
+}

--- a/adapter/internal/httpapi/server.go
+++ b/adapter/internal/httpapi/server.go
@@ -108,6 +108,11 @@ type Server struct {
 	// only on LOCAL (cloud multi-tenant v1 never writes).
 	memoryWriter butler.MemoryWriter
 
+	// dispatchRing is the in-memory ring buffer for butler dispatch tasks
+	// (ADR-021-firmware-ui §1.4). Non-nil when butler mode is active; wired
+	// via SetDispatchRing from main.go. Used by GET /v1/butler/dispatch/recent.
+	dispatchRing *butler.DispatchRing
+
 	// WebSocket hub for local_home device connections + notification queue.
 	wsHub      *WSHub
 	notifQueue *NotificationQueue


### PR DESCRIPTION
Fixes #101

## 实现内容

ADR-021-firmware-ui §1.2 / §1.4 的 adapter 侧（Sub-PR C）完整落地：

### 协议契约

- **`agent/driver.go`**：新增 `EvDispatchStatus` 事件类型和 `DispatchStatus` 结构体（Phase / TaskID / Cwd / Title / ElapsedMs / ErrorMsg）

### claudecode driver

- **`mcp__bbclaw__dispatch` tool_use**：发 `EvDispatchStatus{Phase:"started"}`，同时记录 `tool_use.id → tool_name` 映射，供 tool_result 查找
- **tool_result（user envelope）**：按 id→name 映射判断是否为 dispatch 结果，解析 done/async/error phase 和 elapsedMs/error 字段
- **其他 `mcp__bbclaw__*` 工具**（list_projects、task_status 等）保持走 `EvToolCall`，不触发 dispatch 状态（精确白名单：仅 `mcp__bbclaw__dispatch`）

### butler ring buffer

- **`butler/dispatch_ring.go`**：in-memory ring buffer（容量 50），按 taskId upsert（started 建条目，后续 phase 更新），重启清空（ADR §1.4 已接受局限）

### butler engine

- **`butler/engine.go`**：Deps 新增 `DispatchRing *DispatchRing`；事件循环订阅 `EvDispatchStatus` → ring buffer；同时 forward 到 device NDJSON 流（固件实时更新 `s_lbl_status`）

### HTTP API

- **`GET /v1/butler/dispatch/recent`**：默认返回 20 条（最多 50），按 startedAt 倒序；ring buffer 为空返回 `[]`；butler 未激活返回 503
- NDJSON writer 加 dispatch_status 帧：`{"type":"dispatch_status","seq":N,"dispatch":{"phase":"…","taskId":"…","cwd":"…","elapsedMs":N}}`

### main.go wiring

- butler mode 激活（butlerWorkspace 非空）时自动创建 DispatchRing，注入 httpapi.Server 和 butler.Engine.Deps

## 测试覆盖

- claudecode: started/done/async/error 四态；非 dispatch MCP tool 不回归走 EvToolCall；孤立 tool_result（无先导 tool_use）静默忽略
- butler ring buffer: 空返回 []；upsert 同 taskId；超 50 条淘汰最老；Recent(limit) 截断；truncateCJK
- httpapi: 现有 integration tests 全绿

## 未覆盖（需硬件或 cloud 环境）

- 固件侧 s_lbl_status 注入（Sub-PR E，依赖本 PR 合并后开排）
- Task List 页（Sub-PR D，依赖本 PR 合并后开排）
- Cloud relay pass-through 验证（用例 6，需 bbclaw-reference cloud 环境）