### PR TITLE
feat(firmware): 砍 session picker，新建 Task List 页；CHAT 短按 OK 进入；行 OK 触发 task_status 追问

### DIFF
--- a/firmware/include/bb_agent_client.h
+++ b/firmware/include/bb_agent_client.h
@@ -213,6 +213,19 @@ typedef struct {
 } bb_agent_cwd_entry_t;
 
 /**
+ * One task entry from GET /v1/butler/dispatch/recent (ADR-021-firmware-ui §1.4).
+ * Represents a recently dispatched background task.
+ */
+typedef struct {
+  char task_id[64];   /* tool_use.id used by butler MCP dispatch */
+  char cwd[32];       /* target project short name */
+  char title[52];     /* prompt snippet, truncated to ~24 CJK chars */
+  char status[16];    /* "running" | "done" | "error" | "async" */
+  int64_t started_at_ms; /* Unix epoch ms; 0 if unavailable */
+  int64_t elapsed_ms;    /* worker wall time; 0 if not completed */
+} bb_agent_dispatch_entry_t;
+
+/**
  * GET /v1/agent/cwd-pool — list available project working directories (issue #30).
  *
  * @param out_list   Caller-provided array; may be NULL (count-only query).
@@ -221,3 +234,14 @@ typedef struct {
  * @return ESP_OK / error code.
  */
 esp_err_t bb_agent_list_cwd_pool(bb_agent_cwd_entry_t* out_list, int cap, int* out_count);
+
+/**
+ * GET /v1/butler/dispatch/recent — list recent dispatch tasks (ADR-021-firmware-ui §1.4).
+ * Returns up to `cap` entries ordered newest-first.
+ *
+ * @param out_list   Caller-provided array; may be NULL (count-only query).
+ * @param cap        Capacity of out_list; ignored when out_list is NULL.
+ * @param out_count  Total entries returned (not capped by cap).
+ * @return ESP_OK / error code. Returns ESP_OK with *out_count=0 when buffer is empty.
+ */
+esp_err_t bb_agent_list_dispatch_recent(bb_agent_dispatch_entry_t* out_list, int cap, int* out_count);

--- a/firmware/include/bb_ui_agent_chat.h
+++ b/firmware/include/bb_ui_agent_chat.h
@@ -210,50 +210,8 @@ void bb_ui_agent_chat_voice_listening(int begin);
  */
 void bb_ui_agent_chat_voice_processing(void);
 
-/* ── Phase S1 — Session Picker (multi-session management) ── */
-
-/**
- * Open the session picker overlay. Triggers an async fetch of sessions
- * for the current driver, then builds the picker UI on completion.
- * Must be called inside the LVGL lock.
- */
-void bb_ui_agent_chat_session_picker_show(void);
-
-/**
- * Close the session picker overlay.
- * Must be called inside the LVGL lock.
- */
-void bb_ui_agent_chat_session_picker_hide(void);
-
-/**
- * Move the session picker highlight. delta = -1 (up) / +1 (down), wraps.
- * Must be called inside the LVGL lock.
- */
-void bb_ui_agent_chat_session_picker_move(int delta);
-
-/**
- * Confirm the currently highlighted session picker row.
- * Returns action code:
- *   0 = switched to selected session
- *   2 = user chose "+ 新建 session" (triggers CWD picker)
- *  -1 = no action (picker not visible, driver row selected, or invalid state)
- * Must be called inside the LVGL lock.
- */
-int bb_ui_agent_chat_session_picker_select(void);
-
-/**
- * Cycle the driver selector while the session picker is open and the driver
- * row (row 0) is highlighted.
- * Returns 1 if the event was consumed (driver row was active), 0 if the
- * caller should fall back to the normal close-picker + cycle-driver path.
- * Must be called inside the LVGL lock.
- */
-int bb_ui_agent_chat_session_picker_driver_cycle(int delta);
-
-/**
- * Returns 1 if the session picker is currently visible (loading or shown).
- */
-int bb_ui_agent_chat_session_picker_is_visible(void);
+/* Session picker removed (ADR-021-firmware-ui v2, issue #103).
+ * Short-press OK in CHAT now opens the Task List page (bb_ui_task_list.h). */
 
 /* ── CWD Pool Picker (issue #30) ── */
 

--- a/firmware/include/bb_ui_task_list.h
+++ b/firmware/include/bb_ui_task_list.h
@@ -1,0 +1,44 @@
+#pragma once
+
+/**
+ * Task List page — independent LVGL screen showing recent butler dispatch tasks.
+ *
+ * ADR-021-firmware-ui §3 / §4.2 (Sub-PR D):
+ *   - Entered via short-press OK from CHAT
+ *   - ↑↓ selects row; OK sends "task_status #<taskId>" turn and returns to CHAT
+ *   - BACK returns to CHAT with no side effects
+ *
+ * All functions must be called from the LVGL task (inside lvgl_port_lock).
+ */
+
+/**
+ * Show the Task List page. Triggers an async fetch of /v1/butler/dispatch/recent
+ * and renders results. No-op if already visible.
+ * Must be called inside the LVGL lock.
+ */
+void bb_ui_task_list_show(void);
+
+/**
+ * Hide the Task List page and destroy its LVGL screen.
+ * Must be called inside the LVGL lock.
+ */
+void bb_ui_task_list_hide(void);
+
+/**
+ * Returns 1 if the Task List page is currently visible (loading or shown).
+ */
+int bb_ui_task_list_visible(void);
+
+/**
+ * Move the selection highlight. delta = -1 (up) / +1 (down), wraps.
+ * Must be called inside the LVGL lock.
+ */
+void bb_ui_task_list_move(int delta);
+
+/**
+ * Activate the currently selected row:
+ *   - Sends "task_status #<taskId>" as a text turn via bb_ui_agent_chat_send
+ *   - Hides the Task List page (returns to CHAT screen)
+ * Must be called inside the LVGL lock.
+ */
+void bb_ui_task_list_activate(void);

--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -32,6 +32,7 @@ set(_bb_srcs
     "bb_theme_buddy_anim.c"
     "bb_time.c"
     "bb_ui_agent_chat.c"
+    "bb_ui_task_list.c"
     "bb_ui_settings.c"
     "bb_transport.c"
     "bb_wifi.c"

--- a/firmware/src/bb_agent_client.c
+++ b/firmware/src/bb_agent_client.c
@@ -1034,3 +1034,118 @@ esp_err_t bb_agent_send_message(const char* text, const char* session_id, const 
   }
   return ESP_OK;
 }
