### PR TITLE
fix: CHAT 空闲息屏太快 — 超时延长至 120s 且六键统一续命

### DIFF
--- a/firmware/include/bb_config.h
+++ b/firmware/include/bb_config.h
@@ -668,7 +668,7 @@ const char *bbclaw_session_key(void);
 
 /* ── Idle timeout: dual-level standby → lock ── */
 #ifndef BBCLAW_CHAT_IDLE_TIMEOUT_MS
-#define BBCLAW_CHAT_IDLE_TIMEOUT_MS 30000
+#define BBCLAW_CHAT_IDLE_TIMEOUT_MS 120000        /* Issue #145: 30s→120s，对话设备读回复场景下 30s 偏短 */
 #endif
 
 #ifndef BBCLAW_STANDBY_LOCK_TIMEOUT_MS

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -779,6 +779,12 @@ static void on_ptt_changed(int pressed) {
 static void on_nav_event(bb_nav_event_t event) {
   if ((int)event < 0 || event >= BB_NAV_EVENT_COUNT) return;
 
+  /* Issue #145 — 任意导航键（UP/DOWN/LEFT/RIGHT/OK/BACK）都算用户活动，
+   * 统一在入口续命空闲计时器。此前仅 UP/DOWN 快速路径刷新，导致用户切
+   * driver（LEFT/RIGHT）或翻页（OK/BACK）看回复时计时器仍按上次 PTT 起算，
+   * 长回复读不完就被踢回待机。PTT 边沿与主循环 busy/speaker 续命逻辑不变。 */
+  s_last_activity_ms = bb_now_ms();
+
   /* ADR-017 v2 — fast-path for chat-overlay UP/DOWN. The stream task's
    * version-counter polling is starved during TTS playback (i2s_write
    * blocks for several seconds), so even nav events received here would
@@ -794,7 +800,6 @@ static void on_nav_event(bb_nav_event_t event) {
       s_agent_chat_active &&
       !bb_ui_task_list_visible()) {
     bb_chat_scroll_request(event == BB_NAV_EVENT_UP ? -2 : 2);
-    s_last_activity_ms = bb_now_ms();  /* keep idle-timeout fresh */
     fast_path = 1;
   }
 


### PR DESCRIPTION
Fixes #145

## 问题
CHAT 页读长回复时被过早踢回待机。两个缺口：
1. 只有 PTT 和 UP/DOWN 算用户活动；LEFT/RIGHT（切 driver）、OK、BACK 不重置空闲计时器，切完看回复仍按上次 PTT 起算。
2. 默认空闲超时 30s 对"读回复"场景偏短。

## 改动（仅固件，无协议改动）
- `firmware/src/bb_radio_app.c`：把 `s_last_activity_ms = bb_now_ms();` 从 UP/DOWN 快速路径提升到 `on_nav_event` 入口，**所有六键**统一续命；删除快速路径里的重复赋值。PTT 边沿（`on_ptt_changed`）与主循环 busy/speaker 续命逻辑保持不变。
- `firmware/include/bb_config.h`：`BBCLAW_CHAT_IDLE_TIMEOUT_MS` 30000 → 120000（宏仍以 `#ifndef` 包裹，保留覆盖能力）。

## 验收对照
- ✅ CHAT 页内按任意键（含 LEFT/RIGHT/OK/BACK）后空闲计时从该按键时刻重新起算
- ✅ TTS 播放结束后才开始倒计时（主循环 speaker 续命逻辑未动）
- ✅ agent 回复流式输出期间不会被踢回待机（busy 续命逻辑未动）
- ✅ 默认超时 120s

## 测试状态
改动为常量调整 + 一行已有语句位移（`bb_now_ms`/`s_last_activity_ms` 本就在该函数内使用），无新增依赖。**完整 ESP-IDF 编译与设备端行为验收需真实 ESP32-S3 硬件，本环境无法执行**，请在合并前于设备上确认计时续命与 120s 超时表现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)