### PR TITLE
fix: cloud 语音链路透传 sessionId，修复息屏重进 CHAT 对话记录空白

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **cloud 纯语音链路丢失 sessionId，息屏重进 CHAT 后对话记录空白（issue #146）**：
+  `cloud_saas` 模式下纯语音对话（管家）后，CHAT 空闲退回待机再重进时 transcript 空白——
+  缓存重放（ADR-017）、历史分页（Phase S3）、时间分段全部不触发。根因：重进 CHAT 重放
+  缓存 + 拉历史的唯一入口被 `s_chat.session_id` 非空守卫，而 cloud 语音链路刻意 flatten
+  掉 session 帧，固件语音事件枚举也无 SESSION 类型 → 设备永远拿不到 sid → 不写 NVS、
+  `bb_chat_cache` 未绑定 → 重进守卫为假 → 空白。修复：**adapter** 语音（butler）回复路径
+  在 turn 起始发新事件 `voice.session`（payload: `sessionId`/`driver`），并在最终
+  `voice.reply` 信封冗余携带二者（数据源 butler `EmitSession` 回调）；**固件** 新增
+  `BB_FINISH_STREAM_EVENT_SESSION` 事件，`bb_adapter_client.c` WS 分发解析 `voice.session`，
+  `bb_radio_app.c` 的 `on_finish_stream_event_tts_only` 经新入口
+  `bb_ui_agent_chat_post_session(sid, driver)` 复刻 SESSION 帧持久化逻辑（写 NVS +
+  绑定 chat cache + 更新 display），对同一会话内重复 sid 做幂等保护避免清空累积缓存。
+  cloud（bbclaw-reference）为信封透传，预期零改动。`local_home` 的 SESSION 帧路径不受影响。
+
 ## [0.4.15] - 2026-06-11
 
 ### Changed

--- a/adapter/internal/homeadapter/adapter.go
+++ b/adapter/internal/homeadapter/adapter.go
@@ -827,12 +827,20 @@ func (a *Adapter) handleChatTextViaButler(
 	replyText := sink.replyText()
 	a.log.Infof("phase=chat_text_request_done driver=%s session=%s elapsed_s=%.3f reply_chars=%d butler=true",
 		requestedDriver, sessionKey, time.Since(routeStart).Seconds(), utf8.RuneCountInString(replyText))
+	replyPayload := map[string]any{"ok": true, "text": replyText}
+	// Issue #146: redundantly carry the resolved session id + driver on the final
+	// voice.reply envelope so the firmware can persist them even if the in-turn
+	// voice.session event was dropped. Source: the butler EmitSession callback.
+	if sink.sid != "" {
+		replyPayload["sessionId"] = sink.sid
+		replyPayload["driver"] = sink.driver
+	}
 	return write(CloudEnvelope{
 		Type:       "reply",
 		MessageID:  env.MessageID,
 		HomeSiteID: a.cfg.HomeSiteID,
 		Kind:       "voice.reply",
-		Payload:    map[string]any{"ok": true, "text": replyText},
+		Payload:    replyPayload,
 	})
 }
 
