### PR TITLE
fix(firmware): 用预处理器守卫消除 bb_nav_input.c 的 -Wshift-count-negative UB

### DIFF
--- a/firmware/src/bb_nav_input.c
+++ b/firmware/src/bb_nav_input.c
@@ -350,14 +350,30 @@ esp_err_t bb_nav_input_init(bb_nav_input_callback_t callback) {
   s_callback = callback;
 
 #if BBCLAW_NAV_FLIPPER_6BUTTON
-  /* Build pin_bit_mask from the (up to) 6 buttons whose GPIO macro is >= 0. */
+  /* Build pin_bit_mask from the (up to) 6 buttons whose GPIO macro is >= 0.
+   * Use preprocessor guards instead of runtime if() to avoid 1ULL<<(-1) UB
+   * (C11 6.5.7p3) when a board leaves some buttons undefined (macro == -1).
+   * A runtime if() guard is not sufficient: GCC still evaluates the constant
+   * shift expression and emits -Wshift-count-negative. */
   uint64_t pin_mask = 0;
-  if (BBCLAW_NAV_BTN_UP_GPIO >= 0) pin_mask |= (1ULL << BBCLAW_NAV_BTN_UP_GPIO);
-  if (BBCLAW_NAV_BTN_DOWN_GPIO >= 0) pin_mask |= (1ULL << BBCLAW_NAV_BTN_DOWN_GPIO);
-  if (BBCLAW_NAV_BTN_LEFT_GPIO >= 0) pin_mask |= (1ULL << BBCLAW_NAV_BTN_LEFT_GPIO);
-  if (BBCLAW_NAV_BTN_RIGHT_GPIO >= 0) pin_mask |= (1ULL << BBCLAW_NAV_BTN_RIGHT_GPIO);
-  if (BBCLAW_NAV_BTN_OK_GPIO >= 0) pin_mask |= (1ULL << BBCLAW_NAV_BTN_OK_GPIO);
-  if (BBCLAW_NAV_BTN_BACK_GPIO >= 0) pin_mask |= (1ULL << BBCLAW_NAV_BTN_BACK_GPIO);
+#if BBCLAW_NAV_BTN_UP_GPIO >= 0
+  pin_mask |= (1ULL << BBCLAW_NAV_BTN_UP_GPIO);
+#endif
+#if BBCLAW_NAV_BTN_DOWN_GPIO >= 0
+  pin_mask |= (1ULL << BBCLAW_NAV_BTN_DOWN_GPIO);
+#endif
+#if BBCLAW_NAV_BTN_LEFT_GPIO >= 0
+  pin_mask |= (1ULL << BBCLAW_NAV_BTN_LEFT_GPIO);
+#endif
+#if BBCLAW_NAV_BTN_RIGHT_GPIO >= 0
+  pin_mask |= (1ULL << BBCLAW_NAV_BTN_RIGHT_GPIO);
+#endif
+#if BBCLAW_NAV_BTN_OK_GPIO >= 0
+  pin_mask |= (1ULL << BBCLAW_NAV_BTN_OK_GPIO);
+#endif
+#if BBCLAW_NAV_BTN_BACK_GPIO >= 0
+  pin_mask |= (1ULL << BBCLAW_NAV_BTN_BACK_GPIO);
+#endif
 
   gpio_config_t io_conf = {
       .pin_bit_mask = pin_mask,


### PR DESCRIPTION
Fixes #129

## 问题

自 v0.4.9 起，`firmware/src/bb_nav_input.c` 第 357/358/360 行出现 3 处 `-Wshift-count-negative` 编译警告。根本原因：bbclaw PCB 无 LEFT/RIGHT/BACK 物理按键，`board_config.h` 中对应 GPIO 宏值为 `-1`。原代码用运行期 `if (PIN >= 0)` 守卫，但 GCC 仍会对永远不可达的 `(1ULL << -1)` 常量表达式求值并发出警告（C11 6.5.7p3 未定义行为）。

该问题在 v0.4.9 (#121, `28705d9d`) 切换至 `sdkconfig.bbclaw.latest`（`CONFIG_BBCLAW_BOARD_BBCLAW=y`）后首次暴露，v0.4.8 走 breadboard sdkconfig（六键 GPIO 全 ≥ 0）无此问题。

## 修复

将构建 `pin_bit_mask` 的 6 处运行期 `if()` 替换为 `#if` 预处理器条件，让编译器在预处理阶段即跳过负值 GPIO 对应的移位表达式，彻底消除 UB 形式。

## 验证说明

此修复为固件 C 源码改动，需交叉编译环境（ESP-IDF）验证，本地无硬件环境。建议：
- `make set-board BOARD=bbclaw && make build` → 确认三条 `-Wshift-count-negative` 警告消失
- `make set-board BOARD=breadboard && make build` → 确认六键全有效时编译仍零警告
- 运行期行为不变（LEFT/RIGHT/BACK 按键在 bbclaw board 上本就不存在）