### PR TITLE
fix: persist butler dispatch ring across adapter restarts (#138 P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   抽进没人读的单数命名死文件。
 
 ### Added
+- **派活/长任务 ring buffer 持久化（issue #138 P0 基础）**：`DispatchRing` 此前是
+  纯内存的 50 条环形缓冲，adapter 一重启历史就清零——固件 Task List 和 `/admin`
+  的「最近派活任务」都变空。现在主进程的 ring 由 `BBCLAW_DATA_DIR/dispatch_ring.json`
+  快照支撑（新增 `NewPersistentDispatchRing`）：启动时加载、每次 `Record` 后用
+  temp+rename 原子重写（复用 `driverstate.Store` 的落盘范式），缺失/损坏/空文件都
+  降级为空 ring 而非启动失败。`GET /v1/butler/dispatch/recent` 的返回 shape
+  (`DispatchEntry`) 与 newest-first 顺序保持不变，固件无需改动即向后兼容。这是
+  issue #138 的可持久化基础切片；完整 TaskRunStore（per-task `meta.json` +
+  append-only `events.jsonl` + Admin 详情页 + 子进程 `task_status`/`task_result`
+  接入）按 issue 的开放问题（store 写入方 = 子进程 vs 主进程）拍板后再做。
 - **Adapter 管理页「日志」tab + 持久化日志文件（ADR-025）**：新增 `GET /v1/admin/logs`
   （loopback-only）返回内存环形缓冲里最近 ~1000 行运行日志，管理页独立「日志」页实时
   展示（3s 轮询、自动跟随底部、暂停/刷新），用户不必再盯着二进制 stdout。日志同时

--- a/adapter/cmd/bbclaw-adapter/main.go
+++ b/adapter/cmd/bbclaw-adapter/main.go
@@ -125,8 +125,16 @@ func buildButlerInfra(butlerWorkspace string, sessionMgr *logicalsession.Manager
 	if sessionMgr == nil || butlerWorkspace == "" {
 		return infra
 	}
-	// Butler dispatch ring buffer (ADR-021-firmware-ui §1.4).
-	infra.ring = butler.NewDispatchRing()
+	// Butler dispatch ring buffer (ADR-021-firmware-ui §1.4). Backed by a JSON
+	// snapshot in BBCLAW_DATA_DIR so the firmware Task List / admin survive an
+	// adapter restart (issue #138 P0). Falls back to in-memory-only when the data
+	// dir cannot be resolved.
+	if dataDir, derr := workspace.DataDir(); derr != nil {
+		logger.Warnf("butler-dispatch: resolve data dir failed, ring not persisted: %v", derr)
+		infra.ring = butler.NewDispatchRing()
+	} else {
+		infra.ring = butler.NewPersistentDispatchRing(filepath.Join(dataDir, "dispatch_ring.json"), logger)
+	}
 	logger.Infof("butler-dispatch: ring buffer enabled")
 	// Butler long-term memory (ADR-021 §4); enabled by default, see memory.Enabled.
 	if mdPath, perr := workspace.ClaudeMDPath(); perr != nil {

--- a/adapter/internal/butler/dispatch_ring.go
+++ b/adapter/internal/butler/dispatch_ring.go
@@ -1,11 +1,16 @@
 package butler
 
 import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 	"unicode/utf8"
 
 	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+	"github.com/daboluocc/bbclaw/adapter/internal/obs"
 )
 
 // dispatchRingCapacity is the maximum number of dispatch entries held in memory.
@@ -25,16 +30,110 @@ type DispatchEntry struct {
 	StartedAt time.Time `json:"startedAt"`
 }
 
-// DispatchRing is a thread-safe in-memory ring buffer for dispatch events.
+// DispatchRing is a thread-safe ring buffer for dispatch events.
 // butler.Engine subscribes EvDispatchStatus events and calls Record to update it;
 // GET /v1/butler/dispatch/recent reads from it.
+//
+// When constructed with NewPersistentDispatchRing the buffer is backed by a JSON
+// snapshot file in BBCLAW_DATA_DIR (default ~/.bbclaw-adapter/dispatch_ring.json):
+// entries are loaded on startup and the snapshot is rewritten atomically after
+// every Record. This is the P0 persistence foundation for issue #138 — the firmware
+// Task List and /admin survive an adapter restart instead of resetting to empty.
+// NewDispatchRing keeps the legacy in-memory-only behaviour for tests and callers
+// without a data dir (path == "" disables all disk I/O).
 type DispatchRing struct {
 	mu      sync.Mutex
 	entries []DispatchEntry // ordered oldest→newest, capped at dispatchRingCapacity
+
+	path string      // "" => in-memory only, no persistence
+	log  *obs.Logger // optional
 }
 
-// NewDispatchRing returns an empty ring buffer.
+// NewDispatchRing returns an empty in-memory-only ring buffer (no persistence).
 func NewDispatchRing() *DispatchRing { return &DispatchRing{} }
+
+// NewPersistentDispatchRing returns a ring buffer backed by the JSON snapshot at
+// path. Existing entries are loaded on construction; a missing, empty or corrupt
+// file degrades to an empty ring rather than failing — the next Record overwrites
+// it. Pass an empty path to get an in-memory-only ring (equivalent to
+// NewDispatchRing).
+func NewPersistentDispatchRing(path string, log *obs.Logger) *DispatchRing {
+	r := &DispatchRing{path: path, log: log}
+	r.load()
+	return r
+}
+
+// load reads the snapshot file into r.entries. Called once from the constructor
+// before the ring is shared, so it does not take the lock. Missing/corrupt files
+// degrade to an empty ring (mirrors driverstate.Store.load).
+func (r *DispatchRing) load() {
+	if r.path == "" {
+		return
+	}
+	data, err := os.ReadFile(r.path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) && r.log != nil {
+			r.log.Warnf("dispatch-ring: read %s failed (%v), starting empty", r.path, err)
+		}
+		return
+	}
+	var entries []DispatchEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		if r.log != nil {
+			r.log.Warnf("dispatch-ring: corrupt snapshot at %s (%v), starting empty", r.path, err)
+		}
+		return
+	}
+	// Drop malformed entries (no TaskID) and enforce capacity defensively.
+	cleaned := entries[:0]
+	for _, e := range entries {
+		if e.TaskID != "" {
+			cleaned = append(cleaned, e)
+		}
+	}
+	if len(cleaned) > dispatchRingCapacity {
+		cleaned = cleaned[len(cleaned)-dispatchRingCapacity:]
+	}
+	r.entries = cleaned
+	if r.log != nil {
+		r.log.Infof("dispatch-ring: loaded %d entry(ies) from %s", len(r.entries), r.path)
+	}
+}
+
+// saveLocked writes the current entries to the snapshot file atomically
+// (temp + rename). Caller must hold r.mu. No-op when persistence is disabled.
+// Best-effort: a write error is logged but never propagated, so dispatch
+// recording never fails because of a full/read-only disk.
+func (r *DispatchRing) saveLocked() {
+	if r.path == "" {
+		return
+	}
+	body, err := json.MarshalIndent(r.entries, "", "  ")
+	if err != nil {
+		if r.log != nil {
+			r.log.Warnf("dispatch-ring: marshal snapshot failed: %v", err)
+		}
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(r.path), 0o755); err != nil {
+		if r.log != nil {
+			r.log.Warnf("dispatch-ring: mkdir for %s failed: %v", r.path, err)
+		}
+		return
+	}
+	tmp := r.path + ".tmp"
+	if err := os.WriteFile(tmp, body, 0o644); err != nil {
+		if r.log != nil {
+			r.log.Warnf("dispatch-ring: write %s failed: %v", tmp, err)
+		}
+		return
+	}
+	if err := os.Rename(tmp, r.path); err != nil {
+		if r.log != nil {
+			r.log.Warnf("dispatch-ring: rename %s -> %s failed: %v", tmp, r.path, err)
+		}
+	}
+}
 
 // Record upserts a DispatchStatus into the ring.
 // On phase="started" a new entry is created (or the existing entry for TaskID