+
+/* ── public: list recent dispatch tasks (ADR-021-firmware-ui §1.4) ── */
+
+esp_err_t bb_agent_list_dispatch_recent(bb_agent_dispatch_entry_t* out_list, int cap, int* out_count) {
+  if (out_count != NULL) {
+    *out_count = 0;
+  }
+
+  char url[256] = {0};
+  agent_build_url(url, sizeof(url), "/v1/butler/dispatch/recent");
+
+  bb_http_dyn_accum_t accum = {0};
+  esp_http_client_config_t cfg;
+  bb_http_cfg_init(&cfg, url, BBCLAW_HTTP_TIMEOUT_MS, HTTP_METHOD_GET,
+                   http_event_handler_dyn, &accum);
+
+  esp_http_client_handle_t client = esp_http_client_init(&cfg);
+  if (client == NULL) {
+    return ESP_ERR_NO_MEM;
+  }
+
+  esp_err_t err = esp_http_client_perform(client);
+  int status = (err == ESP_OK) ? esp_http_client_get_status_code(client) : 0;
+  esp_http_client_cleanup(client);
+
+  if (err != ESP_OK) {
+    free(accum.buf);
+    ESP_LOGE(TAG, "list_dispatch_recent transport err=%s", esp_err_to_name(err));
+    return err;
+  }
+  if (status < 200 || status >= 300 || accum.buf == NULL) {
+    ESP_LOGE(TAG, "list_dispatch_recent http status=%d body=%.120s", status,
+             accum.buf != NULL ? accum.buf : "(null)");
+    free(accum.buf);
+    return ESP_FAIL;
+  }
+
+  cJSON* root = cJSON_Parse(accum.buf);
+  free(accum.buf);
+  accum.buf = NULL;
+  if (root == NULL) {
+    ESP_LOGE(TAG, "list_dispatch_recent parse failed");
+    return ESP_FAIL;
+  }
+
+  /* Response is a top-level JSON array (no wrapper object). */
+  if (!cJSON_IsArray(root)) {
+    ESP_LOGE(TAG, "list_dispatch_recent: expected JSON array");
+    cJSON_Delete(root);
+    return ESP_FAIL;
+  }
+
+  int total = cJSON_GetArraySize(root);
+  if (out_count != NULL) {
+    *out_count = total;
+  }
+  if (out_list != NULL && cap > 0) {
+    int n = total < cap ? total : cap;
+    for (int i = 0; i < n; i++) {
+      const cJSON* item = cJSON_GetArrayItem(root, i);
+      if (item == NULL) continue;
+      bb_agent_dispatch_entry_t* slot = &out_list[i];
+      memset(slot, 0, sizeof(*slot));
+
+      const cJSON* task_id = cJSON_GetObjectItemCaseSensitive(item, "taskId");
+      if (cJSON_IsString(task_id) && task_id->valuestring != NULL) {
+        strncpy(slot->task_id, task_id->valuestring, sizeof(slot->task_id) - 1);
+        slot->task_id[sizeof(slot->task_id) - 1] = '\0';
+      }
+
+      const cJSON* cwd = cJSON_GetObjectItemCaseSensitive(item, "cwd");
+      if (cJSON_IsString(cwd) && cwd->valuestring != NULL) {
+        strncpy(slot->cwd, cwd->valuestring, sizeof(slot->cwd) - 1);
+        slot->cwd[sizeof(slot->cwd) - 1] = '\0';
+      }
+
+      const cJSON* title = cJSON_GetObjectItemCaseSensitive(item, "title");
+      if (cJSON_IsString(title) && title->valuestring != NULL) {
+        strncpy(slot->title, title->valuestring, sizeof(slot->title) - 1);
+        slot->title[sizeof(slot->title) - 1] = '\0';
+      }
+
+      const cJSON* st = cJSON_GetObjectItemCaseSensitive(item, "status");
+      if (cJSON_IsString(st) && st->valuestring != NULL) {
+        strncpy(slot->status, st->valuestring, sizeof(slot->status) - 1);
+        slot->status[sizeof(slot->status) - 1] = '\0';
+      }
+
+      const cJSON* started = cJSON_GetObjectItemCaseSensitive(item, "startedAt");
+      if (cJSON_IsString(started) && started->valuestring != NULL) {
+        /* ISO 8601 — crude epoch-ms parse for relative time display only. */
+        struct tm tm_val = {0};
+        if (sscanf(started->valuestring, "%d-%d-%dT%d:%d:%d",
+                   &tm_val.tm_year, &tm_val.tm_mon, &tm_val.tm_mday,
+                   &tm_val.tm_hour, &tm_val.tm_min, &tm_val.tm_sec) == 6) {
+          tm_val.tm_year -= 1900;
+          tm_val.tm_mon -= 1;
+          time_t t = mktime(&tm_val);
+          if (t != (time_t)-1) {
+            slot->started_at_ms = (int64_t)t * 1000LL;
+          }
+        }
+      }
+
+      const cJSON* elapsed = cJSON_GetObjectItemCaseSensitive(item, "elapsedMs");
+      if (cJSON_IsNumber(elapsed)) {
+        slot->elapsed_ms = (int64_t)elapsed->valuedouble;
+      }
+    }
+  }
+
+  ESP_LOGI(TAG, "list_dispatch_recent ok total=%d", total);
+  cJSON_Delete(root);
+  return ESP_OK;
+}

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -26,6 +26,7 @@
 #include "bb_transport.h"
 #include "bb_agent_theme.h"
 #include "bb_ui_agent_chat.h"
+#include "bb_ui_task_list.h"
 #include "bb_session_store.h"
 #include "bb_ui_settings.h"
 #include "bb_wifi.h"
