### PR TITLE
feat(firmware): dispatch_status 文案注入顶部 s_lbl_status + bottom_bar [B] cwd | mem:N+M + LOCKED footer

### DIFF
--- a/firmware/include/bb_adapter_client.h
+++ b/firmware/include/bb_adapter_client.h
@@ -47,7 +47,18 @@ typedef enum {
   BB_FINISH_STREAM_EVENT_ERROR,
   BB_FINISH_STREAM_EVENT_THINKING,
   BB_FINISH_STREAM_EVENT_TOOL_CALL,
+  /* ADR-021-firmware-ui §1.2: butler dispatch progress (started/done/async/error) */
+  BB_FINISH_STREAM_EVENT_DISPATCH_STATUS,
 } bb_finish_stream_event_type_t;
+
+/* Dispatch status payload — carried in bb_finish_stream_event_t.dispatch when
+ * type == BB_FINISH_STREAM_EVENT_DISPATCH_STATUS. */
+typedef struct {
+  char phase[16];    /* "started" | "done" | "async" | "error" */
+  char task_id[64];  /* tool_use id from adapter */
+  char cwd[64];      /* project cwd (filled on started) */
+  int64_t elapsed_ms; /* worker elapsed time (filled on done/async) */
+} bb_dispatch_status_t;
 
 typedef struct {
   bb_finish_stream_event_type_t type;
@@ -55,6 +66,8 @@ typedef struct {
   const char* text;
   bb_tts_chunk_t* tts_chunk; /* callback owns this when non-NULL */
   int reply_wait_timed_out;
+  /* non-NULL when type == BB_FINISH_STREAM_EVENT_DISPATCH_STATUS */
+  const bb_dispatch_status_t* dispatch;
 } bb_finish_stream_event_t;
 
 typedef void (*bb_finish_stream_event_cb_t)(bb_finish_stream_event_t* event, void* user_ctx);

--- a/firmware/include/bb_display.h
+++ b/firmware/include/bb_display.h
@@ -49,3 +49,19 @@ void bb_display_set_chat_active(int active);
  *  告诉用户"按 DOWN 到底回到实时流"；on=0 恢复正常 alias/sid 显示。
  *  由 bb_chat_transcript 在 follow-tail 锁存变化时调用，不需要外部驱动。 */
 void bb_display_set_reading_hint(int on);
+
+/** ADR-021-firmware-ui §1.2: butler cwd 用于 bottom_bar 左侧 "[B] <cwd>" 显示。
+ *  NULL/"" 时显示 "[B]"（无 cwd）。 */
+void bb_display_set_butler_cwd(const char* cwd);
+
+/** ADR-021-firmware-ui §1.2: dispatch_status 帧注入顶部 s_lbl_status。
+ *  phase: "started" | "done" | "async" | "error"
+ *  cwd: 派发目标项目（started 时有效，可为 NULL）
+ *  task_id: MCP tool_use id（async 时显示，可为 NULL）
+ *  elapsed_ms: worker 耗时（done/async 时有效） */
+void bb_display_set_dispatch_status(const char* phase, const char* cwd,
+                                    const char* task_id, int64_t elapsed_ms);
+
+/** ADR-021-firmware-ui §1.3: 记忆条数更新 footer 右侧 "mem: N+M" 显示。
+ *  inbox=-1 或 profile=-1 时降级为 "mem: ?" */
+void bb_display_set_mem_stats(int inbox, int profile);

--- a/firmware/include/bb_page_locked.h
+++ b/firmware/include/bb_page_locked.h
@@ -5,9 +5,14 @@
 /* LOCKED page: independent full-screen padlock view.
  * Shown when cloud_saas passphrase unlock is required.
  * update_status() handles BB_STATUS_VERIFY_TX/VERIFY/VERIFY_ERR transitions.
- * update_battery() refreshes the large battery widget below the padlock. */
+ * update_battery() refreshes the large battery widget below the padlock.
+ * update_footer() refreshes the bottom status bar (ADR-021-firmware-ui §2). */
 
 void bb_page_locked_create(lv_obj_t* scr);
 void bb_page_locked_set_visible(int visible);
 void bb_page_locked_update_status(const char* status);
 void bb_page_locked_update_battery(int supported, int available, int percent, int low, int charging);
+/** ADR-021-firmware-ui §2: refresh LOCKED page footer.
+ *  cwd: butler workspace cwd (NULL/"" → shows "[B]")
+ *  mem_inbox/mem_profile: -1 means unknown → "mem: ?" */
+void bb_page_locked_update_footer(const char* cwd, int mem_inbox, int mem_profile);

--- a/firmware/src/bb_adapter_client.c
+++ b/firmware/src/bb_adapter_client.c
@@ -161,6 +161,24 @@ static void emit_finish_stream_event(bb_finish_stream_event_cb_t cb, void* user_
       .text = text,
       .tts_chunk = tts_chunk,
       .reply_wait_timed_out = reply_wait_timed_out,
+      .dispatch = NULL,
+  };
+  cb(&event, user_ctx);
+}
+
+/* ADR-021-firmware-ui §1.2: emit a dispatch_status event from a parsed
+ * bb_dispatch_status_t. Separate helper to avoid touching every call site of
+ * emit_finish_stream_event. */
+static void emit_dispatch_event(bb_finish_stream_event_cb_t cb, void* user_ctx,
+                                const bb_dispatch_status_t* ds) {
+  if (cb == NULL || ds == NULL) return;
+  bb_finish_stream_event_t event = {
+      .type = BB_FINISH_STREAM_EVENT_DISPATCH_STATUS,
+      .phase = ds->phase,
+      .text = NULL,
+      .tts_chunk = NULL,
+      .reply_wait_timed_out = 0,
+      .dispatch = ds,
   };
   cb(&event, user_ctx);
 }