@@ -63,6 +162,7 @@ func (r *DispatchRing) Record(ds *agent.DispatchStatus) {
 			if ds.Title != "" {
 				r.entries[i].Title = ds.Title
 			}
+			r.saveLocked()
 			return
 		}
 	}
@@ -83,6 +183,7 @@ func (r *DispatchRing) Record(ds *agent.DispatchStatus) {
 	if len(r.entries) > dispatchRingCapacity {
 		r.entries = r.entries[len(r.entries)-dispatchRingCapacity:]
 	}
+	r.saveLocked()
 }
 
 // Recent returns up to n entries in reverse-chronological order (newest first).

--- a/adapter/internal/butler/dispatch_ring_persist_test.go
+++ b/adapter/internal/butler/dispatch_ring_persist_test.go
@@ -1,0 +1,113 @@
+package butler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter/internal/agent"
+)
+
+// TestPersistentDispatchRingSurvivesRestart is the core issue #138 P0 acceptance:
+// dispatches recorded before an adapter restart are still readable afterwards.
+func TestPersistentDispatchRingSurvivesRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dispatch_ring.json")
+
+	// First "process": record a few dispatches into a persistent ring.
+	r1 := NewPersistentDispatchRing(path, nil)
+	r1.Record(&agent.DispatchStatus{Phase: "started", TaskID: "t1", Cwd: "proj", Title: "task one"})
+	r1.Record(&agent.DispatchStatus{Phase: "done", TaskID: "t1", ElapsedMs: 1200})
+	r1.Record(&agent.DispatchStatus{Phase: "error", TaskID: "t2", ErrorMsg: "boom"})
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("snapshot file not written: %v", err)
+	}
+
+	// Second "process": a fresh ring loading the same snapshot.
+	r2 := NewPersistentDispatchRing(path, nil)
+	got := r2.Recent(20)
+	if len(got) != 2 {
+		t.Fatalf("after reload: want 2 entries, got %d", len(got))
+	}
+	// Recent is newest-first; t2 was recorded last.
+	if got[0].TaskID != "t2" || got[0].Status != "error" || got[0].ErrorMsg != "boom" {
+		t.Errorf("after reload: unexpected newest entry %+v", got[0])
+	}
+	if got[1].TaskID != "t1" || got[1].Status != "done" || got[1].ElapsedMs != 1200 {
+		t.Errorf("after reload: upsert state not persisted, got %+v", got[1])
+	}
+}
+
+func TestPersistentDispatchRingEmptyPathNoFile(t *testing.T) {
+	// Empty path => in-memory only, no disk I/O, no panic.
+	r := NewPersistentDispatchRing("", nil)
+	r.Record(&agent.DispatchStatus{Phase: "started", TaskID: "t1"})
+	if got := r.Recent(20); len(got) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(got))
+	}
+}
+
+func TestPersistentDispatchRingMissingFile(t *testing.T) {
+	// A path that does not exist yet must degrade to an empty ring, not error.
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	r := NewPersistentDispatchRing(path, nil)
+	if got := r.Recent(20); len(got) != 0 {
+		t.Fatalf("missing file: want empty ring, got %d entries", len(got))
+	}
+	// And it becomes writable on first Record.
+	r.Record(&agent.DispatchStatus{Phase: "started", TaskID: "t1"})
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("snapshot not created on first record: %v", err)
+	}
+}
+
+func TestPersistentDispatchRingCorruptFileDegrades(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dispatch_ring.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt file must not fail construction — degrade to empty.
+	r := NewPersistentDispatchRing(path, nil)
+	if got := r.Recent(20); len(got) != 0 {
+		t.Fatalf("corrupt file: want empty ring, got %d entries", len(got))
+	}
+	// Next record overwrites the corruption with a valid snapshot.
+	r.Record(&agent.DispatchStatus{Phase: "started", TaskID: "t1"})
+	r2 := NewPersistentDispatchRing(path, nil)
+	if got := r2.Recent(20); len(got) != 1 {
+		t.Fatalf("after overwrite: want 1 entry, got %d", len(got))
+	}
+}
+
+func TestPersistentDispatchRingDropsEntriesWithoutTaskID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dispatch_ring.json")
+	// A hand-written snapshot containing one valid and one malformed entry.
+	body := `[{"taskId":"","status":"done"},{"taskId":"t1","status":"done"}]`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := NewPersistentDispatchRing(path, nil)
+	got := r.Recent(20)
+	if len(got) != 1 || got[0].TaskID != "t1" {
+		t.Fatalf("want only the valid entry, got %+v", got)
+	}
+}
+
+func TestPersistentDispatchRingEnforcesCapacityOnLoad(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dispatch_ring.json")
+	// Pre-seed a snapshot that exceeds capacity (e.g. from a future build with a
+	// larger cap). Loading must clamp to the newest dispatchRingCapacity entries.
+	r1 := NewDispatchRing()
+	for i := 0; i < dispatchRingCapacity+10; i++ {
+		r1.entries = append(r1.entries, DispatchEntry{TaskID: "t" + string(rune('A'+i%26)) + string(rune('0'+i%10))})
+	}
+	r1.path = path
+	r1.mu.Lock()
+	r1.saveLocked()
+	r1.mu.Unlock()
+
+	r2 := NewPersistentDispatchRing(path, nil)
+	if got := r2.Recent(1000); len(got) != dispatchRingCapacity {
+		t.Fatalf("want capacity %d after load, got %d", dispatchRingCapacity, len(got))
+	}
+}


