### PR TITLE
fix(firmware): 设置里调音量/切TTS按OK必崩重启 (NVS写在PSRAM栈)

### DIFF
--- a/firmware/src/bb_ui_settings.c
+++ b/firmware/src/bb_ui_settings.c
@@ -444,7 +444,7 @@ static void render_volume_adjust(void) {
   /* Hint label */
   lv_obj_t* hint = lv_label_create(s_st.rows_box);
   lv_obj_set_style_text_color(hint, lv_color_hex(BB_UI_TEXT_DIM), 0);
-  lv_label_set_text(hint, "UP/DOWN to adjust  OK/BACK to save");
+  lv_label_set_text(hint, "UP/DOWN adjust  OK save & back");
   lv_obj_set_pos(hint, VOL_BAR_X, VOL_PCT_LABEL_Y - HEADER_H + 20);
 }
 
@@ -562,12 +562,15 @@ static void spawn_driver_fetch_task(void) {
 typedef enum {
   COMMIT_KIND_DRIVER = 0,
   COMMIT_KIND_MODEL,
+  COMMIT_KIND_VOLUME,  /* int_val = volume pct 0-100 */
+  COMMIT_KIND_TTS,     /* int_val = 0/1 */
 } commit_kind_t;
 
 typedef struct {
   commit_kind_t kind;
   char driver_name[24];
   char model_id[40];
+  int int_val;
 } commit_payload_t;
 
 static void commit_task(void* arg) {
@@ -599,7 +602,7 @@ static void commit_task(void* arg) {
       }
     }
     ESP_LOGI(TAG, "commit driver='%s' -> %s", p->driver_name, esp_err_to_name(err));
-  } else {
+  } else if (p->kind == COMMIT_KIND_MODEL) {
     err = bb_agent_set_active_model(p->driver_name, p->model_id);
     if (err == ESP_OK) {
       /* ADR-016: push the new model into the bottom-bar slot. We pass model_id
@@ -613,6 +616,12 @@ static void commit_task(void* arg) {
     }
     ESP_LOGI(TAG, "commit driver='%s' model='%s' -> %s",
              p->driver_name, p->model_id, esp_err_to_name(err));
+  } else if (p->kind == COMMIT_KIND_VOLUME) {
+    err = bb_device_config_set_volume_pct(p->int_val);
+    ESP_LOGI(TAG, "commit volume=%d%% -> %s", p->int_val, esp_err_to_name(err));
+  } else if (p->kind == COMMIT_KIND_TTS) {
+    err = persist_tts_enabled(p->int_val);
+    ESP_LOGI(TAG, "commit tts=%d -> %s", p->int_val, esp_err_to_name(err));
   }
   free(p);
   vTaskDelete(NULL);
@@ -637,6 +646,29 @@ static void spawn_commit_task(commit_kind_t kind, const char* driver, const char
                               BB_SETTINGS_FETCH_TASK_PRIO, &t);
   if (ok != pdPASS) {
     ESP_LOGE(TAG, "spawn_commit_task: xTaskCreate failed");
+    free(p);
+  }
+}
+
+/* Persist a simple integer setting (volume / tts) on a fresh task. NVS/flash
+ * writes freeze the cache; the stream_task that drives Settings nav has its
+ * stack in PSRAM, so writing from there panics
+ * (s_task_stack_is_sane_when_cache_frozen). xTaskCreate stacks live in
+ * internal RAM, so the write is safe here. */
+static void spawn_persist_int(commit_kind_t kind, int val) {
+  commit_payload_t* p = (commit_payload_t*)calloc(1, sizeof(*p));
+  if (p == NULL) {
+    ESP_LOGE(TAG, "spawn_persist_int: calloc failed");
+    return;
+  }
+  p->kind = kind;
+  p->int_val = val;
+  TaskHandle_t t = NULL;
+  BaseType_t ok = xTaskCreate(commit_task, "set_persist",
+                              BB_SETTINGS_FETCH_TASK_STACK, p,
+                              BB_SETTINGS_FETCH_TASK_PRIO, &t);
+  if (ok != pdPASS) {
+    ESP_LOGE(TAG, "spawn_persist_int: xTaskCreate failed");
     free(p);
   }
 }
@@ -817,13 +849,11 @@ int bb_ui_settings_handle_click(void) {
           rerender();
           break;
         case MAIN_ROW_TTS: {
-          /* In-place toggle (no sub-picker — binary value). */
+          /* In-place toggle (no sub-picker — binary value). Persist off the
+           * stream_task (PSRAM stack) — an NVS write there freezes the cache
+           * and panics. */
           s_st.tts_enabled = !s_st.tts_enabled;
-          esp_err_t err = persist_tts_enabled(s_st.tts_enabled);
-          if (err != ESP_OK) {
-            ESP_LOGW(TAG, "persist tts %d failed (%s)",
-                     s_st.tts_enabled, esp_err_to_name(err));
-          }
+          spawn_persist_int(COMMIT_KIND_TTS, s_st.tts_enabled);
           rerender();
           break;
         }
@@ -884,9 +914,12 @@ int bb_ui_settings_handle_click(void) {
     }
 
     case LEVEL_VOLUME_ADJUST:
-      /* OK in adjust mode: persist and return to main */
+      /* OK in adjust mode: persist and return to main. Live volume is already
+       * applied via bb_audio_set_volume_pct() on each rotate; here we only
+       * persist — off the stream_task (PSRAM stack) to avoid the cache-freeze
+       * panic on the NVS write. */
       if (s_st.volume_dirty) {
-        bb_device_config_set_volume_pct(s_st.volume_pct);
+        spawn_persist_int(COMMIT_KIND_VOLUME, s_st.volume_pct);
         s_st.volume_dirty = 0;
       }
       s_st.vol_fill = NULL;
@@ -909,9 +942,10 @@ int bb_ui_settings_handle_back(void) {
       return_to_main(MAIN_ROW_MODEL);
       return 0;
     case LEVEL_VOLUME_ADJUST:
-      /* BACK: persist then return to main (same as OK) */
+      /* BACK: persist then return to main (same as OK). Persist off the
+       * stream_task (PSRAM stack) — see handle_click for why. */
       if (s_st.volume_dirty) {
-        bb_device_config_set_volume_pct(s_st.volume_pct);
+        spawn_persist_int(COMMIT_KIND_VOLUME, s_st.volume_pct);
         s_st.volume_dirty = 0;
       }
       s_st.vol_fill = NULL;


### PR DESCRIPTION
## 现象
进设置调完音量(或切 TTS)按 OK,**必然崩溃重启**。

## 根因(来自真机崩溃栈)
```
assert failed: s_task_stack_is_sane_when_cache_frozen()
  persist_config (nvs_set_blob)        bb_device_config.c:68
  bb_device_config_set_volume_pct      bb_device_config.c:179
  bb_ui_settings_handle_back           bb_ui_settings.c:914
  settings_back_locked                 bb_radio_app.c:524
  stream_task                          bb_radio_app.c:1858   ← PSRAM 栈
```
ESP32-S3 写 Flash(NVS commit)要冻结 cache,cache 一冻 PSRAM 不可访问;而 `stream_task` 的栈在 PSRAM,写 Flash 瞬间自己的栈没了 → assert → reboot。这是 CLAUDE.md 反复警告的"别在 stream_task 上碰 NVS"。音量提交(`handle_click`/`handle_back`)和 TTS 开关(`persist_tts_enabled`)都犯了这条;driver/model 提交因为走 `spawn_commit_task`(内部 RAM 栈)所以没事。

## 修复
复用现成的 `spawn_commit_task` 模式:
- 新增 `spawn_persist_int` + `COMMIT_KIND_VOLUME` / `COMMIT_KIND_TTS`,把 NVS 写挪到 `xTaskCreate`(内部 RAM 栈)的任务里。
- 音量 OK/BACK 提交、TTS 切换改为 `spawn_persist_int`,不再在 stream_task 直接写 NVS。
- 即时音量(rotate 时 `bb_audio_set_volume_pct`,无 Flash 写)不变。

## 退出"上一页"
音量调节态:**OK 短按** 或 **BACK(OK 长按)** 都保存并返回设置主菜单——崩溃修好后即正常。提示文案改为 `UP/DOWN adjust  OK save & back`。

## 验证
`make build` 通过;真机闭环待异地验证:进设置调音量→OK→应返回菜单不重启→重启后音量保持;切 TTS→OK→不重启。

🤖 Generated with [Claude Code](https://claude.com/claude-code)