### PR TITLE
fix(firmware): 设备端音量即时生效且重启保持，不再需要重启

### DIFF
--- a/firmware/include/bb_device_config.h
+++ b/firmware/include/bb_device_config.h
@@ -53,9 +53,11 @@ esp_err_t bb_device_config_apply_welcome(const char* config_json);
 
 /**
  * Set volume percentage locally (device-initiated change).
- * Clamps to [0, 100], persists to NVS immediately.
- * Also bumps s_applied_cloud_volume_pct so a subsequent cloud re-send
- * of the same value won't overwrite the local choice.
+ * Clamps to [0, 100], persists to NVS immediately so the choice survives
+ * reboots (re-applied at boot in bb_radio_app via bb_audio_set_volume_pct).
+ * The cloud heartbeat only overrides the volume when the cloud value changes
+ * at runtime, so a local change is never clobbered by a cloud re-send of an
+ * unchanged value.
  *
  * @param pct  Volume 0–100
  */

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -2852,8 +2852,19 @@ static void stream_task(void* arg) {
         remember_transport_state(&state);
         if (health_err == ESP_OK && bb_transport_is_cloud_saas()) {
           if (state.cloud_volume_pct >= 0) {
+            /* The locally-saved volume (applied at boot + via the on-device
+             * Volume setting) is the source of truth. Only let the cloud value
+             * override when it *changes at runtime* — a deliberate remote
+             * action. The first heartbeat after boot just records the cloud
+             * baseline so it doesn't clobber the user's local choice, and a
+             * cloud re-send of an unchanged value is a no-op (so a device-side
+             * adjustment is never silently reverted). */
             static int s_applied_cloud_volume_pct = -1;
-            if (state.cloud_volume_pct != s_applied_cloud_volume_pct) {
+            static int s_cloud_volume_baseline_set = 0;
+            if (!s_cloud_volume_baseline_set) {
+              s_applied_cloud_volume_pct = state.cloud_volume_pct;
+              s_cloud_volume_baseline_set = 1;
+            } else if (state.cloud_volume_pct != s_applied_cloud_volume_pct) {
               s_applied_cloud_volume_pct = state.cloud_volume_pct;
               bb_audio_set_volume_pct(state.cloud_volume_pct);
             }
@@ -3092,6 +3103,11 @@ esp_err_t bb_radio_app_start(void) {
     show_status_error("AUDIO ERR");
     return audio_err;
   }
+  /* Apply the user's persisted volume so the on-device Volume setting survives
+   * reboots. bb_audio_init() starts at the compiled-in default; without this
+   * the saved value would only take effect after a manual restart (and in
+   * cloud_saas the cloud value would otherwise win on the first heartbeat). */
+  bb_audio_set_volume_pct(bb_device_config_get()->volume_pct);
 #if BBCLAW_XL9555_ENABLE
   {
     esp_err_t xl_err = bb_xl9555_init();


### PR DESCRIPTION
## 问题
在设备 Settings 里调音量后**要重启才生效 / 重启就丢**。

根因:开机 `bb_audio_init()` 只用编译期默认音量,**从不应用 NVS 里存的 `volume_pct`**(全固件 `bb_audio_set_volume_pct` 只有云端心跳和 settings 两个调用点,开机没有)。cloud_saas 下云端心跳还会在开机首拍用 `cloud_volume_pct` 覆盖本地选择。

## 修复
- **`bb_radio_app.c`(开机)**:`bb_audio_init()` 后应用 `bb_device_config_get()->volume_pct`,让保存的音量每次开机生效。
- **`bb_radio_app.c`(云端心跳)**:加基线判定——开机首拍只记录云端值不覆盖;之后仅当云端值**运行时真正变化**才覆盖(保留远程改音量);同值重发为 no-op,本地调节不再被悄悄回灌。
- **`bb_device_config.h`**:修正与实现不符的注释。

settings 的即时应用(`bb_ui_settings.c:764`)和 OK/BACK 持久化(`bb_device_config_set_volume_pct`)本就正确,配上开机应用即闭环:调音量即时生效 → OK 存 NVS → 重启自动应用 → 云端不再乱覆盖。

## 验证
`make build` 通过。真机闭环验证待异地进行:进 Settings 调音量 → 听 TTS 确认即时生效 → 重启 → 确认保持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)