### PR TITLE
fix: butler remember MCP tool + consolidate plural filenames & managed block

### DIFF
--- a/adapter/internal/butler/memory/consolidator.go
+++ b/adapter/internal/butler/memory/consolidator.go
@@ -12,10 +12,23 @@ import (
 	"github.com/daboluocc/bbclaw/adapter/internal/workspace"
 )
 
-// dimensions are the canonical memory buckets (ADR-021 §4 / ADR-022 §2). Each
-// becomes one MEMORY/<dim>.md profile file. Order is stable so consolidation is
-// deterministic.
-var dimensions = []string{"preference", "project", "decision"}
+// dimension describes one memory bucket: Key is the logical name used in the
+// summarizer prompt (unchanged from v1); File is the plural filename that
+// matches the workspace scaffold, persona, admin whitelist, and prewarm blocks
+// (all use preferences.md / projects.md / decisions.md — #124).
+type dimension struct {
+	Key  string // summarizer/prompt key (singular, matches ADR-022 §2 contract)
+	File string // MEMORY/<File> on disk (plural, matches workspace.MemoryDimensions)
+}
+
+// dimensions are the canonical memory buckets (ADR-021 §4 / ADR-022 §2). Order
+// is stable so consolidation is deterministic. Files use plural names to match
+// the workspace scaffold (#124 Task 2: fix orphan singular file names).
+var dimensions = []dimension{
+	{Key: "preference", File: "preferences.md"},
+	{Key: "project", File: "projects.md"},
+	{Key: "decision", File: "decisions.md"},
+}
 
 // memoryDirName is the consolidation profile directory, co-located next to the
 // workspace CLAUDE.md (ADR-022 §4: defensively self-built, decoupled from #91).
