### PR TITLE
fix(firmware): device_id 去掉版本号,跨 OTA 稳定身份

### DIFF
--- a/firmware/src/bb_identity.c
+++ b/firmware/src/bb_identity.c
@@ -1,6 +1,5 @@
 #include "bb_identity.h"
 
-#include "esp_app_desc.h"
 #include "esp_log.h"
 #include "esp_mac.h"
 
@@ -14,14 +13,16 @@ static char s_session_key[96];
 static int s_ready;
 
 void bbclaw_identity_init(void) {
-  const esp_app_desc_t *app = esp_app_get_description();
-  const char *ver = (app && app->version[0]) ? app->version : "dev";
+  /* device_id MUST be stable across firmware versions — it keys the cloud
+   * pairing/claim. It used to embed the app version, so every OTA changed the
+   * id and the device re-appeared as a new, unclaimed device. Identity is the
+   * Wi-Fi SoftAP MAC suffix only (per-chip, version-independent). */
   uint8_t mac[6] = {0};
   if (esp_read_mac(mac, ESP_MAC_WIFI_SOFTAP) == ESP_OK) {
-    snprintf(s_device_id, sizeof(s_device_id), "BBClaw-%s-%02X%02X%02X", ver, mac[3], mac[4], mac[5]);
+    snprintf(s_device_id, sizeof(s_device_id), "BBClaw-%02X%02X%02X", mac[3], mac[4], mac[5]);
     snprintf(s_session_key, sizeof(s_session_key), "agent:main:bbclaw-%02x%02x%02x", mac[3], mac[4], mac[5]);
   } else {
-    snprintf(s_device_id, sizeof(s_device_id), "BBClaw-%s-unknown", ver);
+    snprintf(s_device_id, sizeof(s_device_id), "BBClaw-unknown");
     snprintf(s_session_key, sizeof(s_session_key), "agent:main:bbclaw-unknown");
   }
   s_ready = 1;


### PR DESCRIPTION
device_id 原含 app_version('BBClaw-<ver>-<MAC>'),版本从 tag 注入后每次 OTA 都换 id → 云端当新设备要求重配对(真机:升级后 claim_required + 新配对码)。改为只用 MAC('BBClaw-<MAC>'),版本无关。一次性:现有设备 id 变一次需重新认领,此后永久稳定。session_key 本就只用 MAC。🤖 Generated with [Claude Code](https://claude.com/claude-code)