### PR TITLE
fix(firmware/ci): 发布构建实际选中 bbclaw 板(修 OTA 变砖)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,13 @@ jobs:
         run: |
           source ~/esp/esp-idf/export.sh
           cd firmware
-          make set-target BOARD=bbclaw
+          # `make set-target` only runs `idf.py set-target` (ignores BOARD); the
+          # actual board switch is `make set-board`, which flips
+          # CONFIG_BBCLAW_BOARD_* in sdkconfig. Without it CI built the default
+          # board (breadboard) — wrong pins/PSRAM for the bbclaw PCB, which
+          # bricked devices on OTA. Select bbclaw explicitly.
+          make set-target
+          make set-board BOARD=bbclaw
           make build
 
       - name: Generate OTA data (ota_0 boot)

--- a/firmware/src/Kconfig.projbuild
+++ b/firmware/src/Kconfig.projbuild
@@ -2,7 +2,7 @@ menu "BBClaw"
 
 choice BBCLAW_BOARD_CHOICE
     prompt "Board"
-    default BBCLAW_BOARD_BREADBOARD
+    default BBCLAW_BOARD_BBCLAW
     help
         Select the target hardware board. Each board defines its own pin map,
         audio codec, display bus, and peripheral configuration.


### PR DESCRIPTION
## 根因(真机崩溃日志确认)
OTA 到 CI 构建的 v0.4.8 后设备 boot loop:
\`\`\`
E quad_psram: PSRAM chip is not connected, or wrong PSRAM line mode
E cpu_start: Failed to init external RAM!  → abort → 反复重启
\`\`\`
release.yml 用 \`make set-target BOARD=bbclaw\`,但 Makefile 的 \`set-target\` 只跑 \`idf.py set-target\`、**忽略 BOARD**;真正切板的是 \`set-board\`(\`scripts/set_board.py\` 改 sdkconfig 的 \`CONFIG_BBCLAW_BOARD_*\`)。Kconfig 默认又是 \`BREADBOARD\` → **CI 发布的固件一直是 breadboard 板配置(错引脚/PSRAM),不是 bbclaw PCB**。OTA 链路今天才修通,首次 OTA 到 CI 构建即暴露。

## 修复
- \`src/Kconfig.projbuild\`: 默认板 \`BREADBOARD\` → \`BBCLAW\`(生产板;fresh/CI 构建默认即正确)。
- \`release.yml\`: \`set-target\` 后显式 \`make set-board BOARD=bbclaw\` 再 build。
- 本地 \`make set-board BOARD=bbclaw && make build\` ✓。

## ⚠️ 注意
- 当前云端 active 的 v0.4.8 是**会变砖的 breadboard 构建**,需用本修复重出一个正确构建(建议 cut v0.4.9,会自动停用 v0.4.8)后再让设备 OTA。
- 需真机验证:bbclaw 构建 USB 刷入能正常启动后再重新发版。

🤖 Generated with [Claude Code](https://claude.com/claude-code)