### PR TITLE
fix(ci): upgrade Node.js 20 actions before 2026-06-16 deadline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,13 +235,13 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download firmware artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: firmware-bin
           path: release-artifacts/
 
       - name: Download adapter artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           path: release-artifacts/
           pattern: adapter-*
@@ -256,7 +256,7 @@ jobs:
           shasum -a 256 * > SHA256SUMS.txt
 
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Fixes #127

## 变更内容

单文件 `.github/workflows/release.yml` 共 3 行 `uses:` 字段升级，消除 Node.js 20 deprecation 警告，在 2026-06-16 强制切换截止前完成迁移：

| Action | 旧版本 | 新版本 | Node runtime |
|--------|--------|--------|--------------|
| `actions/download-artifact` | `@v5` | `@v6` | Node.js 24 |
| `softprops/action-gh-release` | `@v2` | `@v3` | Node.js 24 |

两个升级均向后兼容：
- `download-artifact@v6` 保留 `name`、`path`、`pattern`、`merge-multiple` 入参，无 breaking change。
- `action-gh-release@v3` 保留 `tag_name`、`name`、`generate_release_notes`、`files` 入参，与 v2 兼容。

## 背景

issue #109 曾升级过一批 action（checkout/setup-go/upload-artifact/download-artifact → v5/v6/v5/v5），但 GitHub 上游对各 action 的 Node 24 切换并非同步：`upload-artifact@v5` 已是 Node 24，而 `download-artifact@v5` 仍为 Node 20；第三方 `softprops/action-gh-release@v2` 亦然。本次属于 #109 之后的「尾巴」升级。

## 验证

- 单元测试：workflow 文件无逻辑，不适用
- 本地验证：CI workflow 变更，需在分支推送后观察 Actions run 是否不再出现 Node 20 deprecation warning，publish job 三步（下载固件 artifact、下载 adapter artifacts、发布 release）均应成功