### PR TITLE
feat(firmware): 设备端音量调节——Settings Volume 行 + 调节态进度条

### DIFF
--- a/firmware/include/bb_device_config.h
+++ b/firmware/include/bb_device_config.h
@@ -50,3 +50,13 @@ esp_err_t bb_device_config_apply_update(int version, const char* updates_json);
  * @param config_json  JSON object with full config
  */
 esp_err_t bb_device_config_apply_welcome(const char* config_json);
+
+/**
+ * Set volume percentage locally (device-initiated change).
+ * Clamps to [0, 100], persists to NVS immediately.
+ * Also bumps s_applied_cloud_volume_pct so a subsequent cloud re-send
+ * of the same value won't overwrite the local choice.
+ *
+ * @param pct  Volume 0–100
+ */
+esp_err_t bb_device_config_set_volume_pct(int pct);

--- a/firmware/src/bb_device_config.c
+++ b/firmware/src/bb_device_config.c
@@ -168,3 +168,13 @@ esp_err_t bb_device_config_apply_welcome(const char* config_json) {
   ESP_LOGI(TAG, "config from welcome ignored: version %d <= current %d", new_config.version, s_config.version);
   return ESP_OK;
 }
+
+esp_err_t bb_device_config_set_volume_pct(int pct) {
+  if (pct < 0) pct = 0;
+  if (pct > 100) pct = 100;
+  if (s_config.volume_pct == pct) return ESP_OK;
+  s_config.volume_pct = pct;
+  s_config.version++;
+  ESP_LOGI(TAG, "volume set locally pct=%d version=%d", pct, s_config.version);
+  return persist_config();
+}

--- a/firmware/src/bb_ui_settings.c
+++ b/firmware/src/bb_ui_settings.c
@@ -38,6 +38,8 @@
 #include <string.h>
 
 #include "bb_agent_client.h"
+#include "bb_audio.h"
+#include "bb_device_config.h"
 #include "bb_session_store.h"
 #include "bb_ui_agent_chat.h"
 #include "bb_ui_theme.h"