@@ -117,10 +130,9 @@ func (c *Consolidator) Consolidate(ctx context.Context) error {
 	// aborts the whole pass with the inbox intact (the next pass re-derives from
 	// the still-present inbox + whatever profiles did land — convergent).
 	for _, dim := range dimensions {
-		bullets := c.cleanAndClamp(merged[dim])
-		body := renderProfile(dim, bullets)
-		if err := atomicWrite(c.profilePath(dim), []byte(body), 0o600); err != nil {
-			return fmt.Errorf("memory: consolidate write %s: %w", dim, err)
+		bullets := c.cleanAndClamp(merged[dim.Key])
+		if err := c.writeDimProfile(dim, bullets); err != nil {
+			return fmt.Errorf("memory: consolidate write %s: %w", dim.Key, err)
 		}
 	}
 
@@ -136,9 +148,11 @@ func (c *Consolidator) Consolidate(ctx context.Context) error {
 	return nil
 }
 
-// readProfiles loads the existing MEMORY/<dim>.md bodies into a dimension-keyed
-// map. Missing files are simply absent (first run). Read errors other than
-// not-exist are returned so a flaky disk doesn't silently lose history.
+// readProfiles loads the existing MEMORY/<File> bodies into a dimension Key-
+// keyed map. Missing files are simply absent (first run). Read errors other
+// than not-exist are returned so a flaky disk doesn't silently lose history.
+// The returned map is keyed by dim.Key (singular) so the Summarizer prompt
+// contract is unchanged; only the on-disk filename is now plural (#124).
 func (c *Consolidator) readProfiles() (map[string]string, error) {
 	out := make(map[string]string, len(dimensions))
 	for _, dim := range dimensions {
@@ -147,9 +161,9 @@ func (c *Consolidator) readProfiles() (map[string]string, error) {
 			continue
 		}
 		if err != nil {
-			return nil, fmt.Errorf("memory: read profile %s: %w", dim, err)
+			return nil, fmt.Errorf("memory: read profile %s: %w", dim.Key, err)
 		}
-		out[dim] = string(raw)
+		out[dim.Key] = string(raw)
 	}
 	return out, nil
 }
@@ -225,26 +239,46 @@ func (c *Consolidator) clearInbox(snapshot string) error {
 	return atomicWrite(c.claudeMDPath, []byte(updated), 0o600)
 }
 
-func (c *Consolidator) profilePath(dim string) string {
-	return filepath.Join(c.memoryDir, dim+".md")
+func (c *Consolidator) profilePath(dim dimension) string {
+	return filepath.Join(c.memoryDir, dim.File)
 }
 
-// renderProfile renders a dimension's bullets as a stable MEMORY/<dim>.md body.
-// Bullets are sorted so an unchanged set produces a byte-identical file
-// (idempotent re-consolidation).
-func renderProfile(dim string, bullets []string) string {
+// writeDimProfile merges bullets into the managed sub-block of dim's profile
+// file, preserving any content outside the block (prewarm markers, AI-written
+// content from the `remember` tool). On first run the file is created with a
+// minimal skeleton followed by the managed block.
+func (c *Consolidator) writeDimProfile(dim dimension, bullets []string) error {
+	path := c.profilePath(dim)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+
+	// Read existing content; start from empty string when the file doesn't exist yet.
+	var existing string
+	if raw, err := os.ReadFile(path); err == nil {
+		existing = string(raw)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	inner := renderProfileInner(bullets)
+	updated := workspace.ReplaceManagedBlock(existing, inner)
+	return atomicWrite(path, []byte(updated), 0o600)
+}
+
+// renderProfileInner renders a dimension's bullets as the inner text of the
+// managed sub-block (no surrounding markers). Bullets are sorted so an
+// unchanged set produces a byte-identical block (idempotent re-consolidation).
+func renderProfileInner(bullets []string) string {
 	sorted := append([]string(nil), bullets...)
 	sort.Strings(sorted)
 	var b strings.Builder
-	b.WriteString("# ")
-	b.WriteString(dim)
-	b.WriteString("\n\n")
 	for _, line := range sorted {
 		b.WriteString("- ")
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
-	return b.String()
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // parseDimensions extracts the first top-level JSON object from raw model output

--- a/adapter/internal/butler/memory/consolidator_test.go
+++ b/adapter/internal/butler/memory/consolidator_test.go
@@ -34,14 +34,25 @@ func inboxWith(lines ...string) string {
 		strings.Join(lines, "\n") + "\n" + workspace.ManagedEnd + "\n"
 }
 
-func readProfile(t *testing.T, dir, dim string) (string, bool) {
+// dimFile maps a test dimension key ("preference","project","decision") to its
+// plural on-disk filename, matching the workspace scaffold (#124 fix).
+func dimFile(key string) string {
+	for _, d := range dimensions {
+		if d.Key == key {
+			return d.File
+		}
+	}
+	return key + ".md" // fallback for unknown keys
+}
+
+func readProfile(t *testing.T, dir, dimKey string) (string, bool) {
 	t.Helper()
-	b, err := os.ReadFile(filepath.Join(dir, memoryDirName, dim+".md"))
+	b, err := os.ReadFile(filepath.Join(dir, memoryDirName, dimFile(dimKey)))
 	if os.IsNotExist(err) {
 		return "", false
 	}
 	if err != nil {
-		t.Fatalf("read profile %s: %v", dim, err)
+		t.Fatalf("read profile %s: %v", dimKey, err)
 	}
 	return string(b), true
 }
@@ -86,7 +97,7 @@ func TestConsolidateProfilesWrittenWith0600(t *testing.T) {
 	if err := c.Consolidate(context.Background()); err != nil {
 		t.Fatalf("Consolidate: %v", err)
 	}
-	info, err := os.Stat(filepath.Join(dir, memoryDirName, "preference.md"))
+	info, err := os.Stat(filepath.Join(dir, memoryDirName, dimFile("preference")))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,5 +235,79 @@ func TestParseDimensionsNoObjectIsEmpty(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("want empty, got %+v", got)
+	}
+}
+
+// TestConsolidateWritesPluralFileNames verifies that consolidate creates
+// preferences.md / projects.md / decisions.md (plural), not the singular
+// orphan names that nothing else reads (#124 Task 2 defect 1).
+func TestConsolidateWritesPluralFileNames(t *testing.T) {
+	path := writeCLAUDE(t, inboxWith("- [preference] plural test"))
+	dir := filepath.Dir(path)
+	sum := &stubSummarizer{result: map[string][]string{
+		"preference": {"plural test"},
+		"project":    {"my project"},
+		"decision":   {},
+	}}
+	c := NewConsolidator(path, sum, nil)
+	if err := c.Consolidate(context.Background()); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+
+	// Plural files must exist.
+	for _, wantFile := range []string{"preferences.md", "projects.md", "decisions.md"} {
+		full := filepath.Join(dir, memoryDirName, wantFile)
+		if _, err := os.Stat(full); err != nil {
+			t.Errorf("expected plural file %s to exist: %v", wantFile, err)
+		}
+	}
+	// Singular orphan files must NOT be created.
+	for _, badFile := range []string{"preference.md", "project.md", "decision.md"} {
+		full := filepath.Join(dir, memoryDirName, badFile)
+		if _, err := os.Stat(full); err == nil {
+			t.Errorf("singular orphan file %s must not exist", badFile)
+		}
+	}
+}
+
+// TestConsolidatePreservesPrewarmBlocksOutsideManagedBlock verifies that
+// content written outside the managed sub-block (e.g. <!-- prewarm:NAME -->
+// markers or AI-authored free text) survives a consolidate pass (#124 Task 2
+// defect 2: full-file overwrite used to wipe prewarm blocks).
+func TestConsolidatePreservesPrewarmBlocksOutsideManagedBlock(t *testing.T) {
+	path := writeCLAUDE(t, inboxWith("- [project] prewarm test"))
+	dir := filepath.Dir(path)
+
+	// Seed projects.md with prewarm content outside the managed block.
+	preexisting := "# 最近在做的项目\n\n<!-- prewarm:PROJECTS -->\n一些预热内容\n<!-- /prewarm:PROJECTS -->\n"
+	projPath := filepath.Join(dir, memoryDirName, "projects.md")
+	if err := os.MkdirAll(filepath.Join(dir, memoryDirName), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projPath, []byte(preexisting), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sum := &stubSummarizer{result: map[string][]string{
+		"project": {"合并后的项目"},
+	}}
+	c := NewConsolidator(path, sum, nil)
+	if err := c.Consolidate(context.Background()); err != nil {
+		t.Fatalf("Consolidate: %v", err)
+	}
+
+	got, _ := os.ReadFile(projPath)
+	body := string(got)
+
+	// Prewarm markers must survive.
+	if !strings.Contains(body, "<!-- prewarm:PROJECTS -->") {
+		t.Errorf("prewarm open marker was clobbered:\n%s", body)
+	}
+	if !strings.Contains(body, "<!-- /prewarm:PROJECTS -->") {
+		t.Errorf("prewarm close marker was clobbered:\n%s", body)
+	}
+	// The consolidated bullet must also be present inside the managed block.
+	if !strings.Contains(body, "合并后的项目") {
+		t.Errorf("consolidated bullet missing:\n%s", body)
 	}
 }

--- a/adapter/internal/butler/memory/summarizer_claude.go
+++ b/adapter/internal/butler/memory/summarizer_claude.go
@@ -78,12 +78,12 @@ func renderExisting(existing map[string]string) string {
 	}
 	var b strings.Builder
 	for _, dim := range dimensions {
-		body := strings.TrimSpace(existing[dim])
+		body := strings.TrimSpace(existing[dim.Key])
 		if body == "" {
 			continue
 		}
 		b.WriteString("[")
-		b.WriteString(dim)
+		b.WriteString(dim.Key)
 		b.WriteString("]\n")
 		b.WriteString(body)
 		b.WriteString("\n")

--- a/adapter/internal/butlermcp/runner_remember.go
+++ b/adapter/internal/butlermcp/runner_remember.go
@@ -1,0 +1,150 @@
+package butlermcp
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/butler/memory"
+	"github.com/daboluocc/bbclaw/adapter/internal/workspace"
+)
+
+// validCategories is the closed set of memory categories the `remember` tool
+// accepts. Each entry maps to a MEMORY/<file>.md on disk (plural, matching
+// the workspace scaffold and persona). The butler addresses them by file name
+// so AI-authored notes and admin UI see the same files.
+var validCategories = map[string]string{
+	"profile":     "profile.md",
+	"preferences": "preferences.md",
+	"projects":    "projects.md",
+	"decisions":   "decisions.md",
+}
+
+// MemoryWriter is the narrow interface the remember tool uses to locate and
+// update MEMORY/*.md files. It is satisfied by a workspace-backed implementation
+// (memoryFileWriter) and by test stubs.
+type MemoryWriter interface {
+	// WriteMemory writes text into the managed sub-block of the given
+	// MEMORY/<file>.md, preserving any content outside the block. category is
+	// one of profile / preferences / projects / decisions; text is the
+	// pre-sanitized content to store.
+	WriteMemory(category, text string) error
+}
+
+// workspaceMemoryWriter is the production MemoryWriter. It resolves paths via
+// workspace.MemoryFilePath, applies IsPoisoned, and writes via
+// workspace.ReplaceManagedBlock + atomic write — identical strategy to the
+// consolidate path.
+type workspaceMemoryWriter struct{}
+
+// NewWorkspaceMemoryWriter returns the production MemoryWriter backed by the
+// workspace MEMORY/ directory.
+func NewWorkspaceMemoryWriter() MemoryWriter { return workspaceMemoryWriter{} }
+
+func (workspaceMemoryWriter) WriteMemory(category, text string) error {
+	file, ok := validCategories[category]
+	if !ok {
+		return fmt.Errorf("remember: unknown category %q", category)
+	}
+	// Poison guard — same defence as Store.Append and Consolidator.cleanAndClamp.
+	if memory.IsPoisoned(text) || memory.IsPoisoned(category) {
+		return fmt.Errorf("remember: poisoned content rejected")
+	}
+
+	path, err := workspace.MemoryFilePath(file)
+	if err != nil {
+		return fmt.Errorf("remember: resolve path: %w", err)
+	}
+	if err := os.MkdirAll(dirOf(path), 0o700); err != nil {
+		return fmt.Errorf("remember: mkdir: %w", err)
+	}
+
+	// Read existing content; empty string on first write.
+	var existing string
+	if raw, err := os.ReadFile(path); err == nil {
+		existing = string(raw)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("remember: read %s: %w", path, err)
+	}
+
+	// Append text as a new bullet inside the managed block. We reuse the same
+	// workspace.ReplaceManagedBlock round-trip as the consolidation engine: read
+	// the current inner text, append the new bullet, write back. Content outside
+	// the managed block (prewarm markers, hand-written notes) is preserved.
+	inner, _ := workspace.ManagedBlock(existing)
+	inner = strings.TrimSpace(inner)
+
+	// Build new bullet line (normalise to "- text").
+	bullet := strings.TrimSpace(text)
+	if !strings.HasPrefix(bullet, "- ") {
+		bullet = "- " + bullet
+	}
+
+	// Dedup: skip if the exact bullet is already present.
+	for _, ln := range strings.Split(inner, "\n") {
+		if strings.TrimSpace(ln) == strings.TrimSpace(bullet) {
+			return nil // idempotent
+		}
+	}
+
+	var newInner string
+	if inner == "" {
+		newInner = bullet
+	} else {
+		newInner = inner + "\n" + bullet
+	}
+
+	updated := workspace.ReplaceManagedBlock(existing, newInner)
+
+	// atomicWrite is unexported in the memory package; mirror it inline for the
+	// MCP layer (same temp+rename approach, same 0600 perm).
+	return atomicWriteFile(path, []byte(updated), 0o600)
+}
+
+// atomicWriteFile writes data to path via a temp file + rename in the same
+// directory. Mirrors memory.atomicWrite; duplicated here to avoid an exported
+// dep on the memory package's internal helper.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := dirOf(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("remember: mkdir %s: %w", dir, err)
+	}
+	tmp, err := os.CreateTemp(dir, ".remember-*.tmp")
+	if err != nil {
+		return fmt.Errorf("remember: create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("remember: write temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("remember: sync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("remember: close temp: %w", err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("remember: chmod temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("remember: rename to %s: %w", path, err)
+	}
+	return nil
+}
+
+// dirOf returns the directory component of path (filepath.Dir equivalent
+// without importing path/filepath to keep the import list short — we already
+// import strings).
+func dirOf(path string) string {
+	idx := strings.LastIndexByte(path, '/')
+	if idx < 0 {
+		idx = strings.LastIndexByte(path, '\\')
+	}
+	if idx < 0 {
+		return "."
+	}
+	return path[:idx]
+}

--- a/adapter/internal/butlermcp/server.go
+++ b/adapter/internal/butlermcp/server.go
@@ -72,6 +72,7 @@ type Server struct {
 	log        Logger
 	bg         context.Context // background ctx for async workers (survives the dispatch call)
 	newID      func() string
+	memWriter  MemoryWriter // optional; nil disables the remember tool
 
 	mu    sync.Mutex
 	tasks map[string]*taskState
@@ -98,6 +99,10 @@ type Options struct {
 	Log              Logger        // nil => no-op
 	// BackgroundCtx is the parent ctx for async workers. nil => context.Background().
 	BackgroundCtx context.Context
+	// MemoryWriter, when non-nil, enables the `remember` MCP tool so the butler
+	// can write directly into MEMORY/*.md files (Layer 1 of the long-term memory
+	// pipeline, #124). nil disables the tool entirely (safe default).
+	MemoryWriter MemoryWriter
 }
 
 // New builds a Server.
@@ -123,6 +128,7 @@ func New(opts Options) *Server {
 		bg:         bg,
 		newID:      newTaskID,
 		tasks:      make(map[string]*taskState),
+		memWriter:  opts.MemoryWriter,
 	}
 }
 
@@ -248,6 +254,25 @@ func toolDefs() []map[string]any {
 			"description": "Get the result of a finished async task. Returns {result} or an error if still running.",
 			"inputSchema": map[string]any{"type": "object", "properties": map[string]any{"taskId": map[string]any{"type": "string"}}, "required": []string{"taskId"}},
 		},
+		{
+			"name":        "remember",
+			"description": "Persist a memory note into the butler's long-term memory. Use this when the user shares stable identity information, preferences, project context, or key decisions that should survive across sessions. Writes into MEMORY/<category>.md inside the butler's managed block, preserving any existing content outside it.",
+			"inputSchema": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"category": map[string]any{
+						"type":        "string",
+						"enum":        []string{"profile", "preferences", "projects", "decisions"},
+						"description": "Memory bucket: profile=user identity/onboarding, preferences=stable habits/tastes, projects=recent work context, decisions=key choices made",
+					},
+					"text": map[string]any{
+						"type":        "string",
+						"description": "One-sentence fact or note to persist (speakable, in the user's language). Must not contain instruction-like content.",
+					},
+				},
+				"required": []string{"category", "text"},
+			},
+		},
 	}
 }
 
@@ -280,6 +305,8 @@ func (s *Server) callTool(name string, args json.RawMessage) (string, bool) {
 		return s.toolTaskStatus(args)
 	case "task_result":
 		return s.toolTaskResult(args)
+	case "remember":
+		return s.toolRemember(args)
 	default:
 		return jsonStr(map[string]any{"error": "UNKNOWN_TOOL", "detail": name}), true
 	}
@@ -444,4 +471,39 @@ func newTaskID() string {
 		return "task-" + fmt.Sprint(time.Now().UnixNano())
 	}
 	return "task-" + hex.EncodeToString(buf[:])
+}
+
+// toolRemember handles the `remember` MCP tool. It writes text into the butler's
+// long-term MEMORY/<category>.md file via the injected MemoryWriter. When no
+// MemoryWriter is configured the tool returns a clear error so the butler knows
+// the feature is not available rather than silently discarding the note.
+func (s *Server) toolRemember(args json.RawMessage) (string, bool) {
+	if s.memWriter == nil {
+		return jsonStr(map[string]any{
+			"error":  "REMEMBER_UNAVAILABLE",
+			"detail": "memory writer not configured; set BBCLAW_BUTLER_MEMORY_DISTILL=1 or wire MemoryWriter in Options",
+		}), true
+	}
+	var a struct {
+		Category string `json:"category"`
+		Text     string `json:"text"`
+	}
+	_ = json.Unmarshal(args, &a)
+	a.Category = strings.TrimSpace(a.Category)
+	a.Text = strings.TrimSpace(a.Text)
+	if a.Category == "" || a.Text == "" {
+		return jsonStr(map[string]any{"error": "INVALID_ARGS", "detail": "category and text are required"}), true
+	}
+	if _, ok := validCategories[a.Category]; !ok {
+		return jsonStr(map[string]any{
+			"error":  "UNKNOWN_CATEGORY",
+			"detail": "category must be one of: profile, preferences, projects, decisions",
+		}), true
+	}
+	if err := s.memWriter.WriteMemory(a.Category, a.Text); err != nil {
+		s.log.Warnf("butlermcp: remember failed category=%q: %v", a.Category, err)
+		return jsonStr(map[string]any{"error": "WRITE_FAILED", "detail": err.Error()}), true
+	}
+	s.log.Infof("butlermcp: remember ok category=%q", a.Category)
+	return jsonStr(map[string]any{"ok": true, "category": a.Category}), false
 }

--- a/adapter/internal/butlermcp/server_test.go
+++ b/adapter/internal/butlermcp/server_test.go
@@ -3,6 +3,7 @@ package butlermcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -80,14 +81,14 @@ func TestServeInitializeAndToolsList(t *testing.T) {
 	list := parse(t, lines[1])
 	lr, _ := list["result"].(map[string]any)
 	tools, _ := lr["tools"].([]any)
-	if len(tools) != 4 {
-		t.Fatalf("tools/list returned %d tools, want 4", len(tools))
+	if len(tools) != 5 {
+		t.Fatalf("tools/list returned %d tools, want 5", len(tools))
 	}
 	names := map[string]bool{}
 	for _, tl := range tools {
 		names[tl.(map[string]any)["name"].(string)] = true
 	}
-	for _, want := range []string{"list_projects", "dispatch", "task_status", "task_result"} {
+	for _, want := range []string{"list_projects", "dispatch", "task_status", "task_result", "remember"} {
 		if !names[want] {
 			t.Errorf("missing tool %q", want)
 		}
@@ -214,4 +215,78 @@ func mustTool(t *testing.T, s *Server, name, args string) string {
 	t.Helper()
 	text, _ := s.callTool(name, json.RawMessage(args))
 	return text
+}
+
+// ─────────────────────────── remember tool ───────────────────────────
+
+// stubMemoryWriter records calls to WriteMemory so tests can assert on them.
+type stubMemoryWriter struct {
+	calls []struct{ category, text string }
+	err   error
+}
+
+func (m *stubMemoryWriter) WriteMemory(category, text string) error {
+	m.calls = append(m.calls, struct{ category, text string }{category, text})
+	return m.err
+}
+
+func newTestServerWithMemory(runner WorkerRunner, wait time.Duration, mw MemoryWriter) *Server {
+	return New(Options{
+		Projects:     []Project{{Name: "proj", Cwd: "/p/proj"}},
+		Runner:       runner,
+		DispatchWait: wait,
+		MemoryWriter: mw,
+	})
+}
+
+func TestRememberWritesMemory(t *testing.T) {
+	mw := &stubMemoryWriter{}
+	s := newTestServerWithMemory(&mockRunner{}, time.Second, mw)
+
+	text, isErr := s.callTool("remember", json.RawMessage(`{"category":"profile","text":"用户叫周老板"}`))
+	if isErr {
+		t.Fatalf("remember returned isErr: %s", text)
+	}
+	m := parse(t, text)
+	if m["ok"] != true {
+		t.Fatalf("expected ok=true, got %v", m)
+	}
+	if len(mw.calls) != 1 || mw.calls[0].category != "profile" || mw.calls[0].text != "用户叫周老板" {
+		t.Errorf("unexpected calls: %+v", mw.calls)
+	}
+}
+
+func TestRememberUnknownCategory(t *testing.T) {
+	mw := &stubMemoryWriter{}
+	s := newTestServerWithMemory(&mockRunner{}, time.Second, mw)
+	text, isErr := s.callTool("remember", json.RawMessage(`{"category":"bogus","text":"test"}`))
+	if !isErr || parse(t, text)["error"] != "UNKNOWN_CATEGORY" {
+		t.Errorf("expected UNKNOWN_CATEGORY, got %s (isErr=%v)", text, isErr)
+	}
+}
+
+func TestRememberMissingArgs(t *testing.T) {
+	mw := &stubMemoryWriter{}
+	s := newTestServerWithMemory(&mockRunner{}, time.Second, mw)
+	text, isErr := s.callTool("remember", json.RawMessage(`{"category":"profile"}`))
+	if !isErr || parse(t, text)["error"] != "INVALID_ARGS" {
+		t.Errorf("expected INVALID_ARGS, got %s (isErr=%v)", text, isErr)
+	}
+}
+
+func TestRememberUnavailableWhenNoMemoryWriter(t *testing.T) {
+	s := newTestServer(&mockRunner{}, time.Second) // no MemoryWriter
+	text, isErr := s.callTool("remember", json.RawMessage(`{"category":"profile","text":"test"}`))
+	if !isErr || parse(t, text)["error"] != "REMEMBER_UNAVAILABLE" {
+		t.Errorf("expected REMEMBER_UNAVAILABLE, got %s (isErr=%v)", text, isErr)
+	}
+}
+
+func TestRememberWriteError(t *testing.T) {
+	mw := &stubMemoryWriter{err: fmt.Errorf("disk full")}
+	s := newTestServerWithMemory(&mockRunner{}, time.Second, mw)
+	text, isErr := s.callTool("remember", json.RawMessage(`{"category":"preferences","text":"喜欢简短"}`))
+	if !isErr || parse(t, text)["error"] != "WRITE_FAILED" {
+		t.Errorf("expected WRITE_FAILED, got %s (isErr=%v)", text, isErr)
+	}
 }

--- a/adapter/internal/cmd/mcpserver.go
+++ b/adapter/internal/cmd/mcpserver.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/daboluocc/bbclaw/adapter/internal/butler/memory"
 	"github.com/daboluocc/bbclaw/adapter/internal/butlermcp"
 	"github.com/daboluocc/bbclaw/adapter/internal/config"
 	"github.com/daboluocc/bbclaw/adapter/internal/obs"
@@ -88,6 +89,7 @@ func runMcpServer(cmd *cobra.Command, args []string) error {
 		ProjectsProvider: projectsFn,
 		Runner:           runner,
 		Log:              logger,
+		MemoryWriter:     resolveMemoryWriter(logger),
 	})
 
 	logger.Infof("mcp-server: serving on stdio (env seed: %d project(s))", len(seed))
@@ -145,4 +147,23 @@ func parseArgList(raw string) []string {
 		}
 	}
 	return out
+}
+
+// resolveMemoryWriter returns a MemoryWriter when the butler memory pipeline is
+// enabled (BBCLAW_BUTLER_MEMORY_DISTILL=1), otherwise nil. A nil MemoryWriter
+// causes the `remember` MCP tool to return REMEMBER_UNAVAILABLE so the butler
+// gets a clear signal rather than silently dropping notes.
+func resolveMemoryWriter(log *obs.Logger) butlermcp.MemoryWriter {
+	if !memory.Enabled() {
+		return nil
+	}
+	// EnsureScaffold guarantees the MEMORY/ directory and skeleton files exist
+	// before the butler session starts writing. A failure here is non-fatal:
+	// WriteMemory will create the directory itself on first write.
+	if _, err := workspace.EnsureScaffold(); err != nil {
+		if log != nil {
+			log.Warnf("mcp-server: workspace scaffold failed (non-fatal): %v", err)
+		}
+	}
+	return butlermcp.NewWorkspaceMemoryWriter()
 }


### PR DESCRIPTION
Fixes #124

## 变更概述

### Task 1 — butler `remember` MCP 工具（Layer 1 写权限）

新增 `adapter/internal/butlermcp/runner_remember.go`：
- 定义 `MemoryWriter` 接口，生产实现为 `workspaceMemoryWriter`
- 写入 `MEMORY/<category>.md` 的 managed 子块，prewarm 标记等块外内容**原样保留**
- `IsPoisoned` 双重过滤（category + text），与 Store/Consolidator 防毒路径一致
- 幂等：完全相同的 bullet 不重复写入
- `Server.Options.MemoryWriter` 注入；nil 时工具返回 `REMEMBER_UNAVAILABLE`（有明确信号，不静默丢弃）

`adapter/internal/cmd/mcpserver.go`：
- `resolveMemoryWriter` 在 `BBCLAW_BUTLER_MEMORY_DISTILL=1` 时自动启用 MemoryWriter，保持现有环境变量门控
- **未改动** `claudecode/driver.go` buildArgs，不添加 `--dangerously-skip-permissions`（issue 已指明备选方案口子大，pass）

### Task 2 — consolidate 两缺陷修复

**缺陷 1：单数孤儿文件名**
- `dimensions` 从 `[]string` 改为 `[]dimension{Key, File}`，Key 保持单数（summarizer prompt 契约不变），File 改为复数（`preferences.md` / `projects.md` / `decisions.md`），与 workspace scaffold、persona、admin 白名单、prewarm 扫描完全对齐

**缺陷 2：整文件覆盖洗掉 prewarm 块**
- 新增 `writeDimProfile`：先读现有文件 → `workspace.ReplaceManagedBlock` 只更新 managed 子块 → atomic write
- 原 `renderProfile + atomicWrite` 全文件覆盖路径已删除
- `<!-- prewarm:NAME -->` 等块外内容在 consolidate 后字节级保留

### 测试
- 全部现有测试通过（`go test ./...`，28 个包）
- 新增 `TestConsolidateWritesPluralFileNames`：断言复数文件存在、单数孤儿不存在
- 新增 `TestConsolidatePreservesPrewarmBlocksOutsideManagedBlock`：断言 prewarm 标记在 consolidate 后保留
- 新增 `TestRememberWritesMemory` / `TestRememberUnknownCategory` / `TestRememberMissingArgs` / `TestRememberUnavailableWhenNoMemoryWriter` / `TestRememberWriteError`

### 注意
- Consolidate 默认仍为 **OFF**（`BBCLAW_BUTLER_MEMORY_CONSOLIDATE` 未设置），由 owner 手动灰度开启
- 固件/Cloud 无变更