### PR TITLE
fix(firmware/ci): 固件版本从 tag 注入(修 OTA 无限重刷)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,11 @@ jobs:
           # make build reconfigures from it.
           make set-target
           cp sdkconfig.bbclaw.latest sdkconfig
+          # Embed the release tag as the firmware version (esp_app_desc.version)
+          # so the OTA'd device reports e.g. v0.4.10 and stops re-downloading.
+          # Without this the version was hardcoded → device always reported the
+          # old version → infinite OTA loop.
+          printf '%s' "${RELEASE_VERSION}" > version.txt
           make build
 
       - name: Generate OTA data (ota_0 boot)

--- a/firmware/.gitignore
+++ b/firmware/.gitignore
@@ -18,3 +18,6 @@ managed_components/
 
 # macOS/SDL2 LVGL 预览
 simulator/build/
+
+# CI writes the release tag here for esp_app_desc.version; never commit (would pin/stale the version)
+version.txt

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -3,4 +3,8 @@ cmake_minimum_required(VERSION 3.16)
 set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/src" "${CMAKE_CURRENT_LIST_DIR}/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-project(bbclaw_firmware VERSION 0.4.1)
+# Firmware version (esp_app_desc.version) comes from version.txt when present
+# (CI writes the release tag there), else `git describe`. Do NOT hardcode a
+# VERSION here — a fixed version makes every OTA'd device report the same value
+# and re-download the "newer" release forever (OTA loop). See release.yml.
+project(bbclaw_firmware)


### PR DESCRIPTION
硬编码 `project(... VERSION 0.4.1)` → esp_app_desc.version 恒为 0.4.1 → OTA 后设备自报仍 0.4.1 < 云端 active → 无限重刷。真机日志确认 v0.4.9 octal 已正常启动,仅版本号不对。修复:CMakeLists 去硬编码 VERSION,CI 写 version.txt=tag(本地退回 git describe),version.txt 加 gitignore。本地验证 project_version=v0.4.10-test。🤖 Generated with [Claude Code](https://claude.com/claude-code)