@@ -852,6 +860,12 @@ type voiceEventSink struct {
 	sessionKey string
 	routeStart time.Time
 
+	// sid/driver are captured from the butler EmitSession callback (issue #146)
+	// so handleChatTextViaButler can redundantly attach them to the final
+	// voice.reply envelope.
+	sid    string
+	driver string
+
 	parts    []string
 	deltaSeq int
 
@@ -861,7 +875,35 @@ type voiceEventSink struct {
 	currentPhase *atomic.Value
 }
 
-func (v *voiceEventSink) EmitSession(string, bool, string) bool { return true }
+// EmitSession forwards the resolved session id + driver to the device as a
+// dedicated voice.session event (issue #146). The cloud voice path historically
+// flattened session frames away, so a device doing pure-voice (butler) turns
+// never learned its session id — it couldn't write NVS, couldn't bind the chat
+// cache, and therefore replayed nothing on re-entry (blank transcript). Carrying
+// {sessionId, driver} here lets the firmware persist the session exactly like
+// the HTTP agent SESSION frame does. The values are also stashed on the sink so
+// handleChatTextViaButler can redundantly attach them to the final voice.reply.
+func (v *voiceEventSink) EmitSession(visibleID string, isNew bool, driver string) bool {
+	visibleID = strings.TrimSpace(visibleID)
+	driver = strings.TrimSpace(driver)
+	if visibleID != "" {
+		v.sid = visibleID
+	}
+	if driver != "" {
+		v.driver = driver
+	}
+	if v.sid == "" {
+		return true
+	}
+	v.a.log.Infof("phase=voice_session device=%s session=%s sid=%s driver=%s is_new=%t",
+		v.env.DeviceID, strings.TrimSpace(v.sessionKey), v.sid, v.driver, isNew)
+	v.writeEvent("voice.session", map[string]any{
+		"sessionId": v.sid,
+		"driver":    v.driver,
+		"isNew":     isNew,
+	})
+	return true
+}
 
 func (v *voiceEventSink) EmitEvent(ev agent.Event) bool {
 	switch ev.Type {

--- a/adapter/internal/homeadapter/butler_voice_test.go
+++ b/adapter/internal/homeadapter/butler_voice_test.go
@@ -90,6 +90,75 @@ func TestHandleChatTextViaAgent_ButlerRouting(t *testing.T) {
 	}
 }
 
+// Issue #146: the cloud voice (butler) path must forward the resolved session
+// id + driver to the device. Historically session frames were flattened away,
+// so a pure-voice device never learned its session id and replayed nothing on
+// re-entry. We now emit a dedicated voice.session event mid-turn AND redundantly
+// carry {sessionId, driver} on the final voice.reply envelope.
+func TestHandleChatTextViaButler_EmitsVoiceSession(t *testing.T) {
+	drv := newFakeAgentDriver("claude-code") // butler.ButlerDriver
+	r := agent.NewRouter()
+	r.Register(drv, obs.NewLogger())
+
+	mgr, err := logicalsession.NewManager(filepath.Join(t.TempDir(), "sessions.json"), "/tmp/default", obs.NewLogger())
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	a := &Adapter{
+		cfg:     Config{HomeSiteID: "home-1"},
+		log:     obs.NewLogger(),
+		metrics: obs.NewMetrics(),
+	}
+	a.SetRouter(r)
+	a.SetSessionManager(mgr)
+	a.SetButlerWorkspace("/ws", []agent.MCPServerSpec{{Name: "bbclaw", Command: "x", Args: []string{"mcp-server"}}})
+
+	var got []CloudEnvelope
+	write := func(env CloudEnvelope) error {
+		got = append(got, env)
+		return nil
+	}
+	env := CloudEnvelope{Type: "request", MessageID: "m-1", DeviceID: "dev-1", Kind: "voice.transcript"}
+	if err := a.handleChatTextViaAgent(context.Background(), write, env, "hello", "sk-1", "st-1", "claude-code", time.Now()); err != nil {
+		t.Fatalf("handleChatTextViaAgent: %v", err)
+	}
+
+	// A voice.session event must appear with a non-empty sessionId + driver.
+	var sessionEvt *CloudEnvelope
+	var final *CloudEnvelope
+	for i := range got {
+		e := got[i]
+		if e.Type == "event" && e.Kind == "voice.session" {
+			sessionEvt = &got[i]
+		}
+		if e.Type == "reply" && e.Kind == "voice.reply" {
+			final = &got[i]
+		}
+	}
+	if sessionEvt == nil {
+		t.Fatalf("missing voice.session event: %+v", got)
+	}
+	sid, _ := sessionEvt.Payload["sessionId"].(string)
+	if sid == "" {
+		t.Fatalf("voice.session missing sessionId: %v", sessionEvt.Payload)
+	}
+	if sessionEvt.Payload["driver"] != "claude-code" {
+		t.Fatalf("voice.session driver=%v want claude-code", sessionEvt.Payload["driver"])
+	}
+
+	// The final voice.reply must redundantly carry the same sessionId + driver.
+	if final == nil {
+		t.Fatalf("missing final voice.reply: %+v", got)
+	}
+	if final.Payload["sessionId"] != sid {
+		t.Fatalf("final voice.reply sessionId=%v want %q", final.Payload["sessionId"], sid)
+	}
+	if final.Payload["driver"] != "claude-code" {
+		t.Fatalf("final voice.reply driver=%v want claude-code", final.Payload["driver"])
+	}
+}
+
 // Without a configured butler workspace the legacy one-shot voice path is used
 // unchanged (the requested driver runs directly, no butler session is created).
 func TestHandleChatTextViaAgent_LegacyWhenButlerUnconfigured(t *testing.T) {

--- a/firmware/include/bb_adapter_client.h
+++ b/firmware/include/bb_adapter_client.h
@@ -49,6 +49,10 @@ typedef enum {
   BB_FINISH_STREAM_EVENT_TOOL_CALL,
   /* ADR-021-firmware-ui §1.2: butler dispatch progress (started/done/async/error) */
   BB_FINISH_STREAM_EVENT_DISPATCH_STATUS,
+  /* Issue #146: cloud voice (butler) session frame — carries the resolved
+   * session id (in event->text) + driver (in event->phase) so the device can
+   * persist the session for cache replay + history on CHAT re-entry. */
+  BB_FINISH_STREAM_EVENT_SESSION,
 } bb_finish_stream_event_type_t;
 
 /* Dispatch status payload — carried in bb_finish_stream_event_t.dispatch when

--- a/firmware/include/bb_ui_agent_chat.h
+++ b/firmware/include/bb_ui_agent_chat.h
@@ -178,6 +178,21 @@ void bb_ui_agent_chat_post_user_text(const char* text);
 void bb_ui_agent_chat_post_reply_delta(const char* text);
 
 /**
+ * Issue #146 — persist a session id + driver learned from the cloud voice
+ * (butler) path so cache replay + history work on CHAT re-entry.
+ *
+ * The HTTP agent stream learns its session id via the SESSION frame; the cloud
+ * pure-voice path historically dropped it, leaving the device without a sid and
+ * the re-entry replay guard skipped (blank transcript). The adapter now emits a
+ * voice.session event carrying {sessionId, driver}; this entry replicates the
+ * SESSION-frame persistence (NVS save + chat cache bind + display update).
+ *
+ * No-op when the sid is unchanged (re-binding the same sid would clear the
+ * accumulating chat cache). Safe to call from any task.
+ */
+void bb_ui_agent_chat_post_session(const char* sid, const char* driver);
+
+/**
  * Returns the current driver name from the last adapter SESSION frame.
  * Used by Settings to fetch sessions for the active driver.
  * Returns "claude-code" if no driver has been set yet.

--- a/firmware/src/bb_adapter_client.c
+++ b/firmware/src/bb_adapter_client.c
@@ -856,7 +856,22 @@ static void ws_handle_text_message(const char* msg) {
     return;
   }
 
-  if (strcmp(kind, "voice.reply.status") == 0) {
+  if (strcmp(kind, "voice.session") == 0) {
+    /* Issue #146: cloud voice (butler) path now forwards the resolved session
+     * id + driver so the device can persist it (NVS + chat cache bind) and
+     * replay history on CHAT re-entry. Payload is nested under "payload". */
+    char sid[80] = {0};
+    char drv[24] = {0};
+    const char* payload_start = strstr(msg, "\"payload\"");
+    const char* src = (payload_start != NULL) ? strchr(payload_start, '{') : NULL;
+    if (src == NULL) src = msg;
+    (void)json_extract_string(src, "sessionId", sid, sizeof(sid));
+    (void)json_extract_string(src, "driver", drv, sizeof(drv));
+    if (s_ws.finish_on_event != NULL && sid[0] != '\0') {
+      emit_finish_stream_event(s_ws.finish_on_event, s_ws.finish_user_ctx, BB_FINISH_STREAM_EVENT_SESSION, drv, sid,
+                               NULL, 0);
+    }
+  } else if (strcmp(kind, "voice.reply.status") == 0) {
     (void)json_extract_string(msg, "phase", phase, sizeof(phase));
     if (s_ws.finish_on_event != NULL) {
       emit_finish_stream_event(s_ws.finish_on_event, s_ws.finish_user_ctx, BB_FINISH_STREAM_EVENT_STATUS, phase, NULL,

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -1233,6 +1233,17 @@ static void on_finish_stream_event_tts_only(bb_finish_stream_event_t* event, voi
     return;
   }
 
+  /* Issue #146: cloud voice (butler) session frame — persist the resolved
+   * session id + driver into the agent chat so cache replay + history work on
+   * CHAT re-entry. Without this a pure-voice device never learns its sid and
+   * the re-entry guard (s_chat.session_id != '\0') skips replay → blank. */
+  if (event->type == BB_FINISH_STREAM_EVENT_SESSION && event->text != NULL && event->text[0] != '\0') {
+    ESP_LOGI(TAG, "phase=voice_session sid=%s driver=%s", event->text,
+             (event->phase != NULL) ? event->phase : "");
+    bb_ui_agent_chat_post_session(event->text, event->phase);
+    return;
+  }
+
   if (event->type == BB_FINISH_STREAM_EVENT_ASR_FINAL) {
     const char* text = (event->text != NULL && event->text[0] != '\0') ? event->text : NULL;
     if (text != NULL) {

--- a/firmware/src/bb_ui_agent_chat.c
+++ b/firmware/src/bb_ui_agent_chat.c
@@ -2133,6 +2133,59 @@ void bb_ui_agent_chat_post_reply_delta(const char* text) {
   post_assistant_chunk(text);
 }
 
+/* Issue #146 — persist a session id + driver learned from the cloud voice
+ * (butler) path. The HTTP agent stream learns its sid via the SESSION frame
+ * (see on_agent_event BB_AGENT_EVENT_SESSION) which writes NVS + binds the
+ * chat cache. Pure-voice cloud turns historically dropped that frame, so the
+ * device never knew its sid and the CHAT re-entry replay guard skipped → blank
+ * transcript. This entry replicates that persistence path. Safe to call from
+ * any task (visual updates go through lv_async_call).
+ *
+ * Guarded on sid change: the adapter re-emits voice.session every turn within
+ * one session, but bb_chat_cache_bind() clears the in-memory tail buffer, so
+ * re-binding the SAME sid mid-conversation would wipe the cache we're trying to
+ * accumulate. Only (re)bind when the session id actually changes. */
+void bb_ui_agent_chat_post_session(const char* sid, const char* driver) {
+  if (!s_chat.active || sid == NULL || sid[0] == '\0') return;
+  if (strcmp(s_chat.session_id, sid) == 0) return; /* already bound — no-op */
+
+  strncpy(s_chat.session_id, sid, sizeof(s_chat.session_id) - 1);
+  s_chat.session_id[sizeof(s_chat.session_id) - 1] = '\0';
+
+  char shortbuf[16] = {0};
+  session_id_short(sid, shortbuf, sizeof(shortbuf));
+  post_session(shortbuf);
+  bb_display_set_session_id(sid);
+
+  /* Persist to NVS + rebind chat cache for the effective driver, mirroring
+   * on_agent_event's SESSION-frame handling. */
+  const char* eff_driver = NULL;
+  if (driver != NULL && driver[0] != '\0') {
+    bb_session_store_save(driver, sid);
+    eff_driver = driver;
+  } else if (s_chat.driver_name[0] != '\0') {
+    bb_session_store_save(s_chat.driver_name, sid);
+    eff_driver = s_chat.driver_name;
+  }
+  if (eff_driver != NULL) {
+    bb_chat_cache_bind(eff_driver, sid);
+  }
+
+  if (driver != NULL && driver[0] != '\0') {
+    strncpy(s_chat.driver_name, driver, sizeof(s_chat.driver_name) - 1);
+    s_chat.driver_name[sizeof(s_chat.driver_name) - 1] = '\0';
+    post_driver(driver);
+    bb_event_payload_t drv_evt = (bb_event_payload_t){ .type = BB_EVT_DRIVER_NAME_UPDATE };
+    strncpy(drv_evt.text, driver, sizeof(drv_evt.text) - 1);
+    bb_state_dispatch(drv_evt);
+  }
+
+  /* SSoT: let the coordinator update session_id / agent_in_flight. */
+  bb_event_payload_t sess_evt = (bb_event_payload_t){ .type = BB_EVT_AGENT_SESSION };
+  strncpy(sess_evt.text, sid, sizeof(sess_evt.text) - 1);
+  bb_state_dispatch(sess_evt);
+}
+
 esp_err_t bb_ui_agent_chat_cycle_driver(int delta) {
   /* Phase 5 — LEFT/RIGHT quick driver switch from picker mode.
    *


### PR DESCRIPTION
Fixes #146

## 根因
cloud_saas 纯语音对话（管家）后空闲退回待机再重进 CHAT，transcript 空白——缓存重放（ADR-017）/历史分页（Phase S3）/时间分段全部不触发。重进 CHAT 重放缓存+拉历史的唯一入口被 `s_chat.session_id` 非空守卫（`bb_ui_agent_chat.c:1342`），而 cloud 语音链路刻意 flatten 掉 session 帧（`agent_proxy.go:13-16`），固件语音事件枚举也无 SESSION 类型 → 设备永远拿不到 sid → 不写 NVS、`bb_chat_cache` 未绑定 → 守卫为假 → 空白。

## 修复
**adapter**（`internal/homeadapter/adapter.go`）：
- `voiceEventSink.EmitSession` 实现实际转发：turn 起始发新事件 `voice.session`（payload: `sessionId`/`driver`），数据源 butler EmitSession 回调；并把 sid/driver 暂存到 sink，在最终 `voice.reply` 信封冗余携带。
- 新增单测 `TestHandleChatTextViaButler_EmitsVoiceSession`。

**固件**：
- `bb_adapter_client.h`：新增 `BB_FINISH_STREAM_EVENT_SESSION`（text=sid, phase=driver）。
- `bb_adapter_client.c`：WS 分发解析 `voice.session` payload。
- `bb_radio_app.c`：`on_finish_stream_event_tts_only` 处理新事件，调用新入口。
- `bb_ui_agent_chat.c/.h`：新增 `bb_ui_agent_chat_post_session(sid, driver)`，复刻 SESSION 帧持久化（写 NVS + `bb_chat_cache_bind` + `bb_display_set_session_id` + state dispatch），对同会话重复 sid 做幂等保护避免清空累积缓存。

**cloud（bbclaw-reference）**：信封透传，预期零改动；需验证 `voice.session` kind 能原样到达设备（如有 kind 白名单补一行）。

## 验证
- adapter `go build ./...` + `go test ./internal/homeadapter/` 通过；新单测 `TestHandleChatTextViaButler_EmitsVoiceSession` 验证 voice.session 事件与 voice.reply 冗余字段，日志出现 `phase=voice_session ... sid=... driver=...`。
- 固件 `idf.py build`（bbclaw 板）编译通过，分区余量 10%。
- **未测**（无实机 cloud_saas 全链路环境）：真实硬件息屏重进 CHAT 的端到端验收（缓存秒显 → 远端历史覆盖 → 串口日志 `loaded session...`/`transcript hydrated from cache`/`history loaded sid=...`）。需人工在 cloud relay + Home Adapter 环境复核，并确认 cloud hub 对 `voice.session` envelope 的透传路由。