### PR TITLE
fix: heartbeat goroutine during long agent turns (cloud idle-window)

### DIFF
--- a/adapter/internal/homeadapter/adapter.go
+++ b/adapter/internal/homeadapter/adapter.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -662,6 +663,16 @@ func (a *Adapter) handleChatTextViaAgent(
 	}
 
 	var replyParts []string
+
+	// Heartbeat: track last activity time and current phase so the ticker
+	// goroutine only fires during genuine silent stretches.
+	var lastActivity atomic.Int64
+	var currentPhase atomic.Value
+	currentPhase.Store("thinking")
+	lastActivity.Store(time.Now().UnixNano())
+	stopHeartbeat := a.startHeartbeat(ctx, write, env, &lastActivity, &currentPhase)
+	defer stopHeartbeat()
+
 loop:
 	for {
 		select {
@@ -675,10 +686,14 @@ loop:
 			case agent.EvText:
 				if t := strings.TrimSpace(ev.Text); t != "" {
 					replyParts = append(replyParts, ev.Text)
+					lastActivity.Store(time.Now().UnixNano())
+					currentPhase.Store("generating")
 					writeEvent("voice.reply.delta", map[string]any{"text": ev.Text})
 				}
 			case agent.EvToolCall:
 				if ev.Tool != nil {
+					lastActivity.Store(time.Now().UnixNano())
+					currentPhase.Store("tool_call")
 					writeEvent("tool_call", map[string]any{"name": ev.Tool.Tool})
 				}
 			case agent.EvTurnEnd:
@@ -732,6 +747,16 @@ func (a *Adapter) handleChatTextViaButler(
 	}
 
 	sink := &voiceEventSink{a: a, write: write, env: env, streamID: streamID, sessionKey: sessionKey, routeStart: routeStart}
+
+	// Heartbeat: initialise shared activity tracking and start background ticker.
+	var lastActivity atomic.Int64
+	var currentPhase atomic.Value
+	currentPhase.Store("thinking")
+	lastActivity.Store(time.Now().UnixNano())
+	sink.lastActivity = &lastActivity
+	sink.currentPhase = &currentPhase
+	stopHeartbeat := a.startHeartbeat(ctx, write, env, &lastActivity, &currentPhase)
+	defer stopHeartbeat()
 
 	eng := butler.NewEngine(butler.Deps{
 		Router:   a.router,
@@ -804,6 +829,11 @@ type voiceEventSink struct {
 
 	parts    []string
 	deltaSeq int
+
+	// lastActivity and currentPhase are shared with the heartbeat goroutine
+	// started by handleChatTextViaButler. Atomic so the goroutine reads are safe.
+	lastActivity *atomic.Int64
+	currentPhase *atomic.Value
 }
 
 func (v *voiceEventSink) EmitSession(string, bool, string) bool { return true }
@@ -814,6 +844,10 @@ func (v *voiceEventSink) EmitEvent(ev agent.Event) bool {
 		if t := strings.TrimSpace(ev.Text); t != "" {
 			v.parts = append(v.parts, ev.Text)
 			v.deltaSeq++
+			if v.lastActivity != nil {
+				v.lastActivity.Store(time.Now().UnixNano())
+				v.currentPhase.Store("generating")
+			}
 			v.a.log.Infof("phase=reply_delta_recv device=%s session=%s stream=%s delta_seq=%d text_chars=%d elapsed_s=%.3f",
 				v.env.DeviceID, strings.TrimSpace(v.sessionKey), strings.TrimSpace(v.streamID), v.deltaSeq,
 				utf8.RuneCountInString(ev.Text), time.Since(v.routeStart).Seconds())
@@ -821,6 +855,10 @@ func (v *voiceEventSink) EmitEvent(ev agent.Event) bool {
 		}
 	case agent.EvToolCall:
 		if ev.Tool != nil {
+			if v.lastActivity != nil {
+				v.lastActivity.Store(time.Now().UnixNano())
+				v.currentPhase.Store("tool_call")
+			}
 			v.writeEvent("tool_call", map[string]any{"name": ev.Tool.Tool})
 		}
 	}
@@ -866,4 +904,57 @@ func (a *Adapter) writeErrorResponse(write func(CloudEnvelope) error, env CloudE
 			"error": err.Error(),
 		},
 	})
+}
+
+// startHeartbeat launches a background goroutine that emits voice.reply.heartbeat
+// envelopes while the agent turn is silent (no EvText / EvToolCall activity).
+// It fires at most once per HeartbeatInterval, only when time since lastActivity
+// exceeds the interval. Returns a stop func that must be deferred by the caller.
+// If HeartbeatInterval <= 0 the goroutine is never started and the stop func is a no-op.
+func (a *Adapter) startHeartbeat(
+	ctx context.Context,
+	write func(CloudEnvelope) error,
+	env CloudEnvelope,
+	lastActivity *atomic.Int64,
+	phase *atomic.Value,
+) (stop func()) {
+	interval := a.cfg.HeartbeatInterval
+	if interval <= 0 {
+		return func() {}
+	}
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				last := lastActivity.Load()
+				if last == 0 || time.Since(time.Unix(0, last)) < interval {
+					continue
+				}
+				phaseStr := "thinking"
+				if v, ok := phase.Load().(string); ok && v != "" {
+					phaseStr = v
+				}
+				if err := write(CloudEnvelope{
+					Type:       "event",
+					MessageID:  env.MessageID,
+					DeviceID:   env.DeviceID,
+					HomeSiteID: a.cfg.HomeSiteID,
+					Kind:       "voice.reply.heartbeat",
+					Payload:    map[string]any{"phase": phaseStr},
+				}); err != nil {
+					a.log.Warnf("heartbeat write failed device=%s err=%v", env.DeviceID, err)
+				} else {
+					a.metrics.Inc("cloud_heartbeat_sent")
+				}
+			}
+		}
+	}()
+	return func() { close(done) }
 }

