### PR TITLE
fix(firmware+adapter): 固件历史时间分段 + adapter 异步消息归属修复

### DIFF
--- a/adapter/web/src/components/Conversation.vue
+++ b/adapter/web/src/components/Conversation.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 import { listSessions, sessionMessages, dispatchRecent, type SessionInfo, type ChatMessage, type DispatchEntry } from "../api";
 
-// Split the transcript into time segments: a gap larger than this between two
-// consecutive messages starts a new segment with a divider.
+// 两条消息间隔超过此值（30 分钟）时，分为新的会话段。
+// 与固件端 BB_HISTORY_SEGMENT_GAP_MS 保持一致。
 const GAP_MS = 30 * 60 * 1000;
 
 const sessions = ref<SessionInfo[]>([]);
@@ -12,8 +12,30 @@ const activeSession = ref<SessionInfo | null>(null);
 const messages = ref<ChatMessage[]>([]);
 const dispatches = ref<DispatchEntry[]>([]);
 const loadingMsgs = ref(false);
+const pollingMsgs = ref(false);
+const streamEl = ref<HTMLElement | null>(null);
+const stickToBottom = ref(true);
+const selectedContext = ref("");
+const lastUpdated = ref("");
 const err = ref("");
 let timer: number | undefined;
+
+type MessageBlock = ChatMessage & { parts: string[] };
+type TurnBlock = {
+  id: string;
+  question?: MessageBlock;
+  replies: MessageBlock[];
+  startedAt?: string;
+  endedAt?: string;
+  contexts: string[];
+};
+type SegmentBlock = {
+  id: string;
+  label: string;
+  range: string;
+  turns: TurnBlock[];
+  contexts: string[];
+};
 
 function clock(s?: string) {
   if (!s) return "";
@@ -21,54 +43,267 @@ function clock(s?: string) {
   return isNaN(+d) ? "" : d.toLocaleString();
 }
 
-// segments groups messages into time-separated runs; each run carries a label
-// (the start time of the run) plus its messages. A gap > GAP_MS, or any
-// transition involving a timestamp-less message, starts a new run.
-const segments = computed(() => {
-  const runs: { label: string; items: ChatMessage[] }[] = [];
-  let prevTs = NaN;
-  for (const m of messages.value) {
-    const t = m.timestamp ? new Date(m.timestamp).getTime() : NaN;
-    const split = runs.length === 0 || (!isNaN(t) && !isNaN(prevTs) && t - prevTs > GAP_MS) || (isNaN(t) !== isNaN(prevTs));
-    if (split) {
-      runs.push({ label: m.timestamp ? new Date(m.timestamp).toLocaleString() : "未记录时间", items: [] });
+function clockShort(s?: string) {
+  if (!s) return "";
+  const d = new Date(s);
+  return isNaN(+d) ? "" : d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function mergeMessages(current: ChatMessage[], incoming: ChatMessage[]) {
+  const byKey = new Map<string, ChatMessage>();
+  for (const m of current) byKey.set(`${m.seq}:${m.role}`, m);
+  for (const m of incoming) byKey.set(`${m.seq}:${m.role}`, m);
+  return Array.from(byKey.values()).sort((a, b) => a.seq - b.seq);
+}
+
+function isNearBottom(el: HTMLElement) {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+}
+
+function rememberScrollIntent() {
+  if (streamEl.value) stickToBottom.value = isNearBottom(streamEl.value);
+}
+
+async function settleScroll(shouldFollow: boolean) {
+  await nextTick();
+  if (shouldFollow && streamEl.value) streamEl.value.scrollTop = streamEl.value.scrollHeight;
+}
+
+function splitContent(content: string) {
+  const trimmed = content.trimEnd();
+  if (trimmed.length <= 1400) return [content];
+  const paras = trimmed.split(/\n{2,}/);
+  const chunks: string[] = [];
+  let buf = "";
+  for (const para of paras) {
+    const next = buf ? `${buf}\n\n${para}` : para;
+    if (next.length > 1400 && buf) {
+      chunks.push(buf);
+      buf = para;
+    } else {
+      buf = next;
     }
-    runs[runs.length - 1].items.push(m);
-    prevTs = t;
+  }
+  if (buf) chunks.push(buf);
+  return chunks.flatMap((chunk) => {
+    if (chunk.length <= 1800) return [chunk];
+    const out: string[] = [];
+    for (let i = 0; i < chunk.length; i += 1600) out.push(chunk.slice(i, i + 1600));
+    return out;
+  });
+}
+
+function urlsIn(text: string) {
+  return Array.from(text.matchAll(/https?:\/\/[^\s)\]}>"'`]+/g)).map((m) => m[0]);
+}
+
+function pathsIn(text: string) {
+  return Array.from(text.matchAll(/(?:~|\/(?:Users|home|tmp|var|opt|workspace|Volumes))\/[^\s)\]}>"'`]+/g)).map((m) => m[0]);
+}
+
+function normalizeContext(v: string) {
+  return v.replace(/[.,;:，。；：]+$/, "");
+}
+
+function contextsForMessage(m: ChatMessage) {
+  return [...urlsIn(m.content), ...pathsIn(m.content)].map(normalizeContext);
+}
+
+function contextsForSession(s?: SessionInfo | null) {
+  return s?.cwd ? [s.cwd] : [];
+}
+
+function labelContext(v: string) {
+  try {
+    const u = new URL(v);
+    return `${u.hostname}${u.pathname}`;
+  } catch {
+    const parts = v.split("/").filter(Boolean);
+    return parts.length > 3 ? `.../${parts.slice(-3).join("/")}` : v;
+  }
+}
+
+function messageMatchesContext(m: ChatMessage) {
+  if (!selectedContext.value) return true;
+  const target = selectedContext.value;
+  return contextsForSession(activeSession.value).includes(target) || contextsForMessage(m).includes(target);
+}
+
+const visibleMessages = computed(() => messages.value.filter(messageMatchesContext));
+
+const contextOptions = computed(() => {
+  const counts = new Map<string, number>();
+  for (const ctx of contextsForSession(activeSession.value)) counts.set(ctx, (counts.get(ctx) ?? 0) + messages.value.length);
+  for (const m of messages.value) {
+    for (const ctx of contextsForMessage(m)) counts.set(ctx, (counts.get(ctx) ?? 0) + 1);
+  }
+  return Array.from(counts, ([value, count]) => ({ value, label: labelContext(value), count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+    .slice(0, 10);
+});
+
+const messageCountLabel = computed(() => {
+  const all = messages.value.length;
+  const visible = visibleMessages.value.length;
+  return selectedContext.value ? `${visible} / ${all} 条` : `${all} 条`;
+});
+
+function messageTime(m: ChatMessage) {
+  return m.timestamp ? new Date(m.timestamp).getTime() : NaN;
+}
+
+function blockForMessage(m: ChatMessage): MessageBlock {
+  return { ...m, parts: splitContent(m.content) };
+}
+
+function turnStart(turn: TurnBlock) {
+  const first = turn.question ?? turn.replies[0];
+  return first?.timestamp;
+}
+
+function turnEnd(turn: TurnBlock) {
+  const last = turn.replies[turn.replies.length - 1] ?? turn.question;
+  return last?.timestamp;
+}
+
+const turns = computed<TurnBlock[]>(() => {
+  const out: TurnBlock[] = [];
+  let current: TurnBlock | undefined;
+  for (const m of visibleMessages.value) {
+    const block = blockForMessage(m);
+    const ctx = contextsForMessage(m);
+    if (m.role === "user") {
+      // New user message always starts a fresh turn.
+      current = {
+        id: `turn-${m.seq}-${m.role}`,
+        question: block,
+        replies: [],
+        startedAt: block.timestamp,
+        endedAt: block.timestamp,
+        contexts: ctx,
+      };
+      out.push(current);
+    } else if (!current) {
+      // Orphan assistant message with no preceding user turn (e.g. async
+      // dispatch result arriving before a user message in the session).
+      // Create a questionless turn rather than dropping the message.
+      current = {
+        id: `turn-${m.seq}-${m.role}`,
+        question: undefined,
+        replies: [block],
+        startedAt: block.timestamp,
+        endedAt: block.timestamp,
+        contexts: ctx,
+      };
+      out.push(current);
+    } else {
+      // Append to the current turn. This also handles async-dispatch late
+      // replies: they arrive as assistant messages without a preceding user
+      // message in the same turn, and we attach them to the last open turn
+      // rather than creating a spurious new one.
+      current.replies.push(block);
+      current.endedAt = block.timestamp || current.endedAt;
+      current.contexts = Array.from(new Set([...current.contexts, ...ctx]));
+    }
+  }
+  for (const turn of out) {
+    turn.startedAt = turnStart(turn);
+    turn.endedAt = turnEnd(turn);
+  }
+  return out;
+});
+
+const segments = computed(() => {
+  const runs: SegmentBlock[] = [];
+  let prevEnd = NaN;
+  for (const turn of turns.value) {
+    const first = turn.question ?? turn.replies[0];
+    const t = first ? messageTime(first) : NaN;
+    const split = runs.length === 0 || (!isNaN(t) && !isNaN(prevEnd) && t - prevEnd > GAP_MS);
+    if (split) {
+      runs.push({
+        id: `segment-${runs.length + 1}-${turn.id}`,
+        label: `会话段 ${runs.length + 1}`,
+        range: "",
+        turns: [],
+        contexts: [],
+      });
+    }
+    const run = runs[runs.length - 1];
+    run.turns.push(turn);
+    run.contexts = Array.from(new Set([...run.contexts, ...turn.contexts]));
+    const last = turn.replies[turn.replies.length - 1] ?? turn.question ?? first;
+    prevEnd = last ? messageTime(last) : prevEnd;
+  }
+  for (const run of runs) {
+    const first = run.turns[0]?.startedAt;
+    const last = run.turns[run.turns.length - 1]?.endedAt;
+    run.range = first && last && first !== last ? `${clockShort(first)} - ${clockShort(last)}` : clockShort(first);
   }
   return runs;
 });
 
 async function loadSessions() {
   try {
-    sessions.value = await listSessions();
+    const next = await listSessions();
+    sessions.value = next;
     err.value = "";
-    if (!activeSession.value && sessions.value.length) select(sessions.value[0]);
+    if (activeSession.value) {
+      const updated = next.find((s) => s.id === activeSession.value?.id);
+      if (updated) activeSession.value = updated;
+    } else if (next.length) {
+      await select(next[0], true);
+    }
   } catch (e: any) { err.value = "会话加载失败：" + e.message; }
 }
-async function select(s: SessionInfo) {
-  activeSession.value = s; activeId.value = s.id; loadingMsgs.value = true; messages.value = [];
-  try { messages.value = (await sessionMessages(s.id, s.driver || "")).messages; err.value = ""; }
+async function loadMessages(s: SessionInfo, reset = false) {
+  const token = `${s.id}:${s.driver || ""}`;
+  if (reset) {
+    loadingMsgs.value = true;
+    messages.value = [];
+  } else {
+    pollingMsgs.value = true;
+  }
+  const shouldFollow = reset || stickToBottom.value;
+  try {
+    const page = await sessionMessages(s.id, s.driver || "");
+    if (`${activeSession.value?.id}:${activeSession.value?.driver || ""}` !== token) return;
+    messages.value = reset ? page.messages : mergeMessages(messages.value, page.messages);
+    lastUpdated.value = new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    err.value = "";
+    await settleScroll(shouldFollow);
+  }
   catch (e: any) { err.value = "消息加载失败：" + e.message; }
-  finally { loadingMsgs.value = false; }
+  finally {
+    loadingMsgs.value = false;
+    pollingMsgs.value = false;
+  }
+}
+async function select(s: SessionInfo, reset = true) {
+  activeSession.value = s; activeId.value = s.id; selectedContext.value = "";
+  await loadMessages(s, reset);
 }
 async function loadDispatch() { dispatches.value = await dispatchRecent(30); }
 
 async function refresh() {
   await Promise.all([loadSessions(), loadDispatch()]);
-  if (activeSession.value) await select(activeSession.value);
+  if (activeSession.value) await loadMessages(activeSession.value, false);
 }
 
 onMounted(async () => {
   await Promise.all([loadSessions(), loadDispatch()]);
-  timer = window.setInterval(() => { loadDispatch(); if (activeSession.value) select(activeSession.value); }, 6000);
+  timer = window.setInterval(() => { loadDispatch(); loadSessions(); if (activeSession.value) loadMessages(activeSession.value, false); }, 3000);
 });
 onUnmounted(() => { if (timer) clearInterval(timer); });
 </script>
 
 <template>
   <div class="card">
-    <h2>对话记录<button class="ghost small" style="margin-left:auto" @click="refresh">刷新</button></h2>
+    <h2>
+      对话记录
+      <span v-if="lastUpdated" class="live">最新 {{ lastUpdated }}<i v-if="pollingMsgs"></i></span>
+      <button class="ghost small" style="margin-left:auto" @click="refresh">刷新</button>
+    </h2>
     <div v-if="err" class="msg err">{{ err }}</div>
     <div class="convo">
       <div class="sesslist">
@@ -83,15 +318,51 @@ onUnmounted(() => { if (timer) clearInterval(timer); });
         </div>
       </div>
 
-      <div class="stream">
-        <div v-if="loadingMsgs" class="empty">加载中…</div>
-        <div v-else-if="!messages.length" class="empty">该会话还没有消息。</div>
-        <template v-for="(seg, si) in segments" :key="si">
-          <div class="seg-div"><span>{{ seg.label }}</span></div>
-          <div v-for="(m, i) in seg.items" :key="si + '-' + i" class="bub" :class="m.role">
-            <div class="who">{{ m.role === 'user' ? '用户' : '管家' }}<span v-if="m.timestamp" class="ts">{{ clock(m.timestamp) }}</span></div>{{ m.content }}
+      <div class="stream-wrap">
+        <div class="stream-tools">
+          <div>
+            <strong>{{ segments.length }}</strong> 段 · <strong>{{ turns.length }}</strong> 轮 · {{ messageCountLabel }}
           </div>
-        </template>
+          <label v-if="contextOptions.length">
+            <span>Path / URL</span>
+            <select v-model="selectedContext">
+              <option value="">全部来源</option>
+              <option v-for="c in contextOptions" :key="c.value" :value="c.value">{{ c.label }} ({{ c.count }})</option>
+            </select>
+          </label>
+        </div>
+        <div ref="streamEl" class="stream" @scroll="rememberScrollIntent">
+          <div v-if="loadingMsgs" class="empty">加载中…</div>
+          <div v-else-if="!messages.length" class="empty">该会话还没有消息。</div>
+          <div v-else-if="!visibleMessages.length" class="empty">当前 path / URL 下没有消息。</div>
+          <section v-for="seg in segments" :key="seg.id" class="conv-segment">
+            <div class="seg-head">
+              <div>
+                <span class="seg-title">{{ seg.label }}</span>
+                <span>{{ seg.turns.length }} 轮 · {{ seg.range || '未记录时间' }}</span>
+              </div>
+              <div v-if="seg.contexts.length" class="seg-source" :title="seg.contexts.join('\n')">{{ labelContext(seg.contexts[0]) }}</div>
+            </div>
+
+            <article v-for="turn in seg.turns" :key="turn.id" class="turn-card">
+              <div v-if="turn.question" class="qa-row user-row">
+                <div class="role-pill">问</div>
+                <div class="msg-panel user-panel">
+                  <div class="msg-meta"><span>用户</span><time v-if="turn.question.timestamp">{{ clock(turn.question.timestamp) }}</time></div>
+                  <div v-for="(part, pi) in turn.question.parts" :key="pi" class="part" :class="{ split: turn.question.parts.length > 1 }">{{ part }}</div>
+                </div>
+              </div>
+
+              <div v-for="reply in turn.replies" :key="reply.seq + '-' + reply.role" class="qa-row">
+                <div class="role-pill assistant-pill">答</div>
+                <div class="msg-panel">
+                  <div class="msg-meta"><span>管家</span><time v-if="reply.timestamp">{{ clock(reply.timestamp) }}</time><em v-if="reply.parts.length > 1">{{ reply.parts.length }} 段</em></div>
+                  <div v-for="(part, pi) in reply.parts" :key="pi" class="part" :class="{ split: reply.parts.length > 1 }">{{ part }}</div>
+                </div>
+              </div>
+            </article>
+          </section>
+        </div>
       </div>
     </div>
   </div>

--- a/firmware/include/bb_agent_client.h
+++ b/firmware/include/bb_agent_client.h
@@ -139,6 +139,10 @@ typedef struct {
   char role[16];
   char* content;
   int seq;
+  /* Unix timestamp in milliseconds parsed from the adapter's RFC3339
+   * "timestamp" field. 0 means the field was absent or could not be parsed
+   * (older adapter versions, non-claudecode drivers). */
+  int64_t timestamp_ms;
 } bb_agent_message_t;
 
 /**

--- a/firmware/include/bb_agent_theme.h
+++ b/firmware/include/bb_agent_theme.h
@@ -51,13 +51,13 @@ typedef struct bb_agent_theme {
   /* Phase S3 — history replay. Optional; NULL-check before calling.
    *   append_history_message: 在 transcript 末尾追加一条已完成消息（不影响 active_assistant，
    *                            不会被后续流式 chunk 错误地拼到一起）。用于初次进入 session 时
-   *                            按时间序填入历史。
+   *                            按时间序填入历史。timestamp_ms 为 Unix ms（0=无时间戳）。
    *   prepend_history_message: 把消息插到 transcript 顶部（lv_obj_move_to_index(0)），用于
-   *                            "上翻到顶 → 拉更早一批"的懒加载。
+   *                            "上翻到顶 → 拉更早一批"的懒加载。timestamp_ms 同上。
    *   is_transcript_at_top:    返回 1 表示用户已经滚到 transcript 顶部（用作懒加载触发条件）。
    */
-  void (*append_history_message)(const char* role, const char* content);
-  void (*prepend_history_message)(const char* role, const char* content);
+  void (*append_history_message)(const char* role, const char* content, int64_t timestamp_ms);
+  void (*prepend_history_message)(const char* role, const char* content, int64_t timestamp_ms);
   int  (*is_transcript_at_top)(void);
   /* Force scroll-to-bottom after a batch of history appends. Required because
    * lv_obj_scroll_by_bounded relies on a settled layout, but a tight append

--- a/firmware/include/bb_chat_transcript.h
+++ b/firmware/include/bb_chat_transcript.h
@@ -34,9 +34,14 @@ void bb_chat_transcript_append_assistant_chunk(const char* delta);
 void bb_chat_transcript_append_tool_call(const char* tool, const char* hint);
 void bb_chat_transcript_append_error(const char* msg);
 
-/* History replay — does not touch the active_assistant streaming bubble. */
-void bb_chat_transcript_append_history(const char* role, const char* content);
-void bb_chat_transcript_prepend_history(const char* role, const char* content);
+/* History replay — does not touch the active_assistant streaming bubble.
+ * timestamp_ms: Unix timestamp in milliseconds (0 = unknown). When non-zero,
+ * a time-segment separator is automatically inserted before the message if
+ * the gap since the previous message exceeds BB_HISTORY_SEGMENT_GAP_MS. */
+void bb_chat_transcript_append_history(const char* role, const char* content,
+                                       int64_t timestamp_ms);
+void bb_chat_transcript_prepend_history(const char* role, const char* content,
+                                        int64_t timestamp_ms);
 
 /* Scroll helpers. `lines > 0` = scroll down; `< 0` = up.
  * ADR-017: UP latches the transcript into reading mode (auto-scroll on new

--- a/firmware/src/bb_agent_client.c
+++ b/firmware/src/bb_agent_client.c
@@ -16,6 +16,50 @@
 
 static const char* TAG = "bb_agent";
 
+/* Parse a subset of RFC3339 / ISO-8601 timestamps as returned by the adapter
+ * (e.g. "2026-04-27T17:57:03Z" or "2026-04-27T17:57:03+08:00").
+ * Returns Unix timestamp in milliseconds, or 0 on parse failure.
+ * We avoid pulling in <time.h> mktime which doesn't handle TZ on ESP-IDF;
+ * instead we do a simple Gregorian calendar computation. */
+static int64_t parse_rfc3339_ms(const char* s) {
+  if (s == NULL || s[0] == '\0') return 0;
+  int year = 0, mon = 0, day = 0, hour = 0, min = 0, sec = 0;
+  /* Expect at minimum "YYYY-MM-DDTHH:MM:SS" (19 chars). */
+  if (sscanf(s, "%4d-%2d-%2dT%2d:%2d:%2d", &year, &mon, &day,
+             &hour, &min, &sec) != 6) {
+    return 0;
+  }
+  if (year < 2020 || mon < 1 || mon > 12 || day < 1 || day > 31) return 0;
+
+  /* Days per month (non-leap; Feb corrected below). */
+  static const int DOM[12] = {31,28,31,30,31,30,31,31,30,31,30,31};
+  int leap = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? 1 : 0;
+
+  /* Days since Unix epoch (1970-01-01). */
+  int64_t days = 0;
+  for (int y = 1970; y < year; y++) {
+    int ly = (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) ? 1 : 0;
+    days += 365 + ly;
+  }
+  for (int m = 1; m < mon; m++) {
+    days += DOM[m - 1] + (m == 2 ? leap : 0);
+  }
+  days += day - 1;
+
+  int64_t unix_sec = days * 86400 + hour * 3600 + min * 60 + sec;
+
+  /* Parse optional timezone offset "+HH:MM" or "-HH:MM" after the seconds. */
+  const char* tz = s + 19;
+  if (*tz == '+' || *tz == '-') {
+    int sign = (*tz == '+') ? 1 : -1;
+    int tzh = 0, tzm = 0;
+    if (sscanf(tz + 1, "%2d:%2d", &tzh, &tzm) == 2) {
+      unix_sec -= sign * (tzh * 3600 + tzm * 60);
+    }
+  }
+  return unix_sec * 1000;  /* convert to ms */
+}
+
 /*
  * Mirror bb_adapter_client.c::active_base_url(): cloud_saas profile uses
  * the cloud URL, otherwise the local adapter. Phase 4.8 wired the cloud-side
@@ -744,6 +788,7 @@ esp_err_t bb_agent_load_messages(const char* session_id,
     const cJSON* role = cJSON_GetObjectItemCaseSensitive(item, "role");
     const cJSON* content = cJSON_GetObjectItemCaseSensitive(item, "content");
     const cJSON* seq = cJSON_GetObjectItemCaseSensitive(item, "seq");
+    const cJSON* ts  = cJSON_GetObjectItemCaseSensitive(item, "timestamp");
     if (!cJSON_IsString(role) || !cJSON_IsString(content)) {
       continue;
     }
@@ -760,6 +805,7 @@ esp_err_t bb_agent_load_messages(const char* session_id,
     }
     memcpy(slot->content, content->valuestring, clen + 1);
     slot->seq = cJSON_IsNumber(seq) ? seq->valueint : i;
+    slot->timestamp_ms = cJSON_IsString(ts) ? parse_rfc3339_ms(ts->valuestring) : 0;
     written++;
   }
 

--- a/firmware/src/bb_chat_transcript.c
+++ b/firmware/src/bb_chat_transcript.c
@@ -28,6 +28,11 @@ extern const lv_font_t lv_font_bbclaw_cjk;
 #define UI_TEXT_DIM    BB_UI_TEXT_DIM
 #define UI_ME_ACCENT   BB_UI_ACCENT
 #define UI_AI_SURFACE  BB_UI_DOT_GHOST /* assistant bubble face */
+
+/* Time-segment threshold: two messages separated by more than this (30 min)
+ * get a visual divider between them.  Must match adapter's GAP_MS constant
+ * (adapter/web/src/components/Conversation.vue). */
+#define BB_HISTORY_SEGMENT_GAP_MS  (30LL * 60 * 1000)
 #define UI_TOOL_FG     BB_UI_TEXT_DIM
 #define UI_ERROR_FG    BB_UI_ERR
 
@@ -37,6 +42,10 @@ extern const lv_font_t lv_font_bbclaw_cjk;
 
 static lv_obj_t* s_transcript;
 static lv_obj_t* s_active_assistant;  /* current streaming bubble, NULL after finalize */
+
+/* Last-seen timestamp for history replay, used to detect segment gaps.
+ * Tracks the most-recently appended message; reset to 0 on transcript clear. */
+static int64_t s_history_last_ts_ms = 0;
 
 /* ADR-017 — reading mode.
  *
@@ -230,32 +239,89 @@ void bb_chat_transcript_append_error(const char* msg) {
   follow_tail_if_active();
 }
 
-void bb_chat_transcript_append_history(const char* role, const char* content) {
+/* Render a dim centered separator line with an HH:MM time label.
+ * Used to mark session-segment boundaries in the history transcript.
+ * No background, just a short dim text label — keeps the tiny screen
+ * from getting too cluttered. */
+static void make_segment_separator(const char* label, int prepend) {
+  if (s_transcript == NULL) return;
+  lv_obj_t* sep = lv_label_create(s_transcript);
+  lv_label_set_long_mode(sep, LV_LABEL_LONG_MODE_DOTS);
+  lv_obj_set_width(sep, 320 - 2 * MSG_HMARGIN);
+  lv_obj_set_style_text_font(sep, font(), 0);
+  lv_obj_set_style_text_color(sep, lv_color_hex(UI_TEXT_DIM), 0);
+  lv_obj_set_style_text_align(sep, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_text_opa(sep, LV_OPA_60, 0);
+  lv_obj_set_style_pad_top(sep, 4, 0);
+  lv_obj_set_style_pad_bottom(sep, 4, 0);
+  lv_label_set_text(sep, label);
+  if (prepend) lv_obj_move_to_index(sep, 0);
+}
+
+/* Format a Unix-ms timestamp into "HH:MM" local-ish display.
+ * We skip real TZ handling on device — display as UTC offset by the
+ * adapter's reported time which is already in the user's wall-clock. */
+static void format_hhmm(int64_t ts_ms, char* out, size_t out_sz) {
+  int64_t ts_sec = ts_ms / 1000;
+  int sec_of_day = (int)(ts_sec % 86400);
+  if (sec_of_day < 0) sec_of_day += 86400;
+  int hh = sec_of_day / 3600;
+  int mm = (sec_of_day % 3600) / 60;
+  snprintf(out, out_sz, "── %02d:%02d ──", hh, mm);
+}
+
+void bb_chat_transcript_append_history(const char* role, const char* content,
+                                       int64_t timestamp_ms) {
   if (s_transcript == NULL || role == NULL || content == NULL) return;
-  int is_user = strcmp(role, "user") == 0;
-  lv_obj_t* lbl;
-  if (is_user) {
-    lbl = make_msg_label(UI_ME_ACCENT, UI_TEXT_MAIN, LV_TEXT_ALIGN_RIGHT, 0);
-  } else {
-    lbl = make_assistant_label();
+
+  /* Insert a segment separator when there's a meaningful time gap. */
+  if (timestamp_ms > 0) {
+    int need_sep = (s_history_last_ts_ms == 0) ||
+                   (timestamp_ms - s_history_last_ts_ms > BB_HISTORY_SEGMENT_GAP_MS);
+    if (need_sep) {
+      char label[24];
+      format_hhmm(timestamp_ms, label, sizeof(label));
+      make_segment_separator(label, /*prepend=*/0);
+    }
+    s_history_last_ts_ms = timestamp_ms;
   }
+
+  int is_user = strcmp(role, "user") == 0;
+  lv_obj_t* lbl = is_user
+      ? make_msg_label(UI_ME_ACCENT, UI_TEXT_MAIN, LV_TEXT_ALIGN_RIGHT, 0)
+      : make_assistant_label();
   if (lbl == NULL) return;
   lv_label_set_text(lbl, content);
   s_active_assistant = NULL;
 }
 
-void bb_chat_transcript_prepend_history(const char* role, const char* content) {
+void bb_chat_transcript_prepend_history(const char* role, const char* content,
+                                        int64_t timestamp_ms) {
   if (s_transcript == NULL || role == NULL || content == NULL) return;
   int is_user = strcmp(role, "user") == 0;
-  lv_obj_t* lbl;
-  if (is_user) {
-    lbl = make_msg_label(UI_ME_ACCENT, UI_TEXT_MAIN, LV_TEXT_ALIGN_RIGHT, 0);
-  } else {
-    lbl = make_assistant_label();
-  }
+  lv_obj_t* lbl = is_user
+      ? make_msg_label(UI_ME_ACCENT, UI_TEXT_MAIN, LV_TEXT_ALIGN_RIGHT, 0)
+      : make_assistant_label();
   if (lbl == NULL) return;
   lv_label_set_text(lbl, content);
   lv_obj_move_to_index(lbl, 0);
+
+  /* For prepended (paginate-earlier) messages, insert a separator BEFORE
+   * this message when the gap to the next-older message warrants it.
+   * We can only detect this on the caller side (which has the full ordered
+   * array); here we just check whether the caller supplied a timestamp that
+   * differs from the last-seen one enough to need a divider.
+   * Strategy: separator goes at index 0 AFTER moving the bubble to 0,
+   * then we move the separator in front of the bubble (index 0 again). */
+  if (timestamp_ms > 0 && s_history_last_ts_ms > 0 &&
+      s_history_last_ts_ms - timestamp_ms > BB_HISTORY_SEGMENT_GAP_MS) {
+    char label[24];
+    format_hhmm(s_history_last_ts_ms, label, sizeof(label));
+    make_segment_separator(label, /*prepend=*/1);
+  }
+  if (timestamp_ms > 0) {
+    s_history_last_ts_ms = timestamp_ms;
+  }
 }
 
 void bb_chat_transcript_scroll(int lines) {
@@ -297,6 +363,7 @@ void bb_chat_transcript_clear(void) {
   if (s_transcript == NULL) return;
   lv_obj_clean(s_transcript);
   s_active_assistant = NULL;
+  s_history_last_ts_ms = 0;
 }
 
 void bb_chat_transcript_finalize_assistant(void) {

--- a/firmware/src/bb_theme_buddy_anim.c
+++ b/firmware/src/bb_theme_buddy_anim.c
@@ -581,15 +581,17 @@ static void theme_set_session(const char* sid_short) {
 }
 
 /* Phase S3 — history replay. Delegated to bb_chat_transcript. */
-static void theme_append_history_message(const char* role, const char* content) {
+static void theme_append_history_message(const char* role, const char* content,
+                                         int64_t timestamp_ms) {
   if (!s_st.built) return;
-  bb_chat_transcript_append_history(role, content);
+  bb_chat_transcript_append_history(role, content, timestamp_ms);
   s_st.active_assistant = NULL;
 }
 
-static void theme_prepend_history_message(const char* role, const char* content) {
+static void theme_prepend_history_message(const char* role, const char* content,
+                                          int64_t timestamp_ms) {
   if (!s_st.built) return;
-  bb_chat_transcript_prepend_history(role, content);
+  bb_chat_transcript_prepend_history(role, content, timestamp_ms);
 }
 
 static int theme_is_transcript_at_top(void) {

--- a/firmware/src/bb_theme_buddy_ascii.c
+++ b/firmware/src/bb_theme_buddy_ascii.c
@@ -404,7 +404,9 @@ static void theme_set_unread_count(int count) {
 }
 
 /* Phase S3 — history replay. Same structure as text-only theme. */
-static void theme_append_history_message(const char* role, const char* content) {
+static void theme_append_history_message(const char* role, const char* content,
+                                         int64_t timestamp_ms) {
+  (void)timestamp_ms;
   if (!s_st.built || role == NULL || content == NULL) return;
   int is_user = strcmp(role, "user") == 0;
   lv_obj_t* lbl;
@@ -417,7 +419,9 @@ static void theme_append_history_message(const char* role, const char* content) 
   s_st.active_assistant = NULL;
 }
 
-static void theme_prepend_history_message(const char* role, const char* content) {
+static void theme_prepend_history_message(const char* role, const char* content,
+                                          int64_t timestamp_ms) {
+  (void)timestamp_ms;
   if (!s_st.built || role == NULL || content == NULL) return;
   int is_user = strcmp(role, "user") == 0;
   lv_obj_t* lbl;

--- a/firmware/src/bb_theme_text_only.c
+++ b/firmware/src/bb_theme_text_only.c
@@ -297,7 +297,9 @@ static void theme_set_session(const char* sid_short) {
  * order (newest in batch first) so the oldest in the batch ends up at the
  * very top after all the move_to_index(0) calls.
  */
-static void theme_append_history_message(const char* role, const char* content) {
+static void theme_append_history_message(const char* role, const char* content,
+                                         int64_t timestamp_ms) {
+  (void)timestamp_ms;
   if (!s_st.built || role == NULL || content == NULL) return;
   int is_user = strcmp(role, "user") == 0;
   lv_obj_t* lbl;
@@ -310,7 +312,9 @@ static void theme_append_history_message(const char* role, const char* content) 
   s_st.active_assistant = NULL;
 }
 
-static void theme_prepend_history_message(const char* role, const char* content) {
+static void theme_prepend_history_message(const char* role, const char* content,
+                                          int64_t timestamp_ms) {
+  (void)timestamp_ms;
   if (!s_st.built || role == NULL || content == NULL) return;
   int is_user = strcmp(role, "user") == 0;
   lv_obj_t* lbl;

--- a/firmware/src/bb_ui_agent_chat.c
+++ b/firmware/src/bb_ui_agent_chat.c
@@ -1250,7 +1250,7 @@ static void cache_replay_cb(char role, const char* content, void* user) {
     case BB_CHAT_CACHE_ROLE_ERROR:     role_str = "error"; break;
     default: break;
   }
-  theme->append_history_message(role_str, content);
+  theme->append_history_message(role_str, content, /*timestamp_ms=*/0);
 }
 
 static void replay_chat_cache_into_theme(const bb_agent_theme_t* theme) {
@@ -1839,6 +1839,13 @@ static void on_history_fetch_done(void* user_data) {
       bb_chat_cache_clear();
     } else {
       ESP_LOGW(TAG, "history fetch failed err=%s", esp_err_to_name(res->err));
+      /* Show a non-intrusive toast so the user knows they're seeing only the
+       * local cache snapshot, not the full adapter history. This is the P0
+       * "offline degradation hint" from issue #110. */
+      const bb_agent_theme_t* t = bb_agent_theme_get_active();
+      if (t != NULL && t->show_toast != NULL) {
+        t->show_toast("仅本地缓存，完整记录需联网");
+      }
     }
     /* Hard fail: leave transcript blank, future scrolls won't retry. */
     s_chat.history_has_more = 0;
@@ -1873,7 +1880,8 @@ static void on_history_fetch_done(void* user_data) {
     /* Chronological order — append from oldest to newest. */
     if (theme->append_history_message != NULL) {
       for (int i = 0; i < res->count; i++) {
-        theme->append_history_message(res->msgs[i].role, res->msgs[i].content);
+        theme->append_history_message(res->msgs[i].role, res->msgs[i].content,
+                                      res->msgs[i].timestamp_ms);
         /* Mirror into cache — translate role to single-byte encoding so
          * the cache buffer stays compact. */
         const char* role = res->msgs[i].role;
@@ -1910,7 +1918,8 @@ static void on_history_fetch_done(void* user_data) {
      * top after all the move_to_index(0) calls. */
     if (theme->prepend_history_message != NULL) {
       for (int i = res->count - 1; i >= 0; i--) {
-        theme->prepend_history_message(res->msgs[i].role, res->msgs[i].content);
+        theme->prepend_history_message(res->msgs[i].role, res->msgs[i].content,
+                                       res->msgs[i].timestamp_ms);
       }
     }
     s_chat.history_min_seq = res->msgs[0].seq;


### PR DESCRIPTION
Fixes #110

## 变更概述

本 PR 实现 issue #110 中 P0–P2 的核心修复（P3 cloud_saas finalize 时机单独跟踪）。

### adapter 端

- **GAP_MS 注释修正**：`Conversation.vue` 第 5–7 行注释改为明确的中文说明，值保持 30 分钟（与固件新增的 `BB_HISTORY_SEGMENT_GAP_MS` 一致）
- **异步消息归属修复**：`turns` computed 重写——只有 `role === "user"` 才开新 turn；无前置 user 消息的孤立 assistant（async dispatch 晚回）归入上一个开放 turn 的 replies，不再凭空开轮

### 固件端

- **P1 — timestamp 解析**：`bb_agent_message_t` 新增 `int64_t timestamp_ms`；`bb_agent_client.c` 添加 `parse_rfc3339_ms()` helper（纯 Gregorian 计算 + 时区偏移，无 `mktime`/TZ 依赖），在消息解析循环中读取 adapter 返回的 `timestamp` 字段
- **P2 — 历史 UI 时间分段**：`bb_chat_transcript.c` 新增 `BB_HISTORY_SEGMENT_GAP_MS = 30 min`、`make_segment_separator()`、`format_hhmm()`；`append_history` 在相邻消息时差超阈值时自动插入 `── HH:MM ──` 分隔行；`prepend_history`（懒加载翻页）同样处理段间分隔；`clear()` 重置时间跟踪变量
- **接口升级**：`append/prepend_history_message` 签名加 `int64_t timestamp_ms`，三个主题文件同步更新（buddy-ascii / text-only 接受参数但暂不渲染分段）
- **P0 离线降级提示**：history fetch 网络失败时通过 `show_toast` 显示「仅本地缓存，完整记录需联网」

## 测试情况

- adapter: `make test` 全绿（30 个包）
- 固件: `make build` 编译成功（0 error，1 个已有的无关 warning）
- 硬件运行时验证：需要真实设备 + cloud_saas profile，本 PR 无法在 CI 自动化覆盖，请参考 testing.md 场景 B 验收