### PR TITLE
feat(adapter): 语音调节设备音量——device set-volume CLI + butler sysprompt 注入 deviceId

### DIFF
--- a/adapter/internal/butler/engine.go
+++ b/adapter/internal/butler/engine.go
@@ -42,10 +42,10 @@ type Deps struct {
 	// active_model 或 ""。butler 不缓存其结果以保留 ADR-016 mid-session 语义。
 	ResolveActiveModel func(driver string) string
 
-	// SystemPrompt 注入(ADR-018 §3):据 logical cwd 构造每轮的系统提示,经
+	// SystemPrompt 注入(ADR-018 §3):据 logical cwd 和当前设备 ID 构造每轮的系统提示,经
 	// StartOpts.SystemPrompt 下达给 driver(claudecode → --append-system-prompt)。
 	// nil = 不注入。两 caller 通常都传 butler.DeviceSystemPrompt。
-	SystemPrompt func(cwd string) string
+	SystemPrompt func(cwd, deviceID string) string
 
 	// StartCtx 是传给 drv.Start 的 ctx(差异 #9)。
 	//   LOCAL  = s.agentCtx(长生命周期)
@@ -124,11 +124,11 @@ func (d Deps) resolveModel(driver string) string {
 	return d.ResolveActiveModel(driver)
 }
 
-func (d Deps) buildSystemPrompt(cwd string) string {
+func (d Deps) buildSystemPrompt(cwd, deviceID string) string {
 	if d.SystemPrompt == nil {
 		return ""
 	}
-	return d.SystemPrompt(cwd)
+	return d.SystemPrompt(cwd, deviceID)
 }
 
 // RunTurn 跑完整个 turn 骨架(解析→主动 resume 校验→attempt 循环→收尾)。
@@ -340,7 +340,7 @@ func (e *Engine) RunTurn(turnCtx context.Context, req Request) (*Result, error) 
 				startOpts.Cwd = logicalCwd
 			}
 			startOpts.Model = d.resolveModel(drv.Name())
-			startOpts.SystemPrompt = d.buildSystemPrompt(logicalCwd)
+			startOpts.SystemPrompt = d.buildSystemPrompt(logicalCwd, req.DeviceID)
 			// 仅管家会话(Role=butler)带 --mcp-config,让它能派发 worker(ADR-021 §2);
 			// worker / 普通会话不带。driver 不支持 MCP 时忽略(契约同 Model)。
 			if logicalRole == logicalsession.RoleButler && d.ButlerMCPConfig != "" {

--- a/adapter/internal/butler/engine_test.go
+++ b/adapter/internal/butler/engine_test.go
@@ -317,7 +317,7 @@ func TestRunTurn_InjectsSystemPrompt(t *testing.T) {
 	})
 	sink := newFakeSink()
 	deps := baseDeps(routerWith(t, drv), sink, newFakeRegistry(), Policy{EmitTurnEndFrame: true})
-	deps.SystemPrompt = func(cwd string) string { return "PERSONA:" + cwd }
+	deps.SystemPrompt = func(cwd, deviceID string) string { return "PERSONA:" + cwd }
 	eng := NewEngine(deps)
 
 	if _, err := eng.RunTurn(context.Background(), Request{Text: "hello"}); err != nil {

--- a/adapter/internal/butler/persona.go
+++ b/adapter/internal/butler/persona.go
@@ -12,10 +12,13 @@ import "strings"
 // cwd is the active project directory; when set it is surfaced as an explicit
 // hint (the CLI also runs in it, but stating it removes ambiguity).
 //
+// deviceID is the current device's ID injected per-turn. When non-empty, a
+// device-control section is appended so the butler knows how to call the
+// bbclaw-adapter device CLI to adjust volume. Empty deviceID = skip that section.
+//
 // This is the static baseline. ADR-018 P1 will append a user-needs summary and
-// project memory here once the memory store exists; the signature stays
-// (cwd) for now and widens when that lands.
-func DeviceSystemPrompt(cwd string) string {
+// project memory here once the memory store exists.
+func DeviceSystemPrompt(cwd, deviceID string) string {
 	var b strings.Builder
 	b.WriteString("你正通过 BBClaw 与用户对话——一台对讲机式的硬件语音外设" +
 		"(1.47 寸小屏、PTT 按键、语音播报),作为 AI 编码助手 CLI 的远程终端。" +
@@ -28,6 +31,14 @@ func DeviceSystemPrompt(cwd string) string {
 	b.WriteString("- 工具调用(读写文件、执行命令)会真实作用于本地项目,请谨慎、按需。\n")
 	if c := strings.TrimSpace(cwd); c != "" {
 		b.WriteString("- 当前工作目录:" + c + "\n")
+	}
+	if id := strings.TrimSpace(deviceID); id != "" {
+		b.WriteString("\n## 设备控制\n")
+		b.WriteString("当前设备 ID:`" + id + "`\n")
+		b.WriteString("如需调节本设备音量,用 Bash 工具执行:\n")
+		b.WriteString("  bbclaw-adapter device set-volume <0-100> --device " + id + "\n")
+		b.WriteString("成功后用一句话朗读结果(例如「已把音量调到 50%,马上生效」)。\n")
+		b.WriteString("如果设备 ID 未知,不要尝试音量调节。\n")
 	}
 	return b.String()
 }

--- a/adapter/internal/butler/persona_test.go
+++ b/adapter/internal/butler/persona_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDeviceSystemPrompt(t *testing.T) {
-	withCwd := DeviceSystemPrompt("/Users/me/proj")
+	withCwd := DeviceSystemPrompt("/Users/me/proj", "")
 	if !strings.Contains(withCwd, "/Users/me/proj") {
 		t.Errorf("expected cwd hint in prompt, got:\n%s", withCwd)
 	}
@@ -16,8 +16,23 @@ func TestDeviceSystemPrompt(t *testing.T) {
 
 	// Empty / whitespace cwd must omit the cwd line entirely.
 	for _, cwd := range []string{"", "   "} {
-		if strings.Contains(DeviceSystemPrompt(cwd), "当前工作目录") {
+		if strings.Contains(DeviceSystemPrompt(cwd, ""), "当前工作目录") {
 			t.Errorf("cwd=%q must omit the cwd line", cwd)
 		}
+	}
+
+	// Non-empty deviceID must inject device-control section.
+	withDevice := DeviceSystemPrompt("", "dev-abc-123")
+	if !strings.Contains(withDevice, "dev-abc-123") {
+		t.Errorf("expected deviceID in prompt, got:\n%s", withDevice)
+	}
+	if !strings.Contains(withDevice, "set-volume") {
+		t.Errorf("expected set-volume CLI hint in prompt, got:\n%s", withDevice)
+	}
+
+	// Empty deviceID must omit device-control section.
+	noDevice := DeviceSystemPrompt("/some/cwd", "")
+	if strings.Contains(noDevice, "set-volume") {
+		t.Errorf("empty deviceID must omit set-volume hint, got:\n%s", noDevice)
 	}
 }

--- a/adapter/internal/cmd/device.go
+++ b/adapter/internal/cmd/device.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/homeadapter"
+	"github.com/spf13/cobra"
+)
+
+// NewDeviceCmd creates the "device" subcommand tree.
+func NewDeviceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "device",
+		Short: "Control BBClaw device settings via cloud API",
+	}
+	cmd.AddCommand(newSetVolumeCmd())
+	return cmd
+}
+
+func newSetVolumeCmd() *cobra.Command {
+	var deviceID string
+
+	cmd := &cobra.Command{
+		Use:   "set-volume <pct>",
+		Short: "Set device volume (0-100) via cloud config API",
+		Long: `Set the volume percentage for a BBClaw device.
+
+The command reads CLOUD_WS_URL and CLOUD_AUTH_TOKEN from the environment
+(or .env file) and calls POST /v1/devices/{deviceId}/config on the cloud.
+
+Examples:
+  bbclaw-adapter device set-volume 50 --device <deviceId>
+  bbclaw-adapter device set-volume 0  --device <deviceId>   # mute
+  bbclaw-adapter device set-volume 100 --device <deviceId>  # max`,
+		Args: cobra.ExactArgs(1),
+		RunE: runSetVolume(&deviceID),
+	}
+
+	cmd.Flags().StringVar(&deviceID, "device", "", "Target device ID (required)")
+	_ = cmd.MarkFlagRequired("device")
+
+	return cmd
+}
+
+type setConfigRequest struct {
+	VolumePct int `json:"volumePct"`
+}
+
+type setConfigResponse struct {
+	OK   bool `json:"ok"`
+	Data struct {
+		Version   int `json:"version"`
+		VolumePct int `json:"volumePct"`
+	} `json:"data"`
+	Error string `json:"error,omitempty"`
+}
+
+func runSetVolume(deviceID *string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		// Parse and clamp pct.
+		var pct int
+		if _, err := fmt.Sscanf(args[0], "%d", &pct); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "invalid volume value %q: must be an integer 0-100\n", args[0])
+			return fmt.Errorf("invalid volume value: %s", args[0])
+		}
+		if pct < 0 {
+			pct = 0
+		}
+		if pct > 100 {
+			pct = 100
+		}
+
+		id := strings.TrimSpace(*deviceID)
+		if id == "" {
+			fmt.Fprintln(cmd.ErrOrStderr(), "--device is required")
+			return fmt.Errorf("--device is required")
+		}
+
+		// Load cloud config from env.
+		cfg, err := homeadapter.LoadFromEnv()
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "config load failed: %v\n", err)
+			return err
+		}
+
+		base, err := homeadapter.DeriveCloudHTTPBase(cfg.CloudWSURL)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "cannot derive HTTP base from CLOUD_WS_URL: %v\n", err)
+			return err
+		}
+
+		// Build request.
+		body, _ := json.Marshal(setConfigRequest{VolumePct: pct})
+		url := base + "/v1/devices/" + id + "/config"
+		httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "构建请求失败: %v\n", err)
+			return err
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		if cfg.CloudAuthToken != "" {
+			httpReq.Header.Set("Authorization", "Bearer "+cfg.CloudAuthToken)
+		}
+
+		client := &http.Client{Timeout: 15 * time.Second}
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "请求云端失败: %v\n", err)
+			return err
+		}
+		defer resp.Body.Close()
+
+		var result setConfigResponse
+		if decErr := json.NewDecoder(resp.Body).Decode(&result); decErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "解析响应失败 (HTTP %d): %v\n", resp.StatusCode, decErr)
+			return decErr
+		}
+
+		if !result.OK || resp.StatusCode != http.StatusOK {
+			errMsg := result.Error
+			if errMsg == "" {
+				errMsg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "云端返回错误: %s\n", errMsg)
+			return fmt.Errorf("cloud error: %s", errMsg)
+		}
+
+		out, _ := json.Marshal(map[string]any{
+			"ok":        true,
+			"volumePct": result.Data.VolumePct,
+			"version":   result.Data.Version,
+		})
+		fmt.Println(string(out))
+		return nil
+	}
+}