@@ -870,6 +888,21 @@ static void ws_handle_text_message(const char* msg) {
       emit_finish_stream_event(s_ws.finish_on_event, s_ws.finish_user_ctx, BB_FINISH_STREAM_EVENT_TOOL_CALL, NULL,
                                name, NULL, 0);
     }
+  } else if (strcmp(kind, "dispatch_status") == 0) {
+    /* ADR-021-firmware-ui §1.2: butler dispatch progress via WS relay */
+    if (s_ws.finish_on_event != NULL) {
+      bb_dispatch_status_t ds = {0};
+      const char* dp = strstr(msg, "\"dispatch\"");
+      const char* src = (dp != NULL) ? strchr(dp, '{') : msg;
+      if (src == NULL) src = msg;
+      (void)json_extract_string(src, "phase",   ds.phase,   sizeof(ds.phase));
+      (void)json_extract_string(src, "taskId",  ds.task_id, sizeof(ds.task_id));
+      (void)json_extract_string(src, "cwd",     ds.cwd,     sizeof(ds.cwd));
+      ds.elapsed_ms = (int64_t)json_extract_int(src, "elapsedMs", 0);
+      if (ds.phase[0] != '\0') {
+        emit_dispatch_event(s_ws.finish_on_event, s_ws.finish_user_ctx, &ds);
+      }
+    }
   } else if (strcmp(kind, "tts.chunk") == 0) {
     /* Agent-bus path / abort path don't want TTS — skip base64 decode + alloc
      * entirely. dispatch_tts_chunk_event would also drop the chunk, but we
@@ -1313,6 +1346,25 @@ static void parse_finish_stream_line(const char* line, bb_finish_stream_accum_t*
     (void)json_extract_string(line, "name", name, sizeof(name));
     if (accum->on_event != NULL && name[0] != '\0') {
       emit_finish_stream_event(accum->on_event, accum->user_ctx, BB_FINISH_STREAM_EVENT_TOOL_CALL, NULL, name, NULL, 0);
+    }
+    return;
+  }
+
+  /* ADR-021-firmware-ui §1.2: butler dispatch progress frame */
+  if (strcmp(type, "dispatch_status") == 0) {
+    if (accum->on_event != NULL) {
+      bb_dispatch_status_t ds = {0};
+      /* dispatch object is nested under "dispatch" key */
+      const char* dp = strstr(line, "\"dispatch\"");
+      const char* src = (dp != NULL) ? strchr(dp, '{') : line;
+      if (src == NULL) src = line;
+      (void)json_extract_string(src, "phase",   ds.phase,   sizeof(ds.phase));
+      (void)json_extract_string(src, "taskId",  ds.task_id, sizeof(ds.task_id));
+      (void)json_extract_string(src, "cwd",     ds.cwd,     sizeof(ds.cwd));
+      ds.elapsed_ms = (int64_t)json_extract_int(src, "elapsedMs", 0);
+      if (ds.phase[0] != '\0') {
+        emit_dispatch_event(accum->on_event, accum->user_ctx, &ds);
+      }
     }
     return;
   }

--- a/firmware/src/bb_lvgl_display.c
+++ b/firmware/src/bb_lvgl_display.c
@@ -218,6 +218,35 @@ static char s_bottom_alias[24];
  * bb_display_set_reading_hint. */
 static int s_reading_hint_on;
 
+/* ADR-021-firmware-ui §1.2: butler cwd for bottom_bar "[B] <cwd>" left cell */
+static char s_butler_cwd[48];
+
+/* ADR-021-firmware-ui §1.3: mem stats for bottom_bar "mem: N+M" right cell.
+ * -1 means unknown → renders as "mem: ?". */
+static int s_mem_inbox   = -1;
+static int s_mem_profile = -1;
+
+/* ADR-021-firmware-ui §1.2: dispatch status state machine.
+ * Tracks the current butler dispatch phase and auto-revert timer. */
+typedef enum {
+  DISPATCH_PHASE_NONE = 0,
+  DISPATCH_PHASE_STARTED,
+  DISPATCH_PHASE_DONE,
+  DISPATCH_PHASE_ASYNC,
+  DISPATCH_PHASE_ERROR,
+} dispatch_phase_t;
+
+typedef struct {
+  dispatch_phase_t phase;
+  char cwd[48];
+  char task_id[64];
+  int64_t elapsed_ms;
+  /* non-NULL while a timed revert is pending */
+  lv_timer_t* revert_timer;
+} bb_dispatch_state_t;
+
+static bb_dispatch_state_t s_dispatch = {0};
+
 /* LVGL objects — locked moved to bb_page_locked.c */
 
 /* LVGL objects — active (status bar + text) */
@@ -405,57 +434,35 @@ static void apply_battery_widget(void) {
 static void apply_bottom_bar(void) {
   if (s_lbl_bottom_session == NULL || s_lbl_bottom_cwd == NULL) return;
 
-  char alias_text[24];
-  char session_text[32];
-  char model_text[40];
-  int reading_hint;
+  /* ADR-021-firmware-ui §1.2: left cell — "[B] <cwd>" (butler badge + workspace) */
+  char left_buf[56];
+  char butler_cwd[48];
   portENTER_CRITICAL(&s_state_lock);
-  strncpy(alias_text, s_bottom_alias, sizeof(alias_text) - 1);
-  alias_text[sizeof(alias_text) - 1] = '\0';
-  reading_hint = s_reading_hint_on;
-  const char* sid = s_bottom_session;
-  if (sid[0] == '\0') {
-    session_text[0] = '\0';
-  } else {
-    /* Tail of the sid is the most distinguishing part; show the last 10
-     * hex chars after stripping the "ls-"/"cs-" prefix the same way the
-     * theme topbar does. Mirrors bb_ui_agent_chat::session_id_short. */
-    const char* hex = sid;
-    if (hex[0] != '\0' && hex[1] != '\0' && hex[2] == '-') hex += 3;
-    size_t hlen = strlen(hex);
-    const int show = 10;
-    const char* tail = hlen > (size_t)show ? hex + hlen - show : hex;
-    strncpy(session_text, tail, sizeof(session_text) - 1);
-    session_text[sizeof(session_text) - 1] = '\0';
-  }
-  strncpy(model_text, s_bottom_model, sizeof(model_text) - 1);
-  model_text[sizeof(model_text) - 1] = '\0';
+  strncpy(butler_cwd, s_butler_cwd, sizeof(butler_cwd) - 1);
+  butler_cwd[sizeof(butler_cwd) - 1] = '\0';
   portEXIT_CRITICAL(&s_state_lock);
 
-  /* ADR-016: prefer logical session alias (adapter title field, e.g.
-   * "daboluocc-bbclaw") over the raw sid. Falls back to sid tail when
-   * the adapter hasn't reported a title (e.g. fresh new session, or
-   * driver_cycle restoring a sid from NVS without metadata). */
-  (void)reading_hint;  /* ADR-017 hint removed — kept setter for ABI but
-                         no longer drawn (scrolling now intuitively works
-                         during TTS, marker turned out to be noise). */
-  if (alias_text[0] != '\0') {
-    lv_label_set_text(s_lbl_bottom_session, alias_text);
-  } else if (session_text[0] != '\0') {
-    char buf[40];
-    snprintf(buf, sizeof(buf), "sid %s", session_text);
-    lv_label_set_text(s_lbl_bottom_session, buf);
+  if (butler_cwd[0] != '\0') {
+    snprintf(left_buf, sizeof(left_buf), "[B] %s", butler_cwd);
   } else {
-    lv_label_set_text(s_lbl_bottom_session, "no session");
+    snprintf(left_buf, sizeof(left_buf), "[B]");
   }
+  lv_label_set_text(s_lbl_bottom_session, left_buf);
 
-  /* ADR-016: right cell shows active model (was cwd_name). When unknown
-   * (adapter not yet polled) fall back to "—" so the bar isn't blank. */
-  if (model_text[0] == '\0') {
-    lv_label_set_text(s_lbl_bottom_cwd, "—");
+  /* ADR-021-firmware-ui §1.3: right cell — "mem: N+M" or "mem: ?" */
+  char right_buf[24];
+  int inbox, profile;
+  portENTER_CRITICAL(&s_state_lock);
+  inbox   = s_mem_inbox;
+  profile = s_mem_profile;
+  portEXIT_CRITICAL(&s_state_lock);
+
+  if (inbox >= 0 && profile >= 0) {
+    snprintf(right_buf, sizeof(right_buf), "mem: %d+%d", inbox, profile);
   } else {
-    lv_label_set_text(s_lbl_bottom_cwd, model_text);
+    snprintf(right_buf, sizeof(right_buf), "mem: ?");
   }
+  lv_label_set_text(s_lbl_bottom_cwd, right_buf);
 }
 
 /* ── Status icon ── */
@@ -1219,13 +1226,54 @@ static void refresh_ui(void) {
       portEXIT_CRITICAL(&s_state_lock);
       bb_page_locked_update_battery(bat_supported, bat_available, bat_percent, bat_low, bat_charging);
     }
+    /* ADR-021-firmware-ui §2: refresh LOCKED footer with butler cwd + mem stats */
+    {
+      char locked_cwd[48];
+      int locked_inbox, locked_profile;
+      portENTER_CRITICAL(&s_state_lock);
+      strncpy(locked_cwd, s_butler_cwd, sizeof(locked_cwd) - 1);
+      locked_cwd[sizeof(locked_cwd) - 1] = '\0';
+      locked_inbox   = s_mem_inbox;
+      locked_profile = s_mem_profile;
+      portEXIT_CRITICAL(&s_state_lock);
+      bb_page_locked_update_footer(locked_cwd, locked_inbox, locked_profile);
+    }
     s_record_view_visible = 0;
   } else {
     /* ACTIVE view (chat) — full layout with top bar + bottom bar */
     const char* status_text = status;
     if (strcmp(status, BB_STATUS_TX) == 0) status_text = "LISTENING";
     else if (strcmp(status, BB_STATUS_RX) == 0 || strcmp(status, "TRANSCRIBING") == 0 || strcmp(status, "PROCESSING") == 0) status_text = "PROCESSING";
-    lv_label_set_text(s_lbl_status, status_text[0] != '\0' ? status_text : BB_STATUS_READY);
+
+    /* ADR-021-firmware-ui §1.2: dispatch phase overlay — highest priority.
+     * error > async > done > started > 常态 */
+    {
+      char dispatch_text[80] = {0};
+      dispatch_phase_t dp = s_dispatch.phase;
+      if (dp == DISPATCH_PHASE_ERROR) {
+        snprintf(dispatch_text, sizeof(dispatch_text), "派发失败 ❌");
+      } else if (dp == DISPATCH_PHASE_ASYNC) {
+        if (s_dispatch.task_id[0] != '\0') {
+          snprintf(dispatch_text, sizeof(dispatch_text), "已转异步 #%.12s", s_dispatch.task_id);
+        } else {
+          snprintf(dispatch_text, sizeof(dispatch_text), "已转异步");
+        }
+      } else if (dp == DISPATCH_PHASE_DONE) {
+        long long elapsed_s = (long long)(s_dispatch.elapsed_ms / 1000LL);
+        snprintf(dispatch_text, sizeof(dispatch_text), "worker 完成 ✅ (%llus)", elapsed_s);
+      } else if (dp == DISPATCH_PHASE_STARTED) {
+        if (s_dispatch.cwd[0] != '\0') {
+          snprintf(dispatch_text, sizeof(dispatch_text), "派发中: %s…", s_dispatch.cwd);
+        } else {
+          snprintf(dispatch_text, sizeof(dispatch_text), "派发中…");
+        }
+      }
+      if (dispatch_text[0] != '\0') {
+        lv_label_set_text(s_lbl_status, dispatch_text);
+      } else {
+        lv_label_set_text(s_lbl_status, status_text[0] != '\0' ? status_text : BB_STATUS_READY);
+      }
+    }
     apply_status_icon(status);
     apply_wifi_bars(s_bar_status_wifi, s_lbl_status_wifi_info, status);
     apply_battery_widget();
@@ -1778,4 +1826,88 @@ void bb_display_set_tts_sentence(const char* sentence_text) {
   s_auto_scroll_pause_until_ms = bb_now_ms() + UI_MANUAL_SCROLL_PAUSE_MS;
 
   lvgl_port_unlock();
+}
+
+/* ── ADR-021-firmware-ui §1.2 / §1.3: dispatch status + footer helpers ── */
+
+/* Revert timer callback: clears the dispatch overlay and re-renders status */
+static void dispatch_revert_timer_cb(lv_timer_t* timer) {
+  (void)timer;
+  s_dispatch.phase = DISPATCH_PHASE_NONE;
+  s_dispatch.revert_timer = NULL;
+  if (s_ready) refresh_ui();
+}
+
+void bb_display_set_butler_cwd(const char* cwd) {
+  portENTER_CRITICAL(&s_state_lock);
+  if (cwd == NULL) {
+    s_butler_cwd[0] = '\0';
+  } else {
+    strncpy(s_butler_cwd, cwd, sizeof(s_butler_cwd) - 1);
+    s_butler_cwd[sizeof(s_butler_cwd) - 1] = '\0';
+  }
+  portEXIT_CRITICAL(&s_state_lock);
+  if (s_ready) refresh_ui();
+}
+
+void bb_display_set_dispatch_status(const char* phase, const char* cwd,
+                                    const char* task_id, int64_t elapsed_ms) {
+  if (phase == NULL || phase[0] == '\0') return;
+
+  /* Cancel any pending revert timer before updating state */
+  if (!lvgl_port_lock(50)) return;
+  if (s_dispatch.revert_timer != NULL) {
+    lv_timer_del(s_dispatch.revert_timer);
+    s_dispatch.revert_timer = NULL;
+  }
+  lvgl_port_unlock();
+
+  portENTER_CRITICAL(&s_state_lock);
+  if (strcmp(phase, "started") == 0) {
+    s_dispatch.phase = DISPATCH_PHASE_STARTED;
+  } else if (strcmp(phase, "done") == 0) {
+    s_dispatch.phase = DISPATCH_PHASE_DONE;
+  } else if (strcmp(phase, "async") == 0) {
+    s_dispatch.phase = DISPATCH_PHASE_ASYNC;
+  } else if (strcmp(phase, "error") == 0) {
+    s_dispatch.phase = DISPATCH_PHASE_ERROR;
+  } else {
+    portEXIT_CRITICAL(&s_state_lock);
+    return;
+  }
+  if (cwd != NULL) {
+    strncpy(s_dispatch.cwd, cwd, sizeof(s_dispatch.cwd) - 1);
+    s_dispatch.cwd[sizeof(s_dispatch.cwd) - 1] = '\0';
+  } else {
+    s_dispatch.cwd[0] = '\0';
+  }
+  if (task_id != NULL) {
+    strncpy(s_dispatch.task_id, task_id, sizeof(s_dispatch.task_id) - 1);
+    s_dispatch.task_id[sizeof(s_dispatch.task_id) - 1] = '\0';
+  } else {
+    s_dispatch.task_id[0] = '\0';
+  }
+  s_dispatch.elapsed_ms = elapsed_ms;
+  portEXIT_CRITICAL(&s_state_lock);
+
+  if (s_ready) refresh_ui();
+
+  /* done/async/error: schedule auto-revert after 4 seconds */
+  if (s_dispatch.phase != DISPATCH_PHASE_STARTED) {
+    if (lvgl_port_lock(50)) {
+      s_dispatch.revert_timer = lv_timer_create(dispatch_revert_timer_cb, 4000, NULL);
+      if (s_dispatch.revert_timer != NULL) {
+        lv_timer_set_repeat_count(s_dispatch.revert_timer, 1);
+      }
+      lvgl_port_unlock();
+    }
+  }
+}
+
+void bb_display_set_mem_stats(int inbox, int profile) {
+  portENTER_CRITICAL(&s_state_lock);
+  s_mem_inbox   = inbox;
+  s_mem_profile = profile;
+  portEXIT_CRITICAL(&s_state_lock);
+  if (s_ready) refresh_ui();
 }

--- a/firmware/src/bb_page_locked.c
+++ b/firmware/src/bb_page_locked.c
@@ -23,6 +23,9 @@ extern const lv_font_t lv_font_bbclaw_cjk;
 #define UI_ME_ACCENT    0x2ec4a0
 #define UI_SAFE_LEFT    10
 #define UI_SAFE_RIGHT   12
+/* Footer bar — must match bb_lvgl_display.c constants */
+#define UI_SAFE_BOTTOM  10
+#define UI_BOTTOM_BAR_H 16
 
 static lv_obj_t* s_view;
 static lv_obj_t* s_obj_shackle;
@@ -30,6 +33,11 @@ static lv_obj_t* s_obj_body;
 static lv_obj_t* s_obj_slot;
 static lv_obj_t* s_lbl_title;
 static lv_obj_t* s_lbl_hint;
+
+/* Footer status bar (ADR-021-firmware-ui §2) */
+static lv_obj_t* s_obj_footer;
+static lv_obj_t* s_lbl_footer_left;
+static lv_obj_t* s_lbl_footer_right;
 
 /* Large battery widget (below padlock) */
 static lv_obj_t* s_bat_container;
@@ -181,6 +189,48 @@ void bb_page_locked_create(lv_obj_t* scr) {
     lv_obj_add_flag(s_bat_container, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(s_bat_pct_lbl, LV_OBJ_FLAG_HIDDEN);
   }
+
+  /* ADR-021-firmware-ui §2: shared footer status bar — "[B] <cwd>" + "mem: N+M"
+   * LOCKED page shows the basic footer (no Task List summary per §1.4). */
+  {
+    const int bar_w = DISP_W - UI_SAFE_LEFT - UI_SAFE_RIGHT;
+    const int bar_y = DISP_H - UI_SAFE_BOTTOM - UI_BOTTOM_BAR_H;
+    const int half  = bar_w / 2;
+
+    s_obj_footer = lv_obj_create(s_view);
+    lv_obj_remove_style_all(s_obj_footer);
+    lv_obj_set_size(s_obj_footer, bar_w, UI_BOTTOM_BAR_H);
+    lv_obj_set_pos(s_obj_footer, UI_SAFE_LEFT, bar_y);
+    lv_obj_clear_flag(s_obj_footer, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_scrollbar_mode(s_obj_footer, LV_SCROLLBAR_MODE_OFF);
+    lv_obj_set_style_border_width(s_obj_footer, 1, LV_PART_MAIN);
+    lv_obj_set_style_border_side(s_obj_footer, LV_BORDER_SIDE_TOP, LV_PART_MAIN);
+    lv_obj_set_style_border_color(s_obj_footer, lv_color_hex(UI_TEXT_DIM), LV_PART_MAIN);
+    lv_obj_set_style_border_opa(s_obj_footer, LV_OPA_30, LV_PART_MAIN);
+
+    const int lh = (int)lv_font_get_line_height(font) + 1;
+    const int txt_y = (UI_BOTTOM_BAR_H - lh - 2) / 2 + 1;
+
+    s_lbl_footer_left = lv_label_create(s_obj_footer);
+    lv_obj_set_width(s_lbl_footer_left, half - 4);
+    lv_obj_set_height(s_lbl_footer_left, lh + 2);
+    lv_obj_set_style_text_color(s_lbl_footer_left, lv_color_hex(UI_TEXT_DIM), 0);
+    lv_obj_set_style_text_font(s_lbl_footer_left, font, 0);
+    lv_obj_set_style_text_align(s_lbl_footer_left, LV_TEXT_ALIGN_LEFT, 0);
+    lv_label_set_long_mode(s_lbl_footer_left, LV_LABEL_LONG_MODE_SCROLL_CIRCULAR);
+    lv_label_set_text(s_lbl_footer_left, "[B]");
+    lv_obj_set_pos(s_lbl_footer_left, 0, txt_y);
+
+    s_lbl_footer_right = lv_label_create(s_obj_footer);
+    lv_obj_set_width(s_lbl_footer_right, half - 4);
+    lv_obj_set_height(s_lbl_footer_right, lh + 2);
+    lv_obj_set_style_text_color(s_lbl_footer_right, lv_color_hex(UI_TEXT_DIM), 0);
+    lv_obj_set_style_text_font(s_lbl_footer_right, font, 0);
+    lv_obj_set_style_text_align(s_lbl_footer_right, LV_TEXT_ALIGN_RIGHT, 0);
+    lv_label_set_long_mode(s_lbl_footer_right, LV_LABEL_LONG_MODE_SCROLL_CIRCULAR);
+    lv_label_set_text(s_lbl_footer_right, "mem: ?");
+    lv_obj_set_pos(s_lbl_footer_right, half + 4, txt_y);
+  }
 }
 
 void bb_page_locked_set_visible(int visible) {
@@ -257,4 +307,26 @@ void bb_page_locked_update_status(const char* status) {
     lv_label_set_text(s_lbl_title, "设备已锁定");
     lv_label_set_text(s_lbl_hint, "请按住说话键后说出密语");
   }
+}
+
+void bb_page_locked_update_footer(const char* cwd, int mem_inbox, int mem_profile) {
+  if (s_lbl_footer_left == NULL || s_lbl_footer_right == NULL) return;
+
+  /* Left: "[B] <cwd>" or "[B]" */
+  char left_buf[56];
+  if (cwd != NULL && cwd[0] != '\0') {
+    snprintf(left_buf, sizeof(left_buf), "[B] %s", cwd);
+  } else {
+    snprintf(left_buf, sizeof(left_buf), "[B]");
+  }
+  lv_label_set_text(s_lbl_footer_left, left_buf);
+
+  /* Right: "mem: N+M" or "mem: ?" */
+  char right_buf[24];
+  if (mem_inbox >= 0 && mem_profile >= 0) {
+    snprintf(right_buf, sizeof(right_buf), "mem: %d+%d", mem_inbox, mem_profile);
+  } else {
+    snprintf(right_buf, sizeof(right_buf), "mem: ?");
+  }
+  lv_label_set_text(s_lbl_footer_right, right_buf);
 }

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -1134,6 +1134,19 @@ static void on_finish_stream_event(bb_finish_stream_event_t* event, void* user_c
     return;
   }
 
+  /* ADR-021-firmware-ui §1.2: butler dispatch progress → top status label */
+  if (event->type == BB_FINISH_STREAM_EVENT_DISPATCH_STATUS && event->dispatch != NULL) {
+    const bb_dispatch_status_t* ds = event->dispatch;
+    ESP_LOGI(TAG, "phase=dispatch_status phase=%s cwd=%s taskId=%s elapsedMs=%lld",
+             ds->phase, ds->cwd, ds->task_id, (long long)ds->elapsed_ms);
+    bb_display_set_dispatch_status(ds->phase, ds->cwd, ds->task_id, ds->elapsed_ms);
+    /* Also update butler cwd from "started" phase so footer left cell stays current */
+    if (strcmp(ds->phase, "started") == 0 && ds->cwd[0] != '\0') {
+      bb_display_set_butler_cwd(ds->cwd);
+    }
+    return;
+  }
+
   if (event->type == BB_FINISH_STREAM_EVENT_REPLY_DELTA && event->text != NULL && event->text[0] != '\0') {
     /* reply delta replaces only the reply portion, keep process log prefix */
     size_t prefix_len = 0;


### PR DESCRIPTION
Fixes #104

## 变更内容

### 协议层 (bb_adapter_client.h / .c)
- 新增 `BB_FINISH_STREAM_EVENT_DISPATCH_STATUS` 事件枚举值
- 新增 `bb_dispatch_status_t` 结构体（phase / task_id / cwd / elapsed_ms）
- `bb_finish_stream_event_t` 添加 `dispatch` 字段
- HTTP streaming（parse_finish_stream_line）和 WS（ws_handle_text_message）两条路径均解析 `dispatch_status` NDJSON 帧，通过独立 `emit_dispatch_event()` 投递，不影响现有 EvToolCall 等路由
- `emit_finish_stream_event` 添加 `.dispatch = NULL` 默认初始化

### 显示接口 (bb_display.h / bb_lvgl_display.c)
- 新增三个接口：`bb_display_set_butler_cwd` / `bb_display_set_dispatch_status` / `bb_display_set_mem_stats`
- `apply_bottom_bar()` 改造：左侧 `[B] <cwd>`，右侧 `mem: N+M`（未知时 `mem: ?`）
- refresh_ui ACTIVE 分支：dispatch phase 仲裁注入顶部 `s_lbl_status`（优先级 error > async > done > started > 常态）
- refresh_ui LOCKED 分支：补调用 `bb_page_locked_update_footer()`
- `bb_display_set_dispatch_status` 含 `lv_timer` 4s 自动回归（done/async/error phase）

### LOCKED 页 footer (bb_page_locked.h / .c)
- 新增 `UI_SAFE_BOTTOM` / `UI_BOTTOM_BAR_H` 常量（与 bb_lvgl_display.c 保持一致）
- `bb_page_locked_create()` 末尾附加 footer status bar（`s_obj_footer` + 左右两个 label）
- 新增 `bb_page_locked_update_footer(cwd, mem_inbox, mem_profile)` 实现

### 事件消费 (bb_radio_app.c)
- `on_finish_stream_event()` 新增 `DISPATCH_STATUS` case，调用 `bb_display_set_dispatch_status` + `bb_display_set_butler_cwd`（started 时同步更新 footer cwd）

## 已知限制 / 后续工作
- **图标资源（v1 fallback）**：图标未就绪，当前用 `[B]`/`[W]` 文字前缀，后续图标入库后替换渲染调用
- **mem stats API**：`/v1/butler/workspace/memory/stats` 暂未就绪，footer 右侧恒显示 `mem: ?`；API 落地后调用 `bb_display_set_mem_stats()` 即可更新
- **硬件验证**：本 PR 不含串口/硬件验证，需在实机（bbclaw board）上运行用例 1/4/5（ADR §5）。Simulator 构建因 `managed_components/lvgl__lvgl` 需要 idf 初始化，CI 环境中待补
- **SETTINGS 页 footer**：Issue 工作清单中未明确要求，SETTINGS 页暂未添加 footer（ADR §2 提到三页共享，可作后续小 patch）