--- a/adapter/internal/homeadapter/adapter_test.go
+++ b/adapter/internal/homeadapter/adapter_test.go
@@ -3,13 +3,16 @@ package homeadapter
 import (
 	"context"
 	"errors"
-	"github.com/daboluocc/bbclaw/adapter/internal/obs"
-	"github.com/daboluocc/bbclaw/adapter/internal/openclaw"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
+	"github.com/daboluocc/bbclaw/adapter/internal/openclaw"
 	"github.com/gorilla/websocket"
 )
 
@@ -178,3 +181,84 @@ func TestHandleTranscriptRequestStreamsIntermediateEvents(t *testing.T) {
 		t.Fatalf("reply = %#v", events[3])
 	}
 }
+
+// TestHeartbeatDuringLongAgentTurn verifies that the legacy voice path (no butler)
+// emits voice.reply.heartbeat envelopes when the agent driver is silent for longer
+// than the configured HeartbeatInterval.
+func TestHeartbeatDuringLongAgentTurn(t *testing.T) {
+	// Use a very short interval so the test runs fast.
+	const interval = 20 * time.Millisecond
+
+	// A driver that waits before emitting any events.
+	drv := &slowFakeAgentDriver{
+		name:   "mock-slow",
+		delay:  4 * interval, // silent for 4 intervals → expect ≥3 heartbeats
+		events: make(chan agent.Event, 4),
+	}
+	r := agent.NewRouter()
+	r.Register(drv, obs.NewLogger())
+
+	a := &Adapter{
+		cfg:     Config{HomeSiteID: "home-1", HeartbeatInterval: interval},
+		log:     obs.NewLogger(),
+		metrics: obs.NewMetrics(),
+	}
+	a.SetRouter(r)
+
+	var mu sync.Mutex
+	var got []CloudEnvelope
+	write := func(env CloudEnvelope) error {
+		mu.Lock()
+		got = append(got, env)
+		mu.Unlock()
+		return nil
+	}
+	env := CloudEnvelope{Type: "request", MessageID: "m-hb", DeviceID: "dev-hb", Kind: "voice.transcript"}
+	if err := a.handleChatTextViaAgent(context.Background(), write, env, "hello", "sk-1", "st-1", "mock-slow", time.Now()); err != nil {
+		t.Fatalf("handleChatTextViaAgent: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var heartbeats int
+	for _, e := range got {
+		if e.Kind == "voice.reply.heartbeat" {
+			heartbeats++
+			if e.Payload["phase"] != "thinking" {
+				t.Errorf("heartbeat phase=%v want thinking", e.Payload["phase"])
+			}
+		}
+	}
+	if heartbeats < 2 {
+		t.Fatalf("got %d heartbeats, want ≥2 (frames: %+v)", heartbeats, got)
+	}
+}
+
+// slowFakeAgentDriver is a driver that sleeps for `delay` before emitting a
+// text event, simulating a long tool-call or thinking silent stretch.
+type slowFakeAgentDriver struct {
+	name   string
+	delay  time.Duration
+	events chan agent.Event
+}
+
+func (d *slowFakeAgentDriver) Name() string                     { return d.name }
+func (d *slowFakeAgentDriver) Capabilities() agent.Capabilities {
+	return agent.Capabilities{Streaming: true, MaxInputBytes: 4096}
+}
+func (d *slowFakeAgentDriver) Start(context.Context, agent.StartOpts) (agent.SessionID, error) {
+	return agent.SessionID(d.name + "-sid"), nil
+}
+func (d *slowFakeAgentDriver) Send(_ agent.SessionID, _ string) error {
+	go func() {
+		time.Sleep(d.delay)
+		d.events <- agent.Event{Type: agent.EvText, Seq: 1, Text: "done"}
+		d.events <- agent.Event{Type: agent.EvTurnEnd, Seq: 2}
+	}()
+	return nil
+}
+func (d *slowFakeAgentDriver) Events(agent.SessionID) <-chan agent.Event { return d.events }
+func (d *slowFakeAgentDriver) Approve(agent.SessionID, agent.ToolID, agent.Decision) error {
+	return agent.ErrUnsupported
+}
+func (d *slowFakeAgentDriver) Stop(agent.SessionID) error { return nil }

--- a/adapter/internal/homeadapter/agent_proxy.go
+++ b/adapter/internal/homeadapter/agent_proxy.go
@@ -32,6 +32,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/daboluocc/bbclaw/adapter/internal/agent"
@@ -921,6 +922,16 @@ func (a *Adapter) handleAgentMessageRequest(ctx context.Context, write func(Clou
 
 	sink := &cloudEventSink{a: a, write: write, env: env}
 
+	// Heartbeat: initialise shared activity tracking and start background ticker.
+	var lastActivity atomic.Int64
+	var currentPhase atomic.Value
+	currentPhase.Store("thinking")
+	lastActivity.Store(time.Now().UnixNano())
+	sink.lastActivity = &lastActivity
+	sink.currentPhase = &currentPhase
+	stopHeartbeat := a.startHeartbeat(ctx, write, env, &lastActivity, &currentPhase)
+	defer stopHeartbeat()
+
 	eng := butler.NewEngine(butler.Deps{
 		Router:   a.router,
 		Sessions: a.sessions,
@@ -1072,6 +1083,11 @@ type cloudEventSink struct {
 	a     *Adapter
 	write func(CloudEnvelope) error
 	env   CloudEnvelope
+
+	// lastActivity and currentPhase are shared with the heartbeat goroutine
+	// started in handleAgentMessageRequest. Atomic so the goroutine reads are safe.
+	lastActivity *atomic.Int64
+	currentPhase *atomic.Value
 }
 
 func (c *cloudEventSink) emit(payload map[string]any) {
@@ -1100,6 +1116,18 @@ func (c *cloudEventSink) EmitSession(visibleID string, isNew bool, driver string
 
 func (c *cloudEventSink) EmitEvent(ev agent.Event) bool {
 	if frame := agentEventToFrame(ev); frame != nil {
+		// Update activity tracking so the heartbeat goroutine knows the turn is
+		// still making progress. EvText and EvToolCall are the meaningful
+		// milestones; other event types (tokens, etc.) also count as activity.
+		if c.lastActivity != nil {
+			c.lastActivity.Store(time.Now().UnixNano())
+			switch ev.Type {
+			case agent.EvText:
+				c.currentPhase.Store("generating")
+			case agent.EvToolCall:
+				c.currentPhase.Store("tool_call")
+			}
+		}
 		c.emit(frame)
 	}
 	return true

--- a/adapter/internal/homeadapter/agent_proxy_test.go
+++ b/adapter/internal/homeadapter/agent_proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/daboluocc/bbclaw/adapter/internal/agent"
 	"github.com/daboluocc/bbclaw/adapter/internal/obs"
@@ -339,5 +340,52 @@ func TestAgentProxyMessageRejectsUnknownDriver(t *testing.T) {
 	}
 	if got := err.Error(); got != "UNKNOWN_DRIVER:nope" {
 		t.Fatalf("agent.message unknown driver err=%q", got)
+	}
+}
+
+// TestHeartbeatDuringLongAgentProxyTurn verifies that the cloud agent-proxy path
+// (/v1/agent/message via cloud WS) emits agent.event heartbeat envelopes when the
+// driver is silent for longer than HeartbeatInterval.
+func TestHeartbeatDuringLongAgentProxyTurn(t *testing.T) {
+	const interval = 20 * time.Millisecond
+
+	drv := &slowFakeAgentDriver{
+		name:   "claude-code",
+		delay:  4 * interval,
+		events: make(chan agent.Event, 4),
+	}
+	a := newProxyTestAdapter(t, drv)
+	a.cfg.HeartbeatInterval = interval
+
+	var mu sync.Mutex
+	var got []CloudEnvelope
+	write := func(env CloudEnvelope) error {
+		mu.Lock()
+		got = append(got, env)
+		mu.Unlock()
+		return nil
+	}
+	env := CloudEnvelope{
+		Type: "request", MessageID: "m-hb", DeviceID: "dev-hb", Kind: "agent.message",
+		Payload: map[string]any{"text": "hi", "driver": "claude-code", "sessionId": ""},
+	}
+	if err := a.handleAgentMessageRequest(context.Background(), write, env); err != nil {
+		t.Fatalf("handleAgentMessageRequest: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var heartbeats int
+	for _, e := range got {
+		if e.Kind == "voice.reply.heartbeat" {
+			heartbeats++
+			phase, _ := e.Payload["phase"].(string)
+			if phase == "" {
+				t.Errorf("heartbeat missing phase field: %+v", e.Payload)
+			}
+		}
+	}
+	if heartbeats < 2 {
+		t.Fatalf("agent proxy path: got %d heartbeats, want ≥2 (frames: %+v)", heartbeats, got)
 	}
 }

--- a/adapter/internal/homeadapter/butler_voice_test.go
+++ b/adapter/internal/homeadapter/butler_voice_test.go
@@ -3,6 +3,7 @@ package homeadapter
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -125,5 +126,61 @@ func TestHandleChatTextViaAgent_LegacyWhenButlerUnconfigured(t *testing.T) {
 	// Legacy path must not create any logical session.
 	if sessions := mgr.List("dev-1", "", 0); len(sessions) != 0 {
 		t.Fatalf("legacy path created %d logical sessions, want 0", len(sessions))
+	}
+}
+
+// TestHeartbeatDuringLongButlerTurn verifies that the butler voice path emits
+// voice.reply.heartbeat envelopes when the agent driver is silent for longer
+// than the configured HeartbeatInterval.
+func TestHeartbeatDuringLongButlerTurn(t *testing.T) {
+	const interval = 20 * time.Millisecond
+
+	// slowFakeAgentDriver (defined in adapter_test.go) delays before emitting.
+	// We need a fresh channel so events don't cross test runs.
+	drv := &slowFakeAgentDriver{
+		name:   "claude-code",
+		delay:  4 * interval,
+		events: make(chan agent.Event, 4),
+	}
+	r := agent.NewRouter()
+	r.Register(drv, obs.NewLogger())
+
+	mgr, err := logicalsession.NewManager(filepath.Join(t.TempDir(), "sessions.json"), "/tmp/default", obs.NewLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	a := &Adapter{
+		cfg:     Config{HomeSiteID: "home-1", HeartbeatInterval: interval},
+		log:     obs.NewLogger(),
+		metrics: obs.NewMetrics(),
+	}
+	a.SetRouter(r)
+	a.SetSessionManager(mgr)
+	a.SetButlerWorkspace("/ws", "/cfg/butler-mcp.json")
+
+	var mu sync.Mutex
+	var got []CloudEnvelope
+	write := func(env CloudEnvelope) error {
+		mu.Lock()
+		got = append(got, env)
+		mu.Unlock()
+		return nil
+	}
+	env := CloudEnvelope{Type: "request", MessageID: "m-hb", DeviceID: "dev-hb", Kind: "voice.transcript"}
+	if err := a.handleChatTextViaAgent(context.Background(), write, env, "hello", "sk-1", "st-1", "claude-code", time.Now()); err != nil {
+		t.Fatalf("handleChatTextViaAgent (butler): %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var heartbeats int
+	for _, e := range got {
+		if e.Kind == "voice.reply.heartbeat" {
+			heartbeats++
+		}
+	}
+	if heartbeats < 2 {
+		t.Fatalf("butler path: got %d heartbeats, want ≥2 (frames: %+v)", heartbeats, got)
 	}
 }

--- a/adapter/internal/homeadapter/config.go
+++ b/adapter/internal/homeadapter/config.go
@@ -25,6 +25,14 @@ type Config struct {
 	OpenClawNodeID       string
 	OpenClawReplyWait    time.Duration
 	OpenClawIdentityPath string
+
+	// HeartbeatInterval controls how often a voice.reply.heartbeat envelope is
+	// sent to the cloud during silent stretches of a long agent turn (tool
+	// execution, long thinking, etc.). This keeps the cloud hub's idle-window
+	// timer from expiring before the turn completes. Only applied on the cloud
+	// WebSocket path; LAN-direct (local_home) never constructs CloudEnvelopes.
+	// Set via BBCLAW_HOMEADAPTER_HEARTBEAT_INTERVAL (e.g. "10s"). <= 0 disables.
+	HeartbeatInterval time.Duration
 }
 
 type identityFile struct {
@@ -98,6 +106,7 @@ func LoadFromEnv() (Config, error) {
 		OpenClawNodeID:       getEnvOrDefault("OPENCLAW_NODE_ID", "bbclaw-home-adapter"),
 		OpenClawReplyWait:    time.Duration(getEnvInt("OPENCLAW_REPLY_WAIT_SECONDS", 25)) * time.Second,
 		OpenClawIdentityPath: strings.TrimSpace(os.Getenv("OPENCLAW_DEVICE_IDENTITY_PATH")),
+		HeartbeatInterval:    getEnvDuration("BBCLAW_HOMEADAPTER_HEARTBEAT_INTERVAL", 10*time.Second),
 	}
 	if err := cfg.Validate(); err != nil {
 		return Config{}, err
@@ -183,4 +192,16 @@ func getEnvInt(name string, fallback int) int {
 		return fallback
 	}
 	return value
+}
+
+func getEnvDuration(name string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return fallback
+	}
+	return d
 }


### PR DESCRIPTION
Fixes #132

## 改动内容

在三条 cloud relay 路径的 agent turn event loop 内添加心跳 goroutine，在静默期（无 EvText / EvToolCall 活动）向 cloud WS 发送 `voice.reply.heartbeat` envelope，防止 cloud hub 的 idle-window timer（bbclaw-reference#19）触发 `HOME_ADAPTER_TIMEOUT`。

### 涉及路径

| 路径 | 文件 | 机制 |
|------|------|------|
| 旧式 one-shot voice | `adapter.go:handleChatTextViaAgent` | event loop 内 atomic lastActivity + startHeartbeat |
| Butler engine voice | `adapter.go:handleChatTextViaButler` + `voiceEventSink` | sink 内打点，外层 startHeartbeat |
| Agent proxy (/v1/agent/message) | `agent_proxy.go:handleAgentMessageRequest` + `cloudEventSink` | sink 内打点，外层 startHeartbeat |

### 关键设计

- **`startHeartbeat`**：通用 helper，`time.NewTicker(interval)`，每 tick 判 `time.Since(lastActivity) >= interval` 才发，避免正常流式输出期间产生噪音
- **`atomic.Int64` lastActivity + `atomic.Value` currentPhase**：活动时间戳和阶段用原子类型共享，无锁竞争
- **`phase` 语义**：初始 `thinking`；`EvToolCall` 后切到 `tool_call`；`EvText` 后切到 `generating`
- **LAN 路径无影响**：`local_home` 模式根本不走 CloudEnvelope 写路径，无需任何分支
- **配置**：`BBCLAW_HOMEADAPTER_HEARTBEAT_INTERVAL`（默认 10s，`<=0` 禁用）
- **指标**：`cloud_heartbeat_sent` 计数器

### 测试

新增 3 个用例，均用 20ms interval + 4×interval 静默 mock driver，断言至少收到 2 个心跳帧：
- `TestHeartbeatDuringLongAgentTurn`（adapter_test.go，legacy 路径）
- `TestHeartbeatDuringLongButlerTurn`（butler_voice_test.go，butler 路径）
- `TestHeartbeatDuringLongAgentProxyTurn`（agent_proxy_test.go，proxy 路径）

全部 homeadapter 测试通过（无回归）。

### 联动说明

依赖 bbclaw-reference#19（cloud hub idle-window timer）落地后才有实际意义。在此之前默认 10s 心跳仍安全，只是多一点 WS 流量（25s ping goroutine 已存在，量级相近）。