--- a/adapter/internal/cmd/root.go
+++ b/adapter/internal/cmd/root.go
@@ -20,6 +20,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(NewDoctorCmd())
 	cmd.AddCommand(NewVersionCmd())
 	cmd.AddCommand(NewMcpServerCmd())
+	cmd.AddCommand(NewDeviceCmd())
 
 	return cmd
 }

--- a/adapter/internal/homeadapter/adapter.go
+++ b/adapter/internal/homeadapter/adapter.go
@@ -642,7 +642,7 @@ func (a *Adapter) handleChatTextViaAgent(
 	// Voice turns get the same butler device persona as session turns (ADR-018
 	// §3) so the backend keeps replies short/speakable instead of leaking the
 	// cwd or dumping walls of code to a 1.47" screen.
-	startOpts.SystemPrompt = butler.DeviceSystemPrompt(startOpts.Cwd)
+	startOpts.SystemPrompt = butler.DeviceSystemPrompt(startOpts.Cwd, env.DeviceID)
 	sid, err := drv.Start(ctx, startOpts)
 	if err != nil {
 		return fmt.Errorf("agent start: %w", err)


### PR DESCRIPTION
Fixes #116

## 改动说明

### 新增 `bbclaw-adapter device set-volume` CLI 子命令

**文件**: `adapter/internal/cmd/device.go`（新建）、`adapter/internal/cmd/root.go`

- 用法: `bbclaw-adapter device set-volume <pct> --device <deviceId>`
- pct 自动 clamp 到 0–100；非法值返回非零退出码 + stderr 说明（agent 可朗读失败原因）
- `--device` 为空时报错退出（首版不做默认设备猜测）
- 读 `CLOUD_WS_URL` + `CLOUD_AUTH_TOKEN`，调 `DeriveCloudHTTPBase()` 得 HTTP base
- 仿 `pairing_http.go` 模板 POST `/v1/devices/{deviceId}/config` `{"volumePct": N}`
- 成功 stdout 输出单行 JSON `{"ok":true,"volumePct":N,"version":M}`（agent 友好）
- 已注册到 root.go

### butler sysprompt 每轮注入 deviceId

**文件**: `adapter/internal/butler/persona.go`、`butler/engine.go`、`homeadapter/adapter.go`

- `DeviceSystemPrompt(cwd, deviceID string)`：非空 deviceID 时追加「设备控制」段
  - 注明当前设备 ID 和 `set-volume` CLI 用法
  - 回执文案用「已下发，马上生效」避免误导用户立刻检查屏幕
  - 空 deviceID 时完全不注入该段（local_home 无 device 也不会打架）
- `Deps.SystemPrompt` 字段签名更新为 `func(cwd, deviceID string) string`
- `buildSystemPrompt` 透传 `req.DeviceID`
- `homeadapter/adapter.go` 语音快速路径同步传入 `env.DeviceID`

## 测试

- `go test ./...` 全部 30 个包通过
- `butler/persona_test.go` 新增 deviceID 注入 / 不注入用例
- `butler/engine_test.go` 更新 SystemPrompt 测试桩签名

## 未测试（硬件 / 云端依赖）

- 云端 `POST /v1/devices/{id}/config` 端点尚未在 bbclaw-reference 落地，端到端链路阻塞
- 设备侧 config.update 下发应用已在 #114/#115 就绪，无需固件改动