### PR TITLE
fix: bump release.yml artifact actions to Node.js 24 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
              "release-stage/firmware/bbclaw-firmware-${RELEASE_VERSION}-esp32s3.bin"
 
       - name: Upload firmware artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: firmware-bin
           path: release-stage/firmware/
@@ -215,7 +215,7 @@ jobs:
           ./scripts/release_build.sh "$RELEASE_VERSION" >/dev/null
 
       - name: Upload adapter artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: adapter-${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -235,13 +235,13 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download firmware artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: firmware-bin
           path: release-artifacts/
 
       - name: Download adapter artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           path: release-artifacts/
           pattern: adapter-*


### PR DESCRIPTION
Fixes #141

## 背景
GitHub Actions 将于 2026-06-16 强制把所有仍打包 Node.js 20 runner 的 JS action 切到 Node.js 24。v0.4.14 发版日志中 `actions/upload-artifact@v5` 与 `actions/download-artifact@v6` 仍报弃用警告。

本 issue 是该主题第 4 次提报（#109/#127/#131）。前几次「升 major」未根治，根因在于**所选 tag 的 `runs.using` 仍是 node20**——升 major 不等于切 Node 24。本次直接核对 upstream `action.yml` 的 `runs.using` 字段后再 pin。

## 改动
逐个核对 upstream `action.yml` 的 `runs.using`，pin 到首个为 `node24` 的 tag：

| Action | 旧版本 (runs.using) | 新版本 (runs.using) |
|---|---|---|
| `actions/upload-artifact` | v5 (node20) | **v6 (node24)** |
| `actions/download-artifact` | v6 (node20) | **v7 (node24)** |

涉及 4 处引用：firmware job 上传（L109）、adapter 矩阵上传（L218，×5 平台）、release 聚合两处下载（L238/L244）。

## 已核对无需改动
release.yml 中其余 action 经 upstream `action.yml` 验证均已是 node24：
- `actions/checkout@v5` → node24
- `actions/setup-go@v6` → node24
- `softprops/action-gh-release@v3` → node24

## 验证
- 通过 `curl raw action.yml | grep using` 逐 tag 核对 runtime，确认 v6 upload / v7 download 的 `runs.using` 为 `node24`。
- YAML 语法 `yaml.safe_load` 校验通过。
- 纯 CI 配置改动，无代码逻辑变更；真实 release 行为需下次推 `v*` tag 触发 workflow 才能完整实证（本仓库无法本地跑 Actions runner）。

## 发布策略
依据 CLAUDE.md「Release & Tag Policy」，CI-only 改动**不打 `v*` tag**，合并到 main 即生效，下次发版自然带上。

## 联动提示
`bbclaw-reference` 的 `deploy-cloud.yml` / `deploy-web.yml` 可能存在同类 node20 警告，建议在该私有仓另行核对（不在本 PR 范围）。