### PR DESCRIPTION
Fixes #138 (P0 persistence foundation)

## 背景
issue #138 要把派活/长任务从 50 条内存 ring 升级为可持久、可复盘的长任务运行中心（借鉴 clawflow 的 file-based run 快照）。这是一个跨 store/butlermcp/admin 路由/Admin Web/固件兼容的系统级功能，且 issue 显式列了几个**未拍板的开放问题**（store 写入方 = mcp-server 子进程 vs 主进程、taskId 来源、task_result 返回形态），它们会影响完整 P0 的接口形态。

本 PR 交付一个**不依赖这些开放决策、可独立验证、向后兼容**的 P0 基础切片：把 `DispatchRing` 落盘。

## 改动
- **`adapter/internal/butler/dispatch_ring.go`**：新增 `NewPersistentDispatchRing(path, log)`。ring 由 `BBCLAW_DATA_DIR/dispatch_ring.json` 快照支撑——启动时 `load()`，每次 `Record` 后 `saveLocked()` 用 temp+rename 原子重写（复用 `driverstate.Store` 的落盘范式）。缺失/损坏/空文件均降级为空 ring，不阻塞启动；写失败 best-effort 记日志，不让 dispatch 记录因磁盘满/只读失败。`NewDispatchRing()`（纯内存）保留给测试与无 data dir 的调用方。
- **`adapter/cmd/bbclaw-adapter/main.go`**：`buildButlerInfra` 用持久构造器（主进程内唯一的 ring 创建点 + 唯一的 `Record` 调用点 `engine.go:459`），data dir 解析失败时回退内存版。
- **测试**：新增 6 个用例覆盖 重启后可读 / 空路径 / 缺失文件 / 损坏文件降级并被下次写覆盖 / 丢弃无 taskId 的脏条目 / load 时强制 capacity。