@@ -781,7 +782,7 @@ static void on_nav_event(bb_nav_event_t event) {
   if ((event == BB_NAV_EVENT_UP || event == BB_NAV_EVENT_DOWN) &&
       s_app_state == BBCLAW_STATE_CHAT &&
       s_agent_chat_active &&
-      !bb_ui_agent_chat_session_picker_is_visible() &&
+      !bb_ui_task_list_visible() &&
       !bb_ui_agent_chat_cwd_picker_is_visible()) {
     bb_chat_scroll_request(event == BB_NAV_EVENT_UP ? -2 : 2);
     s_last_activity_ms = bb_now_ms();  /* keep idle-timeout fresh */
@@ -1732,7 +1733,7 @@ static void stream_task(void* arg) {
             }
             int busy = agent_chat_is_busy_locked();
             int cwd_up = bb_ui_agent_chat_cwd_picker_is_visible();
-            int picker_up = bb_ui_agent_chat_session_picker_is_visible();
+            int task_list_up = bb_ui_task_list_visible();
             if (cwd_up) {
               /* CWD picker is open — route nav to it. */
               switch (nav) {
@@ -1762,58 +1763,37 @@ static void stream_task(void* arg) {
                   break;
                 default: break;
               }
-            } else if (picker_up) {
-              /* Session picker is open — route nav to picker. Longer lock
-               * timeout (600ms) tolerates LVGL congestion during TTS playback. */
+            } else if (task_list_up) {
+              /* Task List page is open (ADR-021-firmware-ui §3, issue #103).
+               * Route ↑↓ to row selection, OK to task_status turn, BACK to CHAT. */
               switch (nav) {
                 case BB_NAV_EVENT_UP:
                   if (lvgl_port_lock(600)) {
-                    bb_ui_agent_chat_session_picker_move(-1);
+                    bb_ui_task_list_move(-1);
                     lvgl_port_unlock();
                   }
                   break;
                 case BB_NAV_EVENT_DOWN:
                   if (lvgl_port_lock(600)) {
-                    bb_ui_agent_chat_session_picker_move(+1);
+                    bb_ui_task_list_move(+1);
                     lvgl_port_unlock();
                   }
                   break;
                 case BB_NAV_EVENT_OK:
+                  /* Sends "task_status #<taskId>" turn and returns to CHAT. */
                   if (lvgl_port_lock(600)) {
-                    bb_ui_agent_chat_session_picker_select();
+                    bb_ui_task_list_activate();
                     lvgl_port_unlock();
                   } else {
-                    ESP_LOGW(TAG, "CHAT picker: OK select lock timeout");
+                    ESP_LOGW(TAG, "CHAT task_list: OK activate lock timeout");
                   }
                   break;
                 case BB_NAV_EVENT_BACK:
                   if (lvgl_port_lock(600)) {
-                    bb_ui_agent_chat_session_picker_hide();
+                    bb_ui_task_list_hide();
                     lvgl_port_unlock();
                   }
                   break;
-                case BB_NAV_EVENT_LEFT:
-                case BB_NAV_EVENT_RIGHT: {
-                  /* If the driver row is highlighted, cycle driver in-place
-                   * and re-fetch sessions; otherwise close picker and cycle. */
-                  int consumed = 0;
-                  if (lvgl_port_lock(600)) {
-                    consumed = bb_ui_agent_chat_session_picker_driver_cycle(
-                        nav == BB_NAV_EVENT_RIGHT ? +1 : -1);
-                    lvgl_port_unlock();
-                  }
-                  if (!consumed) {
-                    /* Non-driver row: close picker, then cycle driver. */
-                    if (lvgl_port_lock(600)) {
-                      bb_ui_agent_chat_session_picker_hide();
-                      lvgl_port_unlock();
-                    }
-                    if (!busy) {
-                      agent_chat_cycle_driver_locked(nav == BB_NAV_EVENT_RIGHT ? +1 : -1);
-                    }
-                  }
-                  break;
-                }
                 default: break;
               }
             } else {
@@ -1849,15 +1829,14 @@ static void stream_task(void* arg) {
                   }
                   break;
                 case BB_NAV_EVENT_OK:
-                  /* Allow opening session picker even while TTS/agent is busy —
-                   * picker is a passive list overlay and does not disturb the
-                   * background stream. Longer lock timeout accommodates LVGL
-                   * task congestion during TTS chunk playback. */
+                  /* Short-press OK → Task List page (ADR-021-firmware-ui §3, issue #103).
+                   * Passive screen switch; allowed even while TTS/agent is busy.
+                   * Long-press OK → SETTINGS (handled by nav driver, emitted as BACK). */
                   if (lvgl_port_lock(600)) {
-                    bb_ui_agent_chat_session_picker_show();
+                    bb_ui_task_list_show();
                     lvgl_port_unlock();
                   } else {
-                    ESP_LOGW(TAG, "CHAT: OK session picker lock timeout");
+                    ESP_LOGW(TAG, "CHAT: OK task_list lock timeout");
                   }
                   break;
                 case BB_NAV_EVENT_BACK:
@@ -2981,7 +2960,7 @@ static void stream_task(void* arg) {
          * (e.g. creating a new session, streaming reply, fetching sessions).
          * Those states represent an in-progress user interaction and must
          * not trip the 30s idle timer. */
-        int picker_open = bb_ui_agent_chat_session_picker_is_visible() ||
+        int picker_open = bb_ui_task_list_visible() ||
                           bb_ui_agent_chat_cwd_picker_is_visible();
         int busy = agent_chat_is_busy_locked();
         if (!picker_open && !busy &&

--- a/firmware/src/bb_ui_agent_chat.c
+++ b/firmware/src/bb_ui_agent_chat.c
@@ -136,9 +136,8 @@ static inline lv_result_t safe_lv_async_call(lv_async_cb_t cb, void* user_data) 
 #define BB_CHAT_PICKER_MAX_ITEMS 12
 #define BB_CHAT_DRIVER_CACHE_MAX 6
 
-/* Session picker (Phase S1) — full-screen overlay for multi-session switching. */
-#define BB_SESSION_PICKER_MAX      16
-#define BB_SESSION_PICKER_VISIBLE  6
+/* Session picker removed (ADR-021-firmware-ui v2, issue #103).
+ * BB_SESSION_PICKER_ROW_H kept for history-fetch row sizing compatibility. */
 #define BB_SESSION_PICKER_ROW_H    20
 
 /* Phase S3 — history replay tunables.
@@ -156,11 +155,6 @@ static inline lv_result_t safe_lv_async_call(lv_async_cb_t cb, void* user_data) 
 #define BB_CWD_PICKER_MAX      8
 #define BB_CWD_PICKER_VISIBLE  5
 #define BB_CWD_PICKER_ROW_H    20
-
-/* Action codes returned by session_picker_select(). */
-#define BB_SESSION_PICKER_ACTION_SWITCH       0
-#define BB_SESSION_PICKER_ACTION_NEW_SESSION  2
-#define BB_SESSION_PICKER_ACTION_NONE        (-1)
 
 /* NVS 配置（与 bb_agent_theme.c 同 namespace）。 */
 #define BB_CHAT_NVS_NS         "bbclaw"
@@ -215,18 +209,8 @@ typedef struct {
   volatile int driver_fetch_pending;
   volatile uint32_t driver_fetch_generation;
 
-  /* Session picker (Phase S1) — multi-session management. */
-  bb_agent_session_info_t session_list[BB_SESSION_PICKER_MAX];
-  int session_list_count;
-  int session_picker_sel;              /* highlighted row (0-based, includes + New / Settings) */
-  int session_picker_active_idx;       /* index of current session in list (-1 if not found) */
-  int session_picker_visible;          /* 0=hidden, 1=loading, 2=visible */
-  lv_obj_t* session_picker_root;
-  lv_obj_t* session_picker_title;      /* title label — updated by apply_styles for position indicator */
-  /* ADR-016: Driver row dropped from session picker (driver selection lives
-   * in Settings now). Layout is "+ New" at row 0, then sessions. */
-  lv_obj_t* session_picker_items[BB_SESSION_PICKER_MAX + 1]; /* New + sessions */
-  int session_picker_total_rows;       /* session_list_count + 1 (just "+ New") */
+  /* Session picker removed (ADR-021-firmware-ui v2, issue #103).
+   * session_fetch fields kept as stale-guard pattern reference for history. */
   volatile int session_fetch_pending;
   volatile uint32_t session_fetch_generation;
 
@@ -322,11 +306,6 @@ static void tts_cancel_in_flight(void);
 /* Forward decls for Phase 4.2.5 / Phase 5 async driver fetch (used by cycle_driver). */
 static void spawn_driver_fetch_task(void);
 static void apply_driver_cache_idx(void);
-
-/* Forward decls for session picker UI (used by on_driver_fetch_done to rebuild
- * the picker in-place when the driver list arrives after the picker is open). */
-static void session_picker_build_ui(void);
-static void session_picker_apply_styles(void);
 
 /* Forward decls for Phase S3 history replay (defined alongside session-fetch). */
 static void spawn_history_fetch_task(int before, int is_initial);
@@ -1342,7 +1321,7 @@ void bb_ui_agent_chat_show(lv_obj_t* parent) {
   if (theme->on_enter != NULL) theme->on_enter(parent);
   if (theme->set_state != NULL) theme->set_state(BB_AGENT_STATE_SLEEP);
   /* Initialize s_chat.driver_name with the fallback so downstream callers
-   * (session_picker_select / spawn_history_fetch_task / session_store_save)
+   * (spawn_history_fetch_task / session_store_save)
    * always see a non-empty driver. The first SESSION frame from adapter
    * will overwrite this with the real driver name. Without this, picking a
    * session from the picker before any agent turn happens triggers the
@@ -1701,13 +1680,7 @@ static void on_driver_fetch_done(void* user_data) {
   }
   /* If the session picker is already visible, rebuild it so the driver row
    * reflects the freshly-loaded driver list instead of staying at "drv: ...".
-   * Preserve the current selection so the cursor doesn't jump. */
-  if (s_chat.session_picker_visible == 2) {
-    int saved_sel = s_chat.session_picker_sel;
-    session_picker_build_ui();
-    s_chat.session_picker_sel = saved_sel;
-    session_picker_apply_styles();
-  }
+  /* Session picker removed (ADR-021-firmware-ui v2) — no picker to rebuild. */
   free(res);
 }
 
@@ -1757,103 +1730,10 @@ static void spawn_driver_fetch_task(void) {
   }
 }
 
-/* ── Phase S1 — session picker (multi-session management) ──
- *
- * Full-screen overlay listing sessions for the current driver. Fetched
- * asynchronously via bb_agent_list_sessions (already implemented for both
- * local_home and cloud_saas). Pattern mirrors spawn_driver_fetch_task.
- */
-
-typedef struct {
-  uint32_t gen;
-  esp_err_t err;
-  int total;
-  bb_agent_session_info_t entries[BB_SESSION_PICKER_MAX];
-} session_fetch_result_t;
-
-#define BB_SESSION_FETCH_TASK_STACK 4096
-#define BB_SESSION_FETCH_TASK_PRIO  4
-
-static void session_picker_apply_styles(void);
-static void session_picker_build_ui(void);
-
-static void on_session_fetch_done(void* user_data) {
-  session_fetch_result_t* res = (session_fetch_result_t*)user_data;
-  if (res == NULL) return;
-  s_chat.session_fetch_pending = 0;
-  if (!s_chat.active || res->gen != s_chat.session_fetch_generation) {
-    free(res);
-    return;
-  }
-  if (res->err != ESP_OK) {
-    ESP_LOGW(TAG, "session fetch failed: %s", esp_err_to_name(res->err));
-    s_chat.session_list_count = 0;
-    s_chat.session_picker_visible = 0;
-    free(res);
-    return;
-  }
-  int total = res->total > BB_SESSION_PICKER_MAX ? BB_SESSION_PICKER_MAX : res->total;
-  memcpy(s_chat.session_list, res->entries, sizeof(res->entries[0]) * (size_t)total);
-  s_chat.session_list_count = total;
-
-  /* Find the active session in the list. */
-  s_chat.session_picker_active_idx = -1;
-  for (int i = 0; i < total; ++i) {
-    if (s_chat.session_id[0] != '\0' &&
-        strcmp(s_chat.session_list[i].id, s_chat.session_id) == 0) {
-      s_chat.session_picker_active_idx = i;
-      /* ADR-016: surface the adapter-side title to the bottom bar so the
-       * left cell switches from the sid hex tail to the friendly alias
-       * (e.g. "daboluocc-bbclaw") as soon as the session-list fetch lands. */
-      bb_display_set_session_alias(s_chat.session_list[i].title);
-      break;
-    }
-  }
-
-  s_chat.session_picker_visible = 2;
-  session_picker_build_ui();
-  free(res);
-}
-
-static void session_fetch_task(void* arg) {
-  uint32_t my_gen = (uint32_t)(uintptr_t)arg;
-  session_fetch_result_t* res = (session_fetch_result_t*)calloc(1, sizeof(*res));
-  if (res == NULL) {
-    s_chat.session_fetch_pending = 0;
-    vTaskDelete(NULL);
-    return;
-  }
-  res->gen = my_gen;
-  for (int i = 0; i < 50 && !bb_wifi_is_connected(); ++i) {
-    vTaskDelay(pdMS_TO_TICKS(200));
-  }
-  const char* drv = s_chat.driver_name[0] != '\0'
-                      ? s_chat.driver_name : BB_CHAT_DRIVER_FALLBACK;
-  res->err = bb_agent_list_sessions(drv, res->entries, BB_SESSION_PICKER_MAX, &res->total);
-  safe_lv_async_call(on_session_fetch_done, res);
-  vTaskDelete(NULL);
-}
-
-static void spawn_session_fetch_task(void) {
-  if (s_chat.session_fetch_pending) return;
-  s_chat.session_fetch_pending = 1;
-  uint32_t gen = ++s_chat.session_fetch_generation;
-  TaskHandle_t t = NULL;
-  BaseType_t ok = xTaskCreate(session_fetch_task, "ses_fetch",
-                              BB_SESSION_FETCH_TASK_STACK,
-                              (void*)(uintptr_t)gen,
-                              BB_SESSION_FETCH_TASK_PRIO, &t);
-  if (ok != pdPASS) {
-    ESP_LOGE(TAG, "spawn_session_fetch_task: xTaskCreate failed");
-    s_chat.session_fetch_pending = 0;
-  }
-}
-
 /* ── Phase S3 — history replay fetch ───────────────────────────────────────
  *
  * Lifecycle:
- *   1. session_picker_select() rebuilds the empty transcript and calls
- *      spawn_history_fetch_task(-1, is_initial=1).
+ *   1. spawn_history_fetch_task(-1, is_initial=1) is called after session switch.
  *   2. The worker task calls bb_agent_load_messages() (HTTP GET, blocks
  *      until response or timeout).
  *   3. Worker hands the result struct (which OWNS the bb_agent_message_t
@@ -2071,62 +1951,8 @@ static void history_state_reset(void) {
   s_chat.history_fetch_generation++;
 }
 
-/* ── Session picker UI ── */
+/* Session picker UI removed (ADR-021-firmware-ui v2, issue #103). */
 
-#define BB_SPICKER_BG       0x12211b
-#define BB_SPICKER_FG       0xc8e2d6
-#define BB_SPICKER_FG_DIM   0x6b8c80
-#define BB_SPICKER_SEL_BG   0x2ec4a0
-#define BB_SPICKER_SEL_FG   0x0a0e0c
-#define BB_SPICKER_TITLE_H  22
-
-static void session_picker_apply_styles(void) {
-  const int total = s_chat.session_picker_total_rows;
-  if (total == 0) return;
-  int first = s_chat.session_picker_sel - BB_SESSION_PICKER_VISIBLE / 2;
-  if (first < 0) first = 0;
-  if (first + BB_SESSION_PICKER_VISIBLE > total) {
-    first = total - BB_SESSION_PICKER_VISIBLE;
-    if (first < 0) first = 0;
-  }
-  for (int i = 0; i < total; ++i) {
-    lv_obj_t* row = s_chat.session_picker_items[i];
-    if (row == NULL) continue;
-    int visible = (i >= first && i < first + BB_SESSION_PICKER_VISIBLE);
-    if (visible) {
-      lv_obj_clear_flag(row, LV_OBJ_FLAG_HIDDEN);
-    } else {
-      lv_obj_add_flag(row, LV_OBJ_FLAG_HIDDEN);
-    }
-    if (i == s_chat.session_picker_sel) {
-      lv_obj_set_style_bg_color(row, lv_color_hex(BB_SPICKER_SEL_BG), 0);
-      lv_obj_set_style_bg_opa(row, LV_OPA_COVER, 0);
-      lv_obj_set_style_text_color(row, lv_color_hex(BB_SPICKER_SEL_FG), 0);
-    } else {
-      lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
-      lv_obj_set_style_text_color(row, lv_color_hex(BB_SPICKER_FG_DIM), 0);
-    }
-  }
-
-  /* Update title position indicator: "Sessions (drv) cur/total" when a
-   * session row is selected; "Sessions (drv) total" otherwise. */
-  if (s_chat.session_picker_title != NULL) {
-    const int n_sessions = s_chat.session_list_count;
-    const char* drv = s_chat.driver_name[0] != '\0'
-                        ? s_chat.driver_name : BB_CHAT_DRIVER_FALLBACK;
-    char title_buf[64];
-    if (n_sessions > 0 && s_chat.session_picker_sel >= 1) {
-      /* sel >= 1 means a session row is highlighted (sel==0 is "+ New") */
-      int cur = s_chat.session_picker_sel; /* 1-based among session rows */
-      snprintf(title_buf, sizeof(title_buf), "Sessions (%s) %d/%d", drv, cur, n_sessions);
-    } else if (n_sessions > 0) {
-      snprintf(title_buf, sizeof(title_buf), "Sessions (%s) %d", drv, n_sessions);
-    } else {
-      snprintf(title_buf, sizeof(title_buf), "Sessions (%s)", drv);
-    }
-    lv_label_set_text(s_chat.session_picker_title, title_buf);
-  }
-}
 
 static void format_relative_time(int64_t last_used_ms, char* buf, int buf_len) {
   if (last_used_ms <= 0) {
@@ -2152,178 +1978,6 @@ static void format_relative_time(int64_t last_used_ms, char* buf, int buf_len) {
   } else {
     snprintf(buf, (size_t)buf_len, "%dd", (int)(diff_s / 86400));
   }
-}
-
-static void session_picker_build_ui(void) {
-  if (s_chat.parent == NULL) return;
-
-#ifdef BBCLAW_HAVE_CJK_FONT
-  extern const lv_font_t lv_font_bbclaw_cjk;
-  const lv_font_t* font = &lv_font_bbclaw_cjk;
-#else
-  const lv_font_t* font = lv_font_get_default();
-#endif
-
-  /* Tear down previous picker if any. */
-  if (s_chat.session_picker_root != NULL) {
-    lv_obj_del(s_chat.session_picker_root);
-    s_chat.session_picker_root = NULL;
-    s_chat.session_picker_title = NULL;
-    memset(s_chat.session_picker_items, 0, sizeof(s_chat.session_picker_items));
-  }
-
-  const int n_sessions = s_chat.session_list_count;
-  /* ADR-016 layout: [+ 新建 session] [session 0..n-1].
-   * Driver selection moved to Settings — picker is for sessions only. */
-  const int total_rows = n_sessions + 1; /* New + sessions */
-  s_chat.session_picker_total_rows = total_rows;
-  /* Active idx is into session_list[]; the picker visual idx is shifted by 1
-   * because row 0 is "+ 新建 session". When no session is active, default
-   * focus to row 0 (New). */
-  s_chat.session_picker_sel = (s_chat.session_picker_active_idx >= 0)
-                                ? s_chat.session_picker_active_idx + 1 : 0;
-
-  /* Full-screen overlay. */
-  s_chat.session_picker_root = lv_obj_create(s_chat.parent);
-  lv_obj_remove_style_all(s_chat.session_picker_root);
-  /* Fixed size — lv_pct(100) on the root combined with flex column children
-   * triggers the same LVGL 9.5 layout oscillation that hangs transcript.
-   * Screen is 320x172; the picker covers the full display. */
-  lv_obj_set_size(s_chat.session_picker_root, 320, 172);
-  lv_obj_align(s_chat.session_picker_root, LV_ALIGN_TOP_LEFT, 0, 0);
-  lv_obj_set_style_bg_color(s_chat.session_picker_root, lv_color_hex(BB_SPICKER_BG), 0);
-  lv_obj_set_style_bg_opa(s_chat.session_picker_root, LV_OPA_COVER, 0);
-  lv_obj_set_style_pad_all(s_chat.session_picker_root, 2, 0);
-  lv_obj_set_flex_flow(s_chat.session_picker_root, LV_FLEX_FLOW_COLUMN);
-  lv_obj_clear_flag(s_chat.session_picker_root, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_move_foreground(s_chat.session_picker_root);
-
-  /* Title row. */
-  lv_obj_t* title = lv_label_create(s_chat.session_picker_root);
-  s_chat.session_picker_title = title;
-  lv_obj_set_size(title, 316, BB_SPICKER_TITLE_H);
-  lv_obj_set_style_text_color(title, lv_color_hex(BB_SPICKER_FG), 0);
-  lv_obj_set_style_text_font(title, font, 0);
-  lv_obj_set_style_pad_left(title, 2, 0);
-  lv_label_set_long_mode(title, LV_LABEL_LONG_MODE_DOTS);
-  char title_buf[48];
-  const char* drv = s_chat.driver_name[0] != '\0'
-                      ? s_chat.driver_name : BB_CHAT_DRIVER_FALLBACK;
-  if (n_sessions > 0) {
-    /* Show position indicator: current index is unknown at build time (sel
-     * may be on Driver or New row), so show total count for now. The
-     * apply_styles pass will update it once sel is known. */
-    snprintf(title_buf, sizeof(title_buf), "Sessions (%s) %d", drv, n_sessions);
-  } else {
-    snprintf(title_buf, sizeof(title_buf), "Sessions (%s)", drv);
-  }
-  lv_label_set_text(title, title_buf);
-
-  /* Row 0: "+ 新建 session" fixed entry. (ADR-016: Driver row removed — driver
-   * selection now lives in Settings, reached by long-press OK from chat.) */
-  {
-    lv_obj_t* row = lv_label_create(s_chat.session_picker_root);
-    lv_obj_set_size(row, 316, BB_SESSION_PICKER_ROW_H);
-    lv_obj_set_style_pad_left(row, 4, 0);
-    lv_obj_set_style_radius(row, 3, 0);
-    lv_obj_set_style_text_font(row, font, 0);
-    lv_label_set_long_mode(row, LV_LABEL_LONG_MODE_DOTS);
-    lv_label_set_text(row, "+ 新建 session");
-    s_chat.session_picker_items[0] = row;
-  }
-
-  /* Session rows: "preview [Nm] [Xt] [<]" */
-  for (int i = 0; i < n_sessions; ++i) {
-    lv_obj_t* row = lv_label_create(s_chat.session_picker_root);
-    lv_obj_set_size(row, 316, BB_SESSION_PICKER_ROW_H);
-    lv_obj_set_style_pad_left(row, 4, 0);
-    lv_obj_set_style_pad_right(row, 4, 0);
-    lv_obj_set_style_radius(row, 3, 0);
-    lv_obj_set_style_text_font(row, font, 0);
-    lv_label_set_long_mode(row, LV_LABEL_LONG_MODE_DOTS);
-
-    const bb_agent_session_info_t* si = &s_chat.session_list[i];
-    const char* title = si->title;
-    /* Fallback order: title → cwd_name → "(untitled)" */
-    if (title == NULL || title[0] == '\0') {
-      title = (si->cwd_name[0] != '\0') ? si->cwd_name : "(untitled)";
-    }
-
-    char time_buf[8] = {0};
-    format_relative_time(si->last_used_ms, time_buf, sizeof(time_buf));
-
-    char suffix[32] = {0};
-    int off = 0;
-    if (si->message_count > 0) {
-      off += snprintf(suffix + off, sizeof(suffix) - (size_t)off, " %dm", si->message_count);
-    }
-    if (time_buf[0] != '\0') {
-      off += snprintf(suffix + off, sizeof(suffix) - (size_t)off, " %s", time_buf);
-    }
-    /* Prefer the human-readable pool name; fall back to raw cwd only if
-     * neither cwd_name nor cwd is available (old adapter). */
-    const char* cwd_label = si->cwd_name[0] != '\0' ? si->cwd_name
-                          : si->cwd[0] != '\0'       ? si->cwd
-                          : NULL;
-    if (cwd_label != NULL) {
-      off += snprintf(suffix + off, sizeof(suffix) - (size_t)off, " %s", cwd_label);
-    }
-    if (i == s_chat.session_picker_active_idx) {
-      snprintf(suffix + off, sizeof(suffix) - (size_t)off, " <");
-    }
-
-    int title_max = 22 - (int)strlen(suffix);
-    if (title_max < 6) title_max = 6;
-
-    char row_buf[48];
-    snprintf(row_buf, sizeof(row_buf), "%.*s%s", title_max, title, suffix);
-    lv_label_set_text(row, row_buf);
-    /* ADR-016: sessions occupy visual rows [1 .. n_sessions]; row 0 = "+ New". */
-    s_chat.session_picker_items[1 + i] = row;
-  }
-
-  session_picker_apply_styles();
-  ESP_LOGI(TAG, "session_picker: built %d sessions + 1 fixed row (+ New)", n_sessions);
-}
-
-/* ── Session picker public API ── */
-
-void bb_ui_agent_chat_session_picker_show(void) {
-  if (!s_chat.active || s_chat.parent == NULL) return;
-  if (s_chat.session_picker_visible) return;
-  s_chat.session_picker_visible = 1; /* loading */
-  ESP_LOGI(TAG, "session_picker: show (fetching sessions for '%s')",
-           s_chat.driver_name[0] != '\0' ? s_chat.driver_name : BB_CHAT_DRIVER_FALLBACK);
-  /* If the driver cache hasn't been populated yet (e.g. picker opened before
-   * the initial chat_open fetch completed), kick a fresh fetch so the driver
-   * row will update once the result arrives. */
-  if (s_chat.driver_cache_count <= 0 && !s_chat.driver_fetch_pending) {
-    spawn_driver_fetch_task();
-  }
-  spawn_session_fetch_task();
-}
-
-void bb_ui_agent_chat_session_picker_hide(void) {
-  if (!s_chat.active) return;
-  if (s_chat.session_picker_root != NULL) {
-    lv_obj_del(s_chat.session_picker_root);
-    s_chat.session_picker_root = NULL;
-    s_chat.session_picker_title = NULL;
-    memset(s_chat.session_picker_items, 0, sizeof(s_chat.session_picker_items));
-  }
-  s_chat.session_picker_visible = 0;
-  s_chat.session_picker_total_rows = 0;
-  ESP_LOGI(TAG, "session_picker: hidden");
-}
-
-void bb_ui_agent_chat_session_picker_move(int delta) {
-  if (!s_chat.active || s_chat.session_picker_visible != 2) return;
-  const int total = s_chat.session_picker_total_rows;
-  if (total == 0) return;
-  int sel = ((s_chat.session_picker_sel + delta) % total + total) % total;
-  if (sel == s_chat.session_picker_sel) return;
-  s_chat.session_picker_sel = sel;
-  session_picker_apply_styles();
 }
 
 /* Common transcript-reset + topbar-refresh used after both session-switch and
@@ -2475,7 +2129,7 @@ static void spawn_new_session_task(const char* cwd_name) {
  * (backward-compatible with single-project setups).
  *
  * Lifecycle:
- *   1. session_picker_select() detects the "+ 新建" row.
+ *   1. history fetch is triggered after session switch.
  *   2. If cwd_pool_count > 1 (already cached) → show picker immediately.
  *      If not yet fetched → spawn cwd_pool_fetch_task, show picker when done.
  *      If pool has ≤ 1 entry → create session directly (existing behaviour).
@@ -2722,111 +2376,6 @@ void bb_ui_agent_chat_cwd_picker_cancel(void) {
  * route UP/DOWN/OK/BACK to it instead of the session picker). */
 int bb_ui_agent_chat_cwd_picker_is_visible(void) {
   return (s_chat.active && s_chat.cwd_picker_visible > 0) ? 1 : 0;
-}
-
-int bb_ui_agent_chat_session_picker_select(void) {
-  if (!s_chat.active || s_chat.session_picker_visible != 2) {
-    return BB_SESSION_PICKER_ACTION_NONE;
-  }
-  const int sel = s_chat.session_picker_sel;
-  const int n = s_chat.session_list_count;
-
-  if (sel == 0) {
-    /* "+ 新建 session" row — fetch CWD pool; if > 1 entry show project picker,
-     * otherwise create directly (backward-compatible). */
-    ESP_LOGI(TAG, "session_picker: new session requested");
-    bb_ui_agent_chat_session_picker_hide();
-    /* Mark cwd_picker as loading so key handler routes to it. */
-    s_chat.cwd_picker_visible = 1;
-    spawn_cwd_pool_fetch_or_use_cache();
-    return BB_SESSION_PICKER_ACTION_NEW_SESSION;
-  }
-
-  if (sel >= 1 && sel <= n) {
-    /* Session row — switch to it. (ADR-016: visual idx shifted by 1, row 0 = "+ New".) */
-    const int idx = sel - 1;
-    const bb_agent_session_info_t* session = &s_chat.session_list[idx];
-    ESP_LOGI(TAG, "session_picker: switch to '%s'", session->id);
-
-    strncpy(s_chat.session_id, session->id, sizeof(s_chat.session_id) - 1);
-    s_chat.session_id[sizeof(s_chat.session_id) - 1] = '\0';
-    bb_session_store_save(s_chat.driver_name, session->id);
-    bb_notification_ack(session->id);
-
-    apply_session_switch_ui(session->id, session->title);
-
-    /* Phase S3 — fetch history for the just-selected session. The fetch is
-     * async (worker task); the empty transcript is what the user sees in the
-     * meantime. We don't gate session_picker_hide() on the response so picker
-     * UX stays snappy. */
-    history_state_reset();
-    spawn_history_fetch_task(-1, /*is_initial=*/1);
-
-    bb_ui_agent_chat_session_picker_hide();
-    return BB_SESSION_PICKER_ACTION_SWITCH;
-  }
-
-  return BB_SESSION_PICKER_ACTION_NONE;
-}
-
-int bb_ui_agent_chat_session_picker_is_visible(void) {
-  return (s_chat.active && s_chat.session_picker_visible > 0) ? 1 : 0;
-}
-
-/**
- * Cycle the driver selection while the session picker is open and the driver
- * row (row 0) is highlighted.  Returns 1 if the event was consumed (driver
- * row was selected), 0 if the caller should fall back to the normal
- * close-picker + cycle-driver behaviour.
- *
- * Must be called inside the LVGL lock.
- */
-int bb_ui_agent_chat_session_picker_driver_cycle(int delta) {
-  if (!s_chat.active || s_chat.session_picker_visible != 2) return 0;
-  /* Consume LEFT/RIGHT unconditionally while the picker is open — driver
-   * cycling applies regardless of which row is highlighted.  This prevents
-   * the event from falling through to the "close picker + cycle driver"
-   * default path in bb_radio_app.c, which looked like the picker being
-   * closed unexpectedly. */
-  if (delta == 0) return 1;
-
-  /* If the driver cache is still loading, kick a fetch and report handled. */
-  if (s_chat.driver_cache_count <= 0) {
-    spawn_driver_fetch_task();
-    return 1;
-  }
-  const int n = s_chat.driver_cache_count;
-  if (n <= 1) return 1;  /* single driver — nothing to cycle */
-
-  /* Positive-modulo wrap (handles delta=-1 going from 0 → n-1). */
-  int next = ((s_chat.driver_cache_idx + delta) % n + n) % n;
-  s_chat.driver_cache_idx = next;
-  const char* name = s_chat.driver_cache[next].name;
-  if (name == NULL || name[0] == '\0') return 1;
-
-  /* Update in-memory driver name (NVS write deferred to next send, consistent
-   * with cycle_driver behaviour). */
-  strncpy(s_chat.driver_name, name, sizeof(s_chat.driver_name) - 1);
-  s_chat.driver_name[sizeof(s_chat.driver_name) - 1] = '\0';
-
-  /* Clear stale session list and rebuild picker immediately so the driver row
-   * text updates without waiting for the network round-trip. */
-  s_chat.session_list_count = 0;
-  s_chat.session_picker_active_idx = -1;
-  session_picker_build_ui();
-  /* Keep the driver row selected after the rebuild. */
-  s_chat.session_picker_sel = 0;
-  session_picker_apply_styles();
-
-  /* Kick an async session fetch for the new driver; stale-generation guard
-   * in on_session_fetch_done will drop any in-flight result from the old
-   * driver. */
-  s_chat.session_fetch_pending = 0;
-  spawn_session_fetch_task();
-
-  ESP_LOGI(TAG, "session_picker: driver cycled to '%s' (delta=%+d, idx=%d/%d)",
-           name, delta, next, n);
-  return 1;
 }
 
 /* ── Phase 4.5 — voice bridge helpers ── */

--- a/firmware/src/bb_ui_task_list.c
+++ b/firmware/src/bb_ui_task_list.c
@@ -1,0 +1,377 @@
+/**
+ * bb_ui_task_list.c — Task List page (ADR-021-firmware-ui §3 / §4.2, Sub-PR D)
+ *
+ * Independent LVGL screen. Fetches /v1/butler/dispatch/recent in a background
+ * FreeRTOS task and renders the results using the same lv_async_call pattern
+ * as the session picker.
+ */
+#include "bb_ui_task_list.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "bb_agent_client.h"
+#include "bb_ui_agent_chat.h"
+#include "bb_wifi.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "lvgl.h"
+
+static const char* TAG = "bb_task_list";
+
+/* ── Layout / colour constants ── */
+#define BB_TASK_LIST_MAX      20
+#define BB_TASK_LIST_VISIBLE  6
+#define BB_TASK_LIST_ROW_H    22  /* ADR §4.2: row height 22px */
+#define BB_TASK_LIST_TITLE_H  22
+
+/* Colour palette — same dark-green family as session picker */
+#define BB_TL_BG       0x12211b
+#define BB_TL_FG       0xc8e2d6
+#define BB_TL_FG_DIM   0x6b8c80
+#define BB_TL_FG_RUN   0x2ec4a0  /* running highlight (primary) */
+#define BB_TL_FG_ERR   0xe05050  /* error red */
+#define BB_TL_SEL_BG   0x2ec4a0
+#define BB_TL_SEL_FG   0x0a0e0c
+
+/* ── Module state ── */
+typedef struct {
+  int visible;          /* 0=hidden, 1=loading, 2=shown */
+  int sel;              /* selected row index (0-based) */
+  int count;            /* number of entries loaded */
+  bb_agent_dispatch_entry_t entries[BB_TASK_LIST_MAX];
+
+  lv_obj_t* screen;     /* independent LVGL screen */
+  lv_obj_t* lbl_title;  /* "派发任务  N" */
+  lv_obj_t* lbl_empty;  /* "暂无派发任务" label */
+  lv_obj_t* rows[BB_TASK_LIST_MAX];
+
+  volatile int fetch_pending;
+  volatile uint32_t fetch_gen;
+} bb_task_list_state_t;
+
+static bb_task_list_state_t s_tl = {0};
+
+/* ── safe_lv_async_call mirror (same approach as bb_ui_agent_chat.c) ── */
+static inline lv_result_t tl_lv_async_call(lv_async_cb_t cb, void* user_data) {
+  if (lv_async_call(cb, user_data) != LV_RESULT_OK) {
+    ESP_LOGW(TAG, "lv_async_call failed");
+    return LV_RESULT_INVALID;
+  }
+  return LV_RESULT_OK;
+}
+
+/* ── Background fetch task ── */
+#define BB_TL_FETCH_STACK 4096
+#define BB_TL_FETCH_PRIO  4
+
+typedef struct {
+  uint32_t gen;
+  esp_err_t err;
+  int count;
+  bb_agent_dispatch_entry_t entries[BB_TASK_LIST_MAX];
+} tl_fetch_result_t;
+
+/* Forward declarations */
+static void task_list_build_ui(void);
+static void task_list_apply_styles(void);
+
+/* ── relative time helper ── */
+static void tl_format_elapsed(int64_t elapsed_ms, char* buf, int len) {
+  if (elapsed_ms <= 0) { buf[0] = '\0'; return; }
+  long ms = (long)elapsed_ms;
+  if (ms < 1000) {
+    snprintf(buf, (size_t)len, "%ldms", ms);
+  } else if (ms < 60000) {
+    snprintf(buf, (size_t)len, "%.1fs", (double)ms / 1000.0);
+  } else {
+    snprintf(buf, (size_t)len, "%ldm", ms / 60000);
+  }
+}
+
+static void tl_format_started(int64_t started_ms, char* buf, int len) {
+  if (started_ms <= 0) { buf[0] = '\0'; return; }
+  time_t now_sec = time(NULL);
+  if (now_sec < 1577836800LL) { buf[0] = '\0'; return; }
+  int64_t diff_s = (int64_t)now_sec - started_ms / 1000;
+  if (diff_s < 0) diff_s = 0;
+  if (diff_s < 60) {
+    snprintf(buf, (size_t)len, "%llds", (long long)diff_s);
+  } else if (diff_s < 3600) {
+    snprintf(buf, (size_t)len, "%lldm", (long long)(diff_s / 60));
+  } else {
+    snprintf(buf, (size_t)len, "%lldh", (long long)(diff_s / 3600));
+  }
+}
+
+/* ── Build row text: "<emoji> <cwd> <title>  <status>  <time>" ── */
+static void tl_format_row(const bb_agent_dispatch_entry_t* e, char* buf, int buf_len) {
+  const char* emoji = "❓";
+  if (strcmp(e->status, "running") == 0) emoji = "⏳";
+  else if (strcmp(e->status, "done")    == 0) emoji = "✅";
+  else if (strcmp(e->status, "error")   == 0) emoji = "❌";
+  else if (strcmp(e->status, "async")   == 0) emoji = "⏰";
+
+  char time_buf[12] = {0};
+  if (strcmp(e->status, "done") == 0 || strcmp(e->status, "error") == 0) {
+    tl_format_elapsed(e->elapsed_ms, time_buf, sizeof(time_buf));
+  } else {
+    tl_format_started(e->started_at_ms, time_buf, sizeof(time_buf));
+  }
+
+  /* Truncate title to first 24 bytes (rough CJK limit) */
+  char title_trunc[52];
+  strncpy(title_trunc, e->title, sizeof(title_trunc) - 1);
+  title_trunc[sizeof(title_trunc) - 1] = '\0';
+  if (strlen(title_trunc) > 24) {
+    title_trunc[24] = '\0';
+    strncat(title_trunc, "…", sizeof(title_trunc) - strlen(title_trunc) - 1);
+  }
+
+  snprintf(buf, (size_t)buf_len, "%s %s %s  %s  %s",
+           emoji,
+           e->cwd[0] != '\0' ? e->cwd : "?",
+           title_trunc,
+           e->status,
+           time_buf);
+}
+
+/* ── Apply selection highlight ── */
+static void task_list_apply_styles(void) {
+  if (s_tl.screen == NULL || s_tl.count == 0) return;
+  int first = s_tl.sel - BB_TASK_LIST_VISIBLE / 2;
+  if (first < 0) first = 0;
+  if (first + BB_TASK_LIST_VISIBLE > s_tl.count)
+    first = s_tl.count - BB_TASK_LIST_VISIBLE;
+  if (first < 0) first = 0;
+
+  for (int i = 0; i < s_tl.count; i++) {
+    lv_obj_t* row = s_tl.rows[i];
+    if (row == NULL) continue;
+    int visible = (i >= first && i < first + BB_TASK_LIST_VISIBLE);
+    if (!visible) { lv_obj_add_flag(row, LV_OBJ_FLAG_HIDDEN); continue; }
+    lv_obj_clear_flag(row, LV_OBJ_FLAG_HIDDEN);
+
+    const bb_agent_dispatch_entry_t* e = &s_tl.entries[i];
+    if (i == s_tl.sel) {
+      lv_obj_set_style_bg_color(row, lv_color_hex(BB_TL_SEL_BG), 0);
+      lv_obj_set_style_bg_opa(row, LV_OPA_COVER, 0);
+      lv_obj_set_style_text_color(row, lv_color_hex(BB_TL_SEL_FG), 0);
+    } else {
+      lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
+      uint32_t fg = BB_TL_FG;
+      if (strcmp(e->status, "running") == 0) fg = BB_TL_FG_RUN;
+      else if (strcmp(e->status, "error") == 0) fg = BB_TL_FG_ERR;
+      else if (strcmp(e->status, "done") == 0 || strcmp(e->status, "async") == 0)
+        fg = BB_TL_FG_DIM;
+      lv_obj_set_style_text_color(row, lv_color_hex(fg), 0);
+    }
+  }
+
+  /* Update title count */
+  if (s_tl.lbl_title != NULL) {
+    char tbuf[32];
+    snprintf(tbuf, sizeof(tbuf), "派发任务  %d", s_tl.count);
+    lv_label_set_text(s_tl.lbl_title, tbuf);
+  }
+}
+
+/* ── Build the LVGL overlay ── */
+static void task_list_build_ui(void) {
+  /* Tear down existing overlay if any. */
+  if (s_tl.screen != NULL) {
+    lv_obj_del(s_tl.screen);
+    s_tl.screen = NULL;
+    s_tl.lbl_title = NULL;
+    s_tl.lbl_empty = NULL;
+    memset(s_tl.rows, 0, sizeof(s_tl.rows));
+  }
+
+#ifdef BBCLAW_HAVE_CJK_FONT
+  extern const lv_font_t lv_font_bbclaw_cjk;
+  const lv_font_t* font = &lv_font_bbclaw_cjk;
+#else
+  const lv_font_t* font = lv_font_get_default();
+#endif
+
+  /* Create full-screen overlay on the active screen (same pattern as session
+   * picker / CWD picker — keeps LVGL screen state intact for easy BACK). */
+  lv_obj_t* parent = lv_screen_active();
+  if (parent == NULL) {
+    ESP_LOGE(TAG, "task_list_build_ui: no active screen");
+    s_tl.visible = 0;
+    return;
+  }
+  s_tl.screen = lv_obj_create(parent);
+  lv_obj_remove_style_all(s_tl.screen);
+  lv_obj_set_size(s_tl.screen, 320, 172);
+  lv_obj_align(s_tl.screen, LV_ALIGN_TOP_LEFT, 0, 0);
+  lv_obj_set_style_bg_color(s_tl.screen, lv_color_hex(BB_TL_BG), 0);
+  lv_obj_set_style_bg_opa(s_tl.screen, LV_OPA_COVER, 0);
+  lv_obj_set_style_pad_all(s_tl.screen, 2, 0);
+  lv_obj_set_flex_flow(s_tl.screen, LV_FLEX_FLOW_COLUMN);
+  lv_obj_clear_flag(s_tl.screen, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_move_foreground(s_tl.screen);
+
+  /* Title row */
+  s_tl.lbl_title = lv_label_create(s_tl.screen);
+  lv_obj_set_size(s_tl.lbl_title, 316, BB_TASK_LIST_TITLE_H);
+  lv_obj_set_style_text_color(s_tl.lbl_title, lv_color_hex(BB_TL_FG), 0);
+  lv_obj_set_style_text_font(s_tl.lbl_title, font, 0);
+  lv_obj_set_style_pad_left(s_tl.lbl_title, 2, 0);
+  lv_label_set_long_mode(s_tl.lbl_title, LV_LABEL_LONG_MODE_DOTS);
+  {
+    char tbuf[32];
+    snprintf(tbuf, sizeof(tbuf), "派发任务  %d", s_tl.count);
+    lv_label_set_text(s_tl.lbl_title, tbuf);
+  }
+
+  if (s_tl.count == 0) {
+    /* Empty state */
+    s_tl.lbl_empty = lv_label_create(s_tl.screen);
+    lv_obj_set_size(s_tl.lbl_empty, 316, 120);
+    lv_obj_set_style_text_color(s_tl.lbl_empty, lv_color_hex(BB_TL_FG_DIM), 0);
+    lv_obj_set_style_text_font(s_tl.lbl_empty, font, 0);
+    lv_obj_set_style_text_align(s_tl.lbl_empty, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_text(s_tl.lbl_empty, "暂无派发任务");
+  } else {
+    /* List rows */
+    for (int i = 0; i < s_tl.count; i++) {
+      lv_obj_t* row = lv_label_create(s_tl.screen);
+      s_tl.rows[i] = row;
+      lv_obj_set_size(row, 316, BB_TASK_LIST_ROW_H);
+      lv_obj_set_style_pad_left(row, 4, 0);
+      lv_obj_set_style_pad_right(row, 4, 0);
+      lv_obj_set_style_radius(row, 3, 0);
+      lv_obj_set_style_text_font(row, font, 0);
+      lv_label_set_long_mode(row, LV_LABEL_LONG_MODE_DOTS);
+      char row_buf[80];
+      tl_format_row(&s_tl.entries[i], row_buf, sizeof(row_buf));
+      lv_label_set_text(row, row_buf);
+    }
+    task_list_apply_styles();
+  }
+
+  s_tl.visible = 2;
+  ESP_LOGI(TAG, "task_list: built screen, count=%d sel=%d", s_tl.count, s_tl.sel);
+}
+
+/* ── Fetch callback (runs on LVGL task via lv_async_call) ── */
+static void on_dispatch_fetch_done(void* user_data) {
+  tl_fetch_result_t* res = (tl_fetch_result_t*)user_data;
+  if (res == NULL) return;
+  s_tl.fetch_pending = 0;
+
+  if (res->gen != s_tl.fetch_gen || !s_tl.visible) {
+    free(res);
+    return;
+  }
+  if (res->err != ESP_OK) {
+    ESP_LOGW(TAG, "dispatch fetch failed: err=%d", res->err);
+    s_tl.count = 0;
+  } else {
+    s_tl.count = res->count;
+    if (s_tl.count > 0) {
+      memcpy(s_tl.entries, res->entries,
+             sizeof(s_tl.entries[0]) * (size_t)s_tl.count);
+    }
+  }
+  s_tl.sel = 0;
+  task_list_build_ui();
+  free(res);
+}
+
+/* FreeRTOS worker task */
+static void dispatch_fetch_task(void* arg) {
+  uint32_t my_gen = (uint32_t)(uintptr_t)arg;
+  tl_fetch_result_t* res = (tl_fetch_result_t*)calloc(1, sizeof(*res));
+  if (res == NULL) {
+    s_tl.fetch_pending = 0;
+    vTaskDelete(NULL);
+    return;
+  }
+  res->gen = my_gen;
+
+  /* Wait for Wi-Fi up to 10 s */
+  for (int i = 0; i < 50 && !bb_wifi_is_connected(); i++) {
+    vTaskDelay(pdMS_TO_TICKS(200));
+  }
+
+  int count = 0;
+  res->err = bb_agent_list_dispatch_recent(res->entries, BB_TASK_LIST_MAX, &count);
+  res->count = (res->err == ESP_OK && count <= BB_TASK_LIST_MAX) ? count : 0;
+
+  tl_lv_async_call(on_dispatch_fetch_done, res);
+  vTaskDelete(NULL);
+}
+
+static void spawn_dispatch_fetch_task(void) {
+  if (s_tl.fetch_pending) return;
+  s_tl.fetch_pending = 1;
+  uint32_t gen = ++s_tl.fetch_gen;
+  TaskHandle_t t = NULL;
+  BaseType_t ok = xTaskCreate(dispatch_fetch_task, "tl_fetch",
+                              BB_TL_FETCH_STACK,
+                              (void*)(uintptr_t)gen,
+                              BB_TL_FETCH_PRIO, &t);
+  if (ok != pdPASS) {
+    ESP_LOGE(TAG, "spawn_dispatch_fetch_task: xTaskCreate failed");
+    s_tl.fetch_pending = 0;
+  }
+}
+
+/* ── Public API ── */
+
+void bb_ui_task_list_show(void) {
+  if (s_tl.visible) return;
+  s_tl.visible = 1; /* loading */
+  s_tl.count = 0;
+  s_tl.sel = 0;
+  memset(s_tl.rows, 0, sizeof(s_tl.rows));
+  ESP_LOGI(TAG, "task_list: show (fetching dispatch/recent)");
+  spawn_dispatch_fetch_task();
+}
+
+void bb_ui_task_list_hide(void) {
+  s_tl.visible = 0;
+  s_tl.fetch_gen++; /* invalidate any in-flight fetch */
+  if (s_tl.screen != NULL) {
+    /* Destroy overlay — underlying screen (CHAT) is automatically visible again. */
+    lv_obj_del(s_tl.screen);
+    s_tl.screen = NULL;
+    s_tl.lbl_title = NULL;
+    s_tl.lbl_empty = NULL;
+    memset(s_tl.rows, 0, sizeof(s_tl.rows));
+  }
+  ESP_LOGI(TAG, "task_list: hidden");
+}
+
+int bb_ui_task_list_visible(void) {
+  return s_tl.visible;
+}
+
+void bb_ui_task_list_move(int delta) {
+  if (s_tl.visible != 2 || s_tl.count == 0) return;
+  int n = s_tl.count;
+  int sel = ((s_tl.sel + delta) % n + n) % n;
+  if (sel == s_tl.sel) return;
+  s_tl.sel = sel;
+  task_list_apply_styles();
+}
+
+void bb_ui_task_list_activate(void) {
+  if (s_tl.visible != 2 || s_tl.count == 0) return;
+  if (s_tl.sel < 0 || s_tl.sel >= s_tl.count) return;
+
+  const bb_agent_dispatch_entry_t* e = &s_tl.entries[s_tl.sel];
+  char cmd[80];
+  snprintf(cmd, sizeof(cmd), "task_status #%s", e->task_id);
+  ESP_LOGI(TAG, "task_list: activating row %d, sending '%s'", s_tl.sel, cmd);
+
+  /* Hide first, then send turn — bb_ui_agent_chat_send requires chat active */
+  bb_ui_task_list_hide();
+  bb_ui_agent_chat_send(cmd);
+}


### PR DESCRIPTION
Fixes #103

## 改动摘要

落地 ADR-021-firmware-ui v2 §3 / §4.2（Sub-PR D）：把 CHAT 短按 OK 目的地从 session picker 改为新增的 **Task List** 全屏 overlay，session picker 整体删除。

## 文件变更

| 文件 | 变更 |
|---|---|
| `firmware/src/bb_ui_agent_chat.c` | 删除全部 session picker 代码（~250 LOC），移除 struct 字段 |
| `firmware/include/bb_ui_agent_chat.h` | 移除 session picker 公开 API 声明 |
| `firmware/src/bb_ui_task_list.c` | 新增 Task List overlay（fetch + 渲染 + 按键 API） |
| `firmware/include/bb_ui_task_list.h` | 新增 Task List 公开 API |
| `firmware/src/bb_agent_client.c` | 新增 `bb_agent_list_dispatch_recent()` HTTP 实现 |
| `firmware/include/bb_agent_client.h` | 新增 `bb_agent_dispatch_entry_t` + API 声明 |
| `firmware/src/bb_radio_app.c` | 按键路由：picker_up → task_list_up；短按 OK → task_list_show |
| `firmware/src/CMakeLists.txt` | 加入 bb_ui_task_list.c |

## 设计决策

- **Overlay 而非独立 screen**：沿用 session picker / CWD picker 的 overlay 模式（在 `lv_screen_active()` 上叠加），BACK 删除 overlay 即恢复 CHAT，无需管理 screen 切换生命周期
- **task_status turn 可见**：按 ADR §3，用户气泡保留对用户可见（不做后台隐藏 turn）
- **数据源**：消费 `GET /v1/butler/dispatch/recent`，依赖 Sub-PR C（adapter 侧实现），adapter 未部署时返回 HTTP 错误，Task List 显示空态「暂无派发任务」
- **颜色**：沿用 session picker 的深绿色系（`#12211b` 背景），running 主色高亮 / error 红 / done|async 灰

## 测试说明

- 固件为 ESP-IDF 交叉编译，本地无目标硬件，无法运行 `make build` / simulator 验证
- 代码层面：大括号平衡检查通过（chat: 347对，task_list: 50对），无残留 session picker 符号
- 端到端验证（ADR §6.D / §5 用例 2/3）需在 adapter Sub-PR C 合并后，配合真机或 simulator 执行