### PR TITLE
feat(adapter): butler workspace 自动建 AGENTS.md→CLAUDE.md 软链(codex/opencode 共享记忆)

### DIFF
--- a/adapter/internal/workspace/workspace.go
+++ b/adapter/internal/workspace/workspace.go
@@ -31,6 +31,12 @@ const (
 	workspaceName  = "workspace"
 	claudeMDName   = "CLAUDE.md"
 
+	// agentsMDName is the native instruction file codex and opencode read from
+	// the cwd. The scaffold points it at CLAUDE.md via a symlink (ADR-024 §2) so
+	// all three butler drivers share the SAME base knowledge + memory index:
+	// claude reads CLAUDE.md natively, codex/opencode read AGENTS.md → CLAUDE.md.
+	agentsMDName = "AGENTS.md"
+
 	// memoryDirName is the workspace sub-directory holding the butler's
 	// dimensioned long-term memory files (ADR-022 / #90). It complements the
 	// CLAUDE.md managed block: CLAUDE.md is loaded natively every turn, while
@@ -173,6 +179,7 @@ func EnsureScaffold() (string, error) {
 			return "", fmt.Errorf("write default CLAUDE.md %s: %w", path, err)
 		}
 		ensureMemoryScaffold(dir)
+		ensureAgentsSymlink(dir)
 		return dir, nil
 	case err != nil:
 		return "", fmt.Errorf("read CLAUDE.md %s: %w", path, err)
@@ -187,7 +194,35 @@ func EnsureScaffold() (string, error) {
 		}
 	}
 	ensureMemoryScaffold(dir)
+	ensureAgentsSymlink(dir)
 	return dir, nil
+}
+
+// ensureAgentsSymlink creates AGENTS.md -> CLAUDE.md (a relative symlink) in the
+// workspace so codex / opencode butlers pick up the same persona + long-term
+// memory index claude gets from CLAUDE.md natively (ADR-024 §2). It runs on
+// every startup via EnsureScaffold, so existing users self-repair without any
+// manual step. Idempotent and conservative:
+//
+//   - anything already at AGENTS.md (our symlink, or a user-authored file) is
+//     left untouched — never clobbered
+//   - missing → a relative symlink to CLAUDE.md is created
+//
+// Any failure is logged and swallowed (non-fatal, matching the scaffold
+// contract): a missing AGENTS.md only means codex/opencode don't read memory
+// natively, not that the butler breaks.
+func ensureAgentsSymlink(workspaceDir string) {
+	link := filepath.Join(workspaceDir, agentsMDName)
+	if _, err := os.Lstat(link); err == nil {
+		return // already exists (our symlink or the user's own file) — leave it
+	} else if !errors.Is(err, os.ErrNotExist) {
+		log.Printf("workspace: lstat AGENTS.md %s failed (non-fatal): %v", link, err)
+		return
+	}
+	// Relative target so the link stays valid regardless of the absolute path.
+	if err := os.Symlink(claudeMDName, link); err != nil {
+		log.Printf("workspace: create AGENTS.md symlink %s failed (non-fatal): %v", link, err)
+	}
 }
 
 // ensureMemoryScaffold creates the MEMORY/ directory and the dimension files

--- a/adapter/internal/workspace/workspace_test.go
+++ b/adapter/internal/workspace/workspace_test.go
@@ -45,6 +45,67 @@ func TestEnsureScaffoldFirstRunWritesDefault(t *testing.T) {
 	}
 }
 
+// TestEnsureScaffoldAgentsSymlink verifies AGENTS.md is auto-created as a
+// symlink to CLAUDE.md (ADR-024 §2) so codex/opencode butlers read the same
+// base knowledge + memory — automatically, no manual fix, on first scaffold.
+func TestEnsureScaffoldAgentsSymlink(t *testing.T) {
+	redirectDataDir(t)
+
+	dir, err := EnsureScaffold()
+	if err != nil {
+		t.Fatalf("EnsureScaffold: %v", err)
+	}
+
+	agents := filepath.Join(dir, "AGENTS.md")
+	fi, err := os.Lstat(agents)
+	if err != nil {
+		t.Fatalf("AGENTS.md not created: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("AGENTS.md should be a symlink, got mode %v", fi.Mode())
+	}
+	if target, _ := os.Readlink(agents); target != "CLAUDE.md" {
+		t.Errorf("AGENTS.md should point at CLAUDE.md (relative), got %q", target)
+	}
+	// Reading AGENTS.md must yield the SAME content as CLAUDE.md.
+	a, _ := os.ReadFile(agents)
+	c, _ := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if string(a) != string(c) || len(a) == 0 {
+		t.Errorf("AGENTS.md content must equal CLAUDE.md (codex/opencode read same base knowledge)")
+	}
+
+	// Idempotent: a second scaffold must not error or change the link.
+	if _, err := EnsureScaffold(); err != nil {
+		t.Fatalf("second EnsureScaffold: %v", err)
+	}
+	if target, _ := os.Readlink(agents); target != "CLAUDE.md" {
+		t.Errorf("symlink changed on second scaffold: %q", target)
+	}
+}
+
+// TestEnsureScaffoldAgentsRespectsUserFile verifies a user-authored AGENTS.md
+// is never clobbered by the symlink scaffold.
+func TestEnsureScaffoldAgentsRespectsUserFile(t *testing.T) {
+	dir := redirectDataDir(t)
+	wsDir := filepath.Join(dir, "workspace")
+	if err := os.MkdirAll(wsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userContent := "# my own AGENTS.md\n"
+	if err := os.WriteFile(filepath.Join(wsDir, "AGENTS.md"), []byte(userContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureScaffold(); err != nil {
+		t.Fatalf("EnsureScaffold: %v", err)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(wsDir, "AGENTS.md"))
+	if string(got) != userContent {
+		t.Errorf("user AGENTS.md was clobbered: got %q", string(got))
+	}
+}
+
 func TestEnsureScaffoldIdempotentDoesNotClobber(t *testing.T) {
 	redirectDataDir(t)
 


### PR DESCRIPTION
## 背景

多-driver 管家(#135 / PR #134)落地后,三家管家共用同一个 workspace cwd `~/.bbclaw-adapter/workspace/`,但**各认各的原生家目录文件**:claude 读 `CLAUDE.md`,codex/opencode 读 `AGENTS.md`。

之前 workspace 里**只有 `CLAUDE.md`**,所以:
- ✅ persona:三家都有(各自 flag 注入)
- ❌ **长期记忆**(`CLAUDE.md` 的 managed 收件箱 + `MEMORY/` 索引):**只有 claude 读得到**,codex/opencode 找的是不存在的 `AGENTS.md`

## 改动

`workspace.EnsureScaffold` 自动建 **`AGENTS.md` → `CLAUDE.md` 相对软链**(ADR-024 §2):
- 三家读**同一份**基础知识 + 同一个 `MEMORY/` 索引;记忆管线只写 `CLAUDE.md`,三家自动同步,无需双写
- **自动、无需手动修**:`EnsureScaffold` 每次启动跑(幂等)——新用户首启自动建,老用户下次启动自愈
- 保守:已存在的 `AGENTS.md`(我们的软链 / 用户自写文件)一律不覆盖
- 失败仅记日志,不致命(管家照常工作,只是 codex/opencode 不原生读记忆)

## 验证
- 单测:软链指向 `CLAUDE.md` + 读出内容与 `CLAUDE.md` 一致 + 幂等 + 不覆盖用户 `AGENTS.md`
- `go build/vet/test ./...` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)