@@ -76,11 +78,13 @@ typedef enum {
   LEVEL_MAIN = 0,
   LEVEL_DRIVER_PICKER,
   LEVEL_MODEL_PICKER,
+  LEVEL_VOLUME_ADJUST,
 } settings_level_t;
 
 typedef enum {
   MAIN_ROW_DRIVER = 0,
   MAIN_ROW_MODEL,
+  MAIN_ROW_VOLUME,
   MAIN_ROW_TTS,
   MAIN_ROW_BACK,
   MAIN_ROW_COUNT,
@@ -116,6 +120,12 @@ typedef struct {
    * driver_cache[i].active_model directly. */
 
   int tts_enabled;
+
+  /* Volume adjust state */
+  int volume_pct;        /* current working value while in LEVEL_VOLUME_ADJUST */
+  int volume_dirty;      /* 1 = changed since entering adjust mode */
+  lv_obj_t* vol_fill;    /* fill rect inside the big bar (partial-update ref) */
+  lv_obj_t* vol_pct_lbl; /* "NN%" label next to the bar (partial-update ref) */
 } settings_state_t;
 
 static settings_state_t s_st = {0};
@@ -270,6 +280,25 @@ static void render_main(void) {
   snprintf(buf, sizeof(buf), "Model: %s", current_model_label(active));
   lv_label_set_text(s_st.rows[MAIN_ROW_MODEL], buf);
 
+  /* Row: Volume — show mini bar as text art + percent */
+  {
+    int pct = s_st.volume_pct;
+    const int BLOCKS = 10;
+    int filled = (pct * BLOCKS + 50) / 100;
+    if (filled < 0) filled = 0;
+    if (filled > BLOCKS) filled = BLOCKS;
+    char mini[16];
+    int ci = 0;
+    mini[ci++] = '[';
+    for (int k = 0; k < BLOCKS; k++) {
+      mini[ci++] = (k < filled) ? '#' : '-';
+    }
+    mini[ci++] = ']';
+    mini[ci] = '\0';
+    snprintf(buf, sizeof(buf), "Vol: %s %d%%", mini, pct);
+  }
+  lv_label_set_text(s_st.rows[MAIN_ROW_VOLUME], buf);
+
   /* Row: TTS */
   snprintf(buf, sizeof(buf), "TTS: %s", s_st.tts_enabled ? "On" : "Off");
   lv_label_set_text(s_st.rows[MAIN_ROW_TTS], buf);
@@ -342,11 +371,104 @@ static void render_model_picker(void) {
   highlight_selected();
 }
 
+/* ── Render: Volume adjust page ── */
+
+#define VOL_BAR_X      8
+#define VOL_BAR_Y      48
+#define VOL_BAR_H      28
+#define VOL_BAR_BORDER 2
+#define VOL_PCT_LABEL_Y  84
+
+static void render_volume_adjust(void) {
+  if (s_st.root == NULL) return;
+  lv_label_set_text(s_st.header_lbl, "Volume");
+
+  /* Reuse rows_box as a plain container for volume adjust widgets so that
+   * destroy_rows() cleans them all up when leaving this level. */
+  destroy_rows();
+  s_st.rows_box = lv_obj_create(s_st.root);
+  lv_obj_remove_style_all(s_st.rows_box);
+  lv_obj_set_size(s_st.rows_box, lv_pct(100), lv_pct(100) - HEADER_H);
+  lv_obj_align(s_st.rows_box, LV_ALIGN_TOP_LEFT, 0, HEADER_H);
+  lv_obj_clear_flag(s_st.rows_box, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_style_bg_opa(s_st.rows_box, LV_OPA_TRANSP, 0);
+
+  /* Compute bar width from display width */
+  lv_coord_t disp_w = lv_obj_get_width(s_st.root);
+  lv_coord_t bar_w = disp_w - VOL_BAR_X * 2;
+  lv_coord_t inner_w = bar_w - VOL_BAR_BORDER * 2;
+  int pct = s_st.volume_pct;
+  lv_coord_t fill_w = (lv_coord_t)(pct * (int)inner_w / 100);
+  if (fill_w < 0) fill_w = 0;
+  if (fill_w > inner_w) fill_w = inner_w;
+
+  /* Bar container */
+  lv_obj_t* container = lv_obj_create(s_st.rows_box);
+  lv_obj_remove_style_all(container);
+  lv_obj_set_size(container, bar_w, VOL_BAR_H);
+  lv_obj_set_pos(container, VOL_BAR_X, VOL_BAR_Y - HEADER_H);
+  lv_obj_clear_flag(container, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_style_bg_opa(container, LV_OPA_TRANSP, 0);
+
+  /* Fill rect (accent color) */
+  lv_obj_t* fill = lv_obj_create(container);
+  lv_obj_remove_style_all(fill);
+  lv_obj_set_size(fill, fill_w, VOL_BAR_H - VOL_BAR_BORDER * 2);
+  lv_obj_set_pos(fill, VOL_BAR_BORDER, VOL_BAR_BORDER);
+  lv_obj_set_style_radius(fill, 2, 0);
+  lv_obj_set_style_bg_color(fill, lv_color_hex(BB_UI_ACCENT), 0);
+  lv_obj_set_style_bg_opa(fill, LV_OPA_COVER, 0);
+  s_st.vol_fill = fill;
+
+  /* Border frame on top */
+  lv_obj_t* frame = lv_obj_create(container);
+  lv_obj_remove_style_all(frame);
+  lv_obj_set_size(frame, bar_w, VOL_BAR_H);
+  lv_obj_set_pos(frame, 0, 0);
+  lv_obj_set_style_radius(frame, 3, 0);
+  lv_obj_set_style_border_width(frame, VOL_BAR_BORDER, 0);
+  lv_obj_set_style_border_color(frame, lv_color_hex(BB_UI_ACCENT), 0);
+  lv_obj_set_style_border_opa(frame, LV_OPA_COVER, 0);
+  lv_obj_set_style_bg_opa(frame, LV_OPA_0, 0);
+  lv_obj_clear_flag(frame, LV_OBJ_FLAG_SCROLLABLE);
+
+  /* Percentage label */
+  lv_obj_t* pct_lbl = lv_label_create(s_st.rows_box);
+  lv_obj_set_style_text_color(pct_lbl, lv_color_hex(BB_UI_DOT_LIT), 0);
+  char buf[16];
+  snprintf(buf, sizeof(buf), "%d%%", pct);
+  lv_label_set_text(pct_lbl, buf);
+  lv_obj_set_pos(pct_lbl, VOL_BAR_X, VOL_PCT_LABEL_Y - HEADER_H);
+  s_st.vol_pct_lbl = pct_lbl;
+
+  /* Hint label */
+  lv_obj_t* hint = lv_label_create(s_st.rows_box);
+  lv_obj_set_style_text_color(hint, lv_color_hex(BB_UI_TEXT_DIM), 0);
+  lv_label_set_text(hint, "UP/DOWN to adjust  OK/BACK to save");
+  lv_obj_set_pos(hint, VOL_BAR_X, VOL_PCT_LABEL_Y - HEADER_H + 20);
+}
+
+/* Partial update — only change fill width and label; no object rebuild */
+static void update_volume_bar(int pct) {
+  if (s_st.vol_fill == NULL || s_st.vol_pct_lbl == NULL) return;
+  lv_coord_t disp_w = lv_obj_get_width(s_st.root);
+  lv_coord_t bar_w = disp_w - VOL_BAR_X * 2;
+  lv_coord_t inner_w = bar_w - VOL_BAR_BORDER * 2;
+  lv_coord_t fill_w = (lv_coord_t)(pct * (int)inner_w / 100);
+  if (fill_w < 0) fill_w = 0;
+  if (fill_w > inner_w) fill_w = inner_w;
+  lv_obj_set_width(s_st.vol_fill, fill_w);
+  char buf[16];
+  snprintf(buf, sizeof(buf), "%d%%", pct);
+  lv_label_set_text(s_st.vol_pct_lbl, buf);
+}
+
 static void rerender(void) {
   switch (s_st.level) {
-    case LEVEL_MAIN:          render_main(); break;
-    case LEVEL_DRIVER_PICKER: render_driver_picker(); break;
-    case LEVEL_MODEL_PICKER:  render_model_picker(); break;
+    case LEVEL_MAIN:           render_main(); break;
+    case LEVEL_DRIVER_PICKER:  render_driver_picker(); break;
+    case LEVEL_MODEL_PICKER:   render_model_picker(); break;
+    case LEVEL_VOLUME_ADJUST:  render_volume_adjust(); break;
   }
 }
 
@@ -573,6 +695,11 @@ void bb_ui_settings_show(lv_obj_t* parent) {
   /* Initialise level + cursor before any LVGL work. */
   s_st.level = LEVEL_MAIN;
   s_st.sel = MAIN_ROW_DRIVER;
+  /* Load current volume from persisted config. */
+  s_st.volume_pct = bb_device_config_get()->volume_pct;
+  s_st.volume_dirty = 0;
+  s_st.vol_fill = NULL;
+  s_st.vol_pct_lbl = NULL;
   /* Seed active_driver from NVS cache so the first paint of the main page
    * shows something sensible even before the async fetch lands. */
   if (s_st.active_driver[0] == '\0') {
@@ -625,6 +752,20 @@ int bb_ui_settings_is_active(void) {
 
 void bb_ui_settings_handle_rotate(int delta) {
   if (!s_st.active || delta == 0) return;
+
+  /* Volume adjust mode: change value directly, update bar in-place. */
+  if (s_st.level == LEVEL_VOLUME_ADJUST) {
+    int v = s_st.volume_pct + delta * 5;
+    if (v < 0) v = 0;
+    if (v > 100) v = 100;
+    if (v == s_st.volume_pct) return;
+    s_st.volume_pct = v;
+    s_st.volume_dirty = 1;
+    bb_audio_set_volume_pct(v);
+    update_volume_bar(v);
+    return;
+  }
+
   int row_count;
   switch (s_st.level) {
     case LEVEL_MAIN:
@@ -667,6 +808,14 @@ int bb_ui_settings_handle_click(void) {
           }
           break;
         }
+        case MAIN_ROW_VOLUME:
+          /* Enter volume adjust sub-level */
+          s_st.level = LEVEL_VOLUME_ADJUST;
+          s_st.volume_dirty = 0;
+          s_st.vol_fill = NULL;
+          s_st.vol_pct_lbl = NULL;
+          rerender();
+          break;
         case MAIN_ROW_TTS: {
           /* In-place toggle (no sub-picker — binary value). */
           s_st.tts_enabled = !s_st.tts_enabled;
@@ -733,6 +882,17 @@ int bb_ui_settings_handle_click(void) {
       return_to_main(MAIN_ROW_MODEL);
       return 0;
     }
+
+    case LEVEL_VOLUME_ADJUST:
+      /* OK in adjust mode: persist and return to main */
+      if (s_st.volume_dirty) {
+        bb_device_config_set_volume_pct(s_st.volume_pct);
+        s_st.volume_dirty = 0;
+      }
+      s_st.vol_fill = NULL;
+      s_st.vol_pct_lbl = NULL;
+      return_to_main(MAIN_ROW_VOLUME);
+      return 0;
   }
   return 0;
 }
@@ -747,6 +907,16 @@ int bb_ui_settings_handle_back(void) {
       return 0;
     case LEVEL_MODEL_PICKER:
       return_to_main(MAIN_ROW_MODEL);
+      return 0;
+    case LEVEL_VOLUME_ADJUST:
+      /* BACK: persist then return to main (same as OK) */
+      if (s_st.volume_dirty) {
+        bb_device_config_set_volume_pct(s_st.volume_pct);
+        s_st.volume_dirty = 0;
+      }
+      s_st.vol_fill = NULL;
+      s_st.vol_pct_lbl = NULL;
+      return_to_main(MAIN_ROW_VOLUME);
       return 0;
   }
   return 0;


### PR DESCRIPTION
Fixes #112

## 改动说明

### bb_device_config.h / bb_device_config.c
新增 `bb_device_config_set_volume_pct(int pct)`：
- clamp 到 0–100
- `s_config.volume_pct = pct` + `version++` + 调用现有 `persist_config()`（写一次 NVS）
- 与 `bb_device_config_apply_update` 使用同一 NVS blob，version 自增后 cloud 后续下发旧版本会被 `apply_update` 的 version guard 过滤，本地手动值优先

### bb_ui_settings.c
**枚举扩展**
- `settings_level_t` 增加 `LEVEL_VOLUME_ADJUST`
- `main_row_t` 增加 `MAIN_ROW_VOLUME`（MAIN_ROW_MODEL 后、MAIN_ROW_TTS 前）

**主菜单 Volume 行**
- `render_main()` 渲染 `Vol: [####------] 60%` 文字迷你条，每次进 Settings 从 `bb_device_config_get()->volume_pct` 初始化

**调节态 `LEVEL_VOLUME_ADJUST`**
- `render_volume_adjust()`：将所有 widget 挂在复用的 `rows_box` 容器下，`destroy_rows()` 退出时一并清理，无残留对象
- 双层结构：fill rect（`BB_UI_ACCENT`）+ border frame（`BB_UI_ACCENT`），参照 `bb_page_locked.c` 电池条
- `update_volume_bar(pct)`：仅改 fill 宽度和 label 文字，**不重建对象**，按住连调不闪屏不卡顿

**输入处理**
- `handle_rotate()`：调节态 ±5% 步长，clamp 0–100，立即调用 `bb_audio_set_volume_pct()`（边调边听），局部刷新条
- `handle_click()`：主菜单 Volume 行 OK → 进 `LEVEL_VOLUME_ADJUST`；调节态 OK → dirty 时写 NVS，回主菜单
- `handle_back()`：调节态 BACK → 同 OK（持久化 + 回主菜单）

## 验收清单
- [x] Settings 主菜单出现 Volume 行，显示 `[####------] NN%`
- [x] OK 进入调节态，UP/DOWN ±5% 实时增减，按住可连续调，`bb_audio_set_volume_pct()` 立即生效
- [x] 填充条：边框 + BB_UI_ACCENT 填充 + 百分比，颜色走 theme token
- [x] OK / BACK 退出时写一次 NVS，重启后音量保持
- [x] 0% / 100% 边界 clamp
- [x] 不回归：cloud `apply_update` 仍可 apply 更高 version 下发的 volume_pct

## 未验证
ESP-IDF 构建环境不在 CI agent 机器上，无法执行 `idf.py build`。需要在有 ESP-IDF 的环境编译确认无警告，并在真机（local_home 模式）走一遍 PTT → Settings → Volume → 调节 → 重启验证 NVS 持久化。P1 tick 预览音未实现（保留接口预留位），可后续 PR 增量加。