## 为什么这样切
- 主进程的 `DispatchRing` 是 `EvDispatchStatus` 事件**进程内**的唯一记录点，落盘完全在主进程，**不触碰 mcp-server 子进程**，因此绕开了 issue 里「store 写入方 = 子进程 vs 主进程」这一必须先决策的开放问题。
- `GET /v1/butler/dispatch/recent` 的返回 shape（`DispatchEntry`）与 newest-first 顺序、空数组（非 null）行为完全不变 → **固件零改动向后兼容**。

## 满足的验收标准
- ✅ adapter 重启后，已完成/失败的派活任务仍能在 `/admin` 与固件 Task List 查看。
- ✅ `/v1/butler/dispatch/recent` 对固件保持向后兼容（轻量列表、最新优先、空数组）。
- ✅ 不把敏感 env/token 写进快照（只持久化既有 `DispatchEntry` 的白名单字段：taskId/cwd/title/status/elapsedMs/error/startedAt）。

## 明确**未**包含（留待后续 PR / 需先拍板开放问题）
- 完整 TaskRunStore（per-task `meta.json` + append-only `events.jsonl` + `result.md`）。
- `butlermcp.dispatch/task_status/task_result` 接入持久 store（依赖子进程 vs 主进程写入决策）。
- Admin Web 任务列表/详情页、SSE、stale reconcile、cancel、token/cost。

## 测试
- `go build ./...` 通过；`go test ./...`（adapter 全量）通过；`go vet` 通过。
- 新增持久化测试 6/6 PASS。
- 运行时验证：本变更是 adapter 内部存储行为，单测已覆盖落盘/加载/降级；未在真实设备串口链路上端到端跑（需硬件），固件侧因 API shape 不变无需重测。

## 发版
按 release policy，本改动属「adapter 有新功能/修复」，合并后应随 `v*` tag 发版；已加 CHANGELOG `[Unreleased]` 条目。