### PR TITLE
fix: OTA 升级改为用户确认制，不再静默强制

### DIFF
--- a/firmware/include/bb_page_ota_confirm.h
+++ b/firmware/include/bb_page_ota_confirm.h
@@ -1,0 +1,59 @@
+/**
+ * OTA confirm page — user-consent prompt before firmware update.
+ *
+ * Shown when a new firmware version is detected (cloud_saas mode only).
+ * The user can press OK to start the update or BACK to skip it.
+ * A 30-second countdown auto-dismisses with "skip" if no input is received,
+ * so unattended devices are never stuck on this screen.
+ *
+ * Visual language matches bb_page_ota / bb_page_netconn (dot palette,
+ * lv_layer_top, synchronous show/dismiss). Input is routed by bb_radio_app.c
+ * via bb_page_ota_confirm_active() + bb_page_ota_confirm_handle_nav().
+ *
+ * All calls take the LVGL port lock internally; callers hold no lock.
+ */
+#ifndef BB_PAGE_OTA_CONFIRM_H
+#define BB_PAGE_OTA_CONFIRM_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Callback fired when the user (or timeout) makes a decision.
+ *  accept == 1  → user pressed OK, proceed with update.
+ *  accept == 0  → user pressed BACK or 30 s elapsed, skip update. */
+typedef void (*bb_page_ota_confirm_cb_t)(int accept);
+
+/** Create the confirm page on lv_layer_top(). No-op if already shown.
+ *  current_ver / new_ver: firmware version strings (may be NULL/"").
+ *  size_bytes: download size; shown as KB or MB.
+ *  cb: called exactly once when the decision is made. */
+void bb_page_ota_confirm_show(const char* current_ver,
+                              const char* new_ver,
+                              uint32_t    size_bytes,
+                              bb_page_ota_confirm_cb_t cb);
+
+/** Destroy the page synchronously. No-op if never shown / already dismissed.
+ *  Does NOT fire the callback. */
+void bb_page_ota_confirm_dismiss(void);
+
+/** 1 while the page object exists (use to gate nav routing). */
+int bb_page_ota_confirm_active(void);
+
+/** 1 if the 30 s countdown expired and the main loop should call
+ *  bb_page_ota_confirm_handle_nav(0) to dismiss and fire the callback. */
+int bb_page_ota_confirm_timed_out(void);
+
+/** Route a nav key press to the confirm page.
+ *  nav_ok == 1 → treat as OK (upgrade); nav_ok == 0 → treat as BACK (skip).
+ *  No-op if the page is not active.
+ *  Also call this when bb_page_ota_confirm_timed_out() returns 1. */
+void bb_page_ota_confirm_handle_nav(int nav_ok);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BB_PAGE_OTA_CONFIRM_H */

--- a/firmware/simulator/CMakeLists.txt
+++ b/firmware/simulator/CMakeLists.txt
@@ -33,6 +33,8 @@ set(_sim_srcs
   "${CMAKE_CURRENT_SOURCE_DIR}/../src/bb_page_standby.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/../src/bb_page_netconn.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/../src/bb_page_apconfig.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../src/bb_page_ota.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../src/bb_page_ota_confirm.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/../src/bb_page_locked.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/../src/bb_chat_transcript.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/../src/bb_chat_recording.c"

--- a/firmware/simulator/main.c
+++ b/firmware/simulator/main.c
@@ -11,6 +11,7 @@
 #include "bb_display.h"
 #include "bb_page_apconfig.h"
 #include "bb_page_netconn.h"
+#include "bb_page_ota_confirm.h"
 #include "bb_time.h"
 #include "lvgl.h"
 #include "src/drivers/sdl/lv_sdl_keyboard.h"
@@ -32,6 +33,7 @@ typedef enum {
   APP_MODE_NETCONN = 4,
   APP_MODE_LOCKED = 5,
   APP_MODE_APCONFIG = 6,
+  APP_MODE_OTA_CONFIRM = 7,
 } app_mode_t;
 
 typedef struct {
@@ -100,6 +102,8 @@ static void parse_args(app_state_t* state, int argc, char** argv) {
         state->mode = APP_MODE_LOCKED;
       } else if (strcmp(argv[i], "apconfig") == 0) {
         state->mode = APP_MODE_APCONFIG;
+      } else if (strcmp(argv[i], "ota_confirm") == 0) {
+        state->mode = APP_MODE_OTA_CONFIRM;
       } else {
         state->mode = APP_MODE_AUTO;
       }
@@ -132,7 +136,7 @@ static void parse_args(app_state_t* state, int argc, char** argv) {
       strncpy(state->export_path, argv[i], sizeof(state->export_path) - 1);
       state->export_path[sizeof(state->export_path) - 1] = '\0';
     } else if (strcmp(argv[i], "--help") == 0) {
-      printf("bbclaw_lvgl_sim [--mode auto|standby|notification|speaking|netconn|locked|apconfig] [--status READY|TASK|TX|RX|SPEAK]\n");
+      printf("bbclaw_lvgl_sim [--mode auto|standby|notification|speaking|netconn|locked|apconfig|ota_confirm] [--status READY|TASK|TX|RX|SPEAK]\n");
       printf("               [--you TEXT] [--reply TEXT] [--turn-num N] [--turn-den N]\n");
       printf("               [--zoom 3.0] [--timeout-ms 0] [--export PATH]\n");
       exit(0);
@@ -250,6 +254,14 @@ static void populate_preview_state(const app_state_t* state) {
     bb_display_set_battery(1, 1, 82, 0, 0);
     (void)bb_display_show_status("WIFI AP");
     bb_page_apconfig_show();
+    return;
+  }
+
+  if (state->mode == APP_MODE_OTA_CONFIRM) {
+    /* OTA user-confirm page: shows version prompt + 30 s countdown bar. */
+    bb_display_set_battery(1, 1, 82, 0, 0);
+    (void)bb_display_show_status("READY");
+    bb_page_ota_confirm_show("v0.4.17", "v0.4.18", 1024 * 1024 + 256 * 1024, NULL);
     return;
   }
 

--- a/firmware/src/CMakeLists.txt
+++ b/firmware/src/CMakeLists.txt
@@ -18,6 +18,7 @@ set(_bb_srcs
     "bb_page_netconn.c"
     "bb_page_apconfig.c"
     "bb_page_ota.c"
+    "bb_page_ota_confirm.c"
     "bb_chat_transcript.c"
     "bb_chat_cache.c"
     "bb_chat_recording.c"

--- a/firmware/src/bb_page_ota_confirm.c
+++ b/firmware/src/bb_page_ota_confirm.c
@@ -1,0 +1,235 @@
+/**
+ * OTA confirm page. See bb_page_ota_confirm.h.
+ *
+ * Layout (320×172 display):
+ *   Y= 18  "UPDATE?"  title (accent teal)
+ *   Y= 44  "vA.B.C -> vX.Y.Z"  version line (cool white)
+ *   Y= 62  "NNN KB"  size line (dim)
+ *   Y= 86  dot countdown bar (30 cells, one dot extinguished per second)
+ *   Y=108  "OK upgrade  BACK skip" hint (dim)
+ *
+ * Timer design: the LVGL 1 Hz timer ONLY updates the dot bar and sets
+ * s_timed_out=1 when it reaches zero — it never calls user code.
+ * bb_page_ota_confirm_handle_nav() (called from the radio-app main loop)
+ * destroys the page and fires the callback outside the LVGL lock.
+ */
+#include "bb_page_ota_confirm.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "bb_config.h"
+#include "bb_ui_theme.h"
+#include "lvgl.h"
+
+#if defined(BBCLAW_SIMULATOR)
+#define ESP_LOGI(tag, fmt, ...) ((void)(tag))
+#define ESP_LOGW(tag, fmt, ...) ((void)(tag))
+static int lvgl_port_lock(int t) { (void)t; return 1; }
+static void lvgl_port_unlock(void) {}
+#else
+#include "esp_log.h"
+#include "esp_lvgl_port.h"
+#endif
+
+static const char *TAG = "bb_page_ota_confirm";
+
+/* ── palette ── */
+#define UI_SCR_BG    BB_UI_BG
+#define UI_DOT_GHOST BB_UI_DOT_GHOST
+#define UI_ACCENT    BB_UI_ACCENT
+#define UI_DOT_LIT   BB_UI_DOT_LIT
+#define UI_TEXT_DIM  BB_UI_TEXT_DIM
+
+/* ── countdown bar geometry ── */
+#define CDOWN_CELLS      30
+#define CDOWN_CELL_DOT   5
+#define CDOWN_CELL_PITCH 8
+#define CDOWN_BAR_W      ((CDOWN_CELLS - 1) * CDOWN_CELL_PITCH + CDOWN_CELL_DOT)
+
+/* ── Y positions ── */
+#define TITLE_Y    18
+#define VER_Y      44
+#define SIZE_Y     62
+#define BAR_Y      86
+#define HINT_Y    108
+
+#define TIMEOUT_SEC 30
+
+#if LV_FONT_MONTSERRAT_14
+LV_FONT_DECLARE(lv_font_montserrat_14)
+#endif
+
+static const lv_font_t *small_font(void) {
+#if LV_FONT_MONTSERRAT_14
+  return &lv_font_montserrat_14;
+#else
+  return lv_font_get_default();
+#endif
+}
+
+/* ── module state ── */
+static lv_obj_t            *s_root;
+static lv_obj_t            *s_cells[CDOWN_CELLS];
+static lv_timer_t          *s_timer;
+static volatile int         s_remaining;  /* seconds left; written by timer cb */
+static volatile int         s_timed_out;  /* set to 1 by timer when done       */
+static bb_page_ota_confirm_cb_t s_cb;
+
+/* ── internal helpers (called with LVGL lock held) ── */
+
+static void destroy_now(void) {
+  if (s_timer) { lv_timer_del(s_timer); s_timer = NULL; }
+  if (s_root)  { lv_obj_del(s_root);  s_root  = NULL; }
+}
+
+static void paint_countdown(int remaining) {
+  for (int i = 0; i < CDOWN_CELLS; i++) {
+    uint32_t col = (i < remaining) ? UI_ACCENT : UI_DOT_GHOST;
+    lv_obj_set_style_bg_color(s_cells[i], lv_color_hex(col), 0);
+  }
+}
+
+/* 1 Hz timer — only touches LVGL objects and volatile flags, never user cb. */
+static void confirm_timer_cb(lv_timer_t *t) {
+  (void)t;
+  if (!s_root) return;
+  int rem = s_remaining - 1;
+  if (rem < 0) rem = 0;
+  s_remaining = rem;
+  paint_countdown(rem);
+  if (rem == 0) s_timed_out = 1;
+}
+
+/* ── public API ── */
+
+void bb_page_ota_confirm_show(const char *current_ver,
+                              const char *new_ver,
+                              uint32_t    size_bytes,
+                              bb_page_ota_confirm_cb_t cb) {
+  if (!lvgl_port_lock(1000)) {
+    ESP_LOGW(TAG, "show: lvgl lock timeout");
+    return;
+  }
+  if (s_root) { lvgl_port_unlock(); return; }
+
+  s_cb        = cb;
+  s_remaining = TIMEOUT_SEC;
+  s_timed_out = 0;
+
+  /* Root */
+  s_root = lv_obj_create(lv_layer_top());
+  lv_obj_remove_style_all(s_root);
+  lv_obj_set_size(s_root, BBCLAW_ST7789_WIDTH, BBCLAW_ST7789_HEIGHT);
+  lv_obj_set_pos(s_root, 0, 0);
+  lv_obj_set_style_bg_color(s_root, lv_color_hex(UI_SCR_BG), 0);
+  lv_obj_set_style_bg_opa(s_root, LV_OPA_COVER, 0);
+  lv_obj_clear_flag(s_root, LV_OBJ_FLAG_SCROLLABLE | LV_OBJ_FLAG_CLICKABLE);
+
+  /* Title */
+  lv_obj_t *title = lv_label_create(s_root);
+  lv_obj_set_style_text_color(title, lv_color_hex(UI_ACCENT), 0);
+  lv_obj_set_style_text_font(title, small_font(), 0);
+  lv_obj_set_style_text_align(title, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_width(title, BBCLAW_ST7789_WIDTH);
+  lv_obj_set_pos(title, 0, TITLE_Y);
+  lv_label_set_text(title, "UPDATE?");
+
+  /* Version line */
+  const char *cv = (current_ver && current_ver[0]) ? current_ver : "?";
+  const char *nv = (new_ver     && new_ver[0])     ? new_ver     : "?";
+  char ver_buf[80];
+  snprintf(ver_buf, sizeof(ver_buf), "%s -> %s", cv, nv);
+  lv_obj_t *ver = lv_label_create(s_root);
+  lv_obj_set_style_text_color(ver, lv_color_hex(UI_DOT_LIT), 0);
+  lv_obj_set_style_text_font(ver, small_font(), 0);
+  lv_obj_set_style_text_align(ver, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_width(ver, BBCLAW_ST7789_WIDTH);
+  lv_obj_set_pos(ver, 0, VER_Y);
+  lv_label_set_text(ver, ver_buf);
+
+  /* Size line */
+  char size_buf[24];
+  if (size_bytes >= 1024u * 1024u) {
+    snprintf(size_buf, sizeof(size_buf), "%.1f MB",
+             (double)size_bytes / (1024.0 * 1024.0));
+  } else {
+    snprintf(size_buf, sizeof(size_buf), "%u KB",
+             (unsigned)((size_bytes + 512u) / 1024u));
+  }
+  lv_obj_t *sz = lv_label_create(s_root);
+  lv_obj_set_style_text_color(sz, lv_color_hex(UI_TEXT_DIM), 0);
+  lv_obj_set_style_text_font(sz, small_font(), 0);
+  lv_obj_set_style_text_align(sz, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_width(sz, BBCLAW_ST7789_WIDTH);
+  lv_obj_set_pos(sz, 0, SIZE_Y);
+  lv_label_set_text(sz, size_buf);
+
+  /* Countdown dot bar — all lit at start */
+  int x0 = (BBCLAW_ST7789_WIDTH - CDOWN_BAR_W) / 2;
+  for (int i = 0; i < CDOWN_CELLS; i++) {
+    lv_obj_t *c = lv_obj_create(s_root);
+    lv_obj_remove_style_all(c);
+    lv_obj_set_size(c, CDOWN_CELL_DOT, CDOWN_CELL_DOT);
+    lv_obj_set_pos(c, x0 + i * CDOWN_CELL_PITCH, BAR_Y);
+    lv_obj_set_style_radius(c, 1, 0);
+    lv_obj_set_style_bg_color(c, lv_color_hex(UI_ACCENT), 0);
+    lv_obj_set_style_bg_opa(c, LV_OPA_COVER, 0);
+    lv_obj_clear_flag(c, LV_OBJ_FLAG_SCROLLABLE);
+    s_cells[i] = c;
+  }
+
+  /* Hint */
+  lv_obj_t *hint = lv_label_create(s_root);
+  lv_obj_set_style_text_color(hint, lv_color_hex(UI_TEXT_DIM), 0);
+  lv_obj_set_style_text_font(hint, small_font(), 0);
+  lv_obj_set_style_text_align(hint, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_width(hint, BBCLAW_ST7789_WIDTH);
+  lv_obj_set_pos(hint, 0, HINT_Y);
+  lv_label_set_text(hint, "OK upgrade  BACK skip");
+
+  s_timer = lv_timer_create(confirm_timer_cb, 1000, NULL);
+
+  lvgl_port_unlock();
+  ESP_LOGI(TAG, "confirm shown cur=%s new=%s size=%u", cv, nv, (unsigned)size_bytes);
+}
+
+void bb_page_ota_confirm_dismiss(void) {
+  if (!lvgl_port_lock(1000)) {
+    ESP_LOGW(TAG, "dismiss: lvgl lock timeout");
+    return;
+  }
+  s_cb = NULL;
+  destroy_now();
+  lvgl_port_unlock();
+  ESP_LOGI(TAG, "confirm dismissed");
+}
+
+int bb_page_ota_confirm_active(void) {
+  return s_root ? 1 : 0;
+}
+
+/** Returns 1 if the 30 s timeout fired and we're waiting for the main loop
+ *  to call handle_nav(0) to dismiss + fire the callback. */
+int bb_page_ota_confirm_timed_out(void) {
+  return s_timed_out;
+}
+
+/** Route a nav decision.  nav_ok=1 → accept, nav_ok=0 → skip.
+ *  Destroys the page, then calls the callback outside the LVGL lock.
+ *  Safe to call when page is not active (no-op). */
+void bb_page_ota_confirm_handle_nav(int nav_ok) {
+  if (!s_root) return;
+  if (!lvgl_port_lock(600)) {
+    ESP_LOGW(TAG, "handle_nav: lvgl lock timeout");
+    return;
+  }
+  int accept = nav_ok ? 1 : 0;
+  bb_page_ota_confirm_cb_t cb = s_cb;
+  s_cb = NULL;
+  s_timed_out = 0;
+  destroy_now();
+  lvgl_port_unlock();
+  ESP_LOGI(TAG, "confirm decision accept=%d", accept);
+  if (cb) cb(accept);
+}

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -23,6 +23,7 @@
 #include "bb_page_boot.h"
 #include "bb_page_netconn.h"
 #include "bb_page_ota.h"
+#include "bb_page_ota_confirm.h"
 #include "bb_ui_theme.h"
 #include "bb_power.h"
 #include "bb_ptt.h"
@@ -49,9 +50,40 @@
 
 static const char* TAG = "bb_radio_app";
 
+/* Pending OTA confirm state — declared here so ota_confirm_cb (below) can
+ * reference them before the main block of static variables at ~line 290. */
+static int               s_pending_ota_prompt;    /* 1 = waiting to show    */
+static ota_update_info_t s_pending_ota_info;      /* cached check result    */
+static int               s_ota_skipped_this_boot; /* 1 = skipped this boot  */
+
 /* Forwards OTA download progress to the on-screen dot-matrix progress page. */
 static void ota_ui_progress_cb(int percent) {
   bb_page_ota_set_progress(percent);
+}
+
+/* Called by bb_page_ota_confirm when the user (or 30 s timeout) decides.
+ * accept=1 → run the existing download/flash/reboot flow.
+ * accept=0 → mark skipped for this boot cycle; system resumes normally. */
+static void ota_confirm_cb(int accept) {
+  if (!accept) {
+    ESP_LOGI(TAG, "OTA confirm: user skipped version=%s", s_pending_ota_info.version);
+    s_ota_skipped_this_boot = 1;
+    s_pending_ota_prompt    = 0;
+    return;
+  }
+  ESP_LOGI(TAG, "OTA confirm: user accepted version=%s", s_pending_ota_info.version);
+  s_pending_ota_prompt = 0;
+  bb_page_ota_show(s_pending_ota_info.version);
+  esp_err_t dl_err = bb_ota_download_and_flash(&s_pending_ota_info, ota_ui_progress_cb);
+  if (dl_err == ESP_OK) {
+    ESP_LOGI(TAG, "OTA download+flash success, rebooting...");
+    bb_page_ota_set_done();
+    (void)bb_ota_apply_update();
+    /* Never returns */
+  } else {
+    ESP_LOGW(TAG, "OTA download+flash failed err=%s", esp_err_to_name(dl_err));
+    bb_page_ota_dismiss();
+  }
 }
 
 #if BBCLAW_SPK_TEST_ON_BOOT
@@ -255,6 +287,7 @@ static size_t s_voice_verify_pcm_len;
 static size_t s_voice_verify_pcm_cap;
 static int s_voice_verify_truncated;
 
+
 /* VAD 触发后首帧原经 xRingbufferSend 进环；与 LVGL/SPI 异核时易在环缓冲自旋锁上触发 INT WDT，改为先内存再 ingest */
 static volatile int s_capture_seed_pending;
 static uint8_t s_capture_seed_buf[2048];
@@ -317,6 +350,15 @@ static void set_radio_app_state(bb_radio_app_state_t state) {
         bb_state_dispatch_simple(
           (prev == BBCLAW_STATE_LOCKED) ? BB_EVT_VOICE_VERIFY_OK
                                         : BB_EVT_REQUEST_SETTINGS_EXIT);
+        /* After unlock (LOCKED→CHAT): show OTA confirm page if pending. */
+        if (prev == BBCLAW_STATE_LOCKED && s_pending_ota_prompt &&
+            !s_ota_skipped_this_boot) {
+          s_pending_ota_prompt = 0;
+          bb_page_ota_confirm_show(bb_ota_get_current_version(),
+                                   s_pending_ota_info.version,
+                                   s_pending_ota_info.size,
+                                   ota_confirm_cb);
+        }
         break;
       case BBCLAW_STATE_SETTINGS:
         bb_state_dispatch_simple(BB_EVT_REQUEST_SETTINGS_ENTER);
@@ -1751,6 +1793,20 @@ static void stream_task(void* arg) {
         bb_nav_event_t nav = (bb_nav_event_t)event;
 
         /* ADR-012 §3 button-routing table — each page owns its dispatch. */
+
+        /* OTA confirm page intercepts OK/BACK when active (lv_layer_top).
+         * All other nav events reset the 30 s timeout (keeps it fair). */
+        if (bb_page_ota_confirm_active()) {
+          if (nav == BB_NAV_EVENT_OK) {
+            bb_page_ota_confirm_handle_nav(1);
+          } else if (nav == BB_NAV_EVENT_BACK) {
+            bb_page_ota_confirm_handle_nav(0);
+          }
+          /* Any nav key: treat as activity (do NOT reset countdown here;
+           * the countdown bar is the user's cue, no reset on input). */
+          break;
+        }
+
         switch (s_app_state) {
           case BBCLAW_STATE_LOCKED:
             /* Nav events ignored; only PTT (passphrase verify) is alive. */
@@ -3024,6 +3080,10 @@ static void stream_task(void* arg) {
     }
 
     if (!streaming) {
+      /* Poll OTA confirm timeout: timer sets the flag, main loop drains it. */
+      if (bb_page_ota_confirm_timed_out()) {
+        bb_page_ota_confirm_handle_nav(0);
+      }
       vTaskDelay(pdMS_TO_TICKS(20));
     }
   }
@@ -3239,26 +3299,27 @@ esp_err_t bb_radio_app_start(void) {
         if (rpt != ESP_OK) {
           ESP_LOGW(TAG, "device info report failed err=%s (non-fatal)", esp_err_to_name(rpt));
         }
-        /* Silent OTA check: download and flash if update available */
-        if (bb_transport_is_cloud_saas()) {
+        /* OTA check: if update available, queue a user-confirm prompt.
+         * The confirm page is shown after unlock (or immediately if unlocked).
+         * Download/flash only happens when the user presses OK. */
+        if (bb_transport_is_cloud_saas() && !s_ota_skipped_this_boot) {
           ota_update_info_t ota_info = {0};
           esp_err_t ota_err = bb_ota_check(&ota_info);
           if (ota_err == ESP_OK && ota_info.has_update) {
-            ESP_LOGI(TAG, "OTA update available: version=%s size=%u", ota_info.version, ota_info.size);
-            /* Dot-matrix progress page on lv_layer_top, fed by the download
-             * progress callback (replaces the old silent NULL). */
-            bb_page_ota_show(ota_info.version);
-            esp_err_t dl_err = bb_ota_download_and_flash(&ota_info, ota_ui_progress_cb);
-            if (dl_err == ESP_OK) {
-              ESP_LOGI(TAG, "OTA download+flash success, rebooting...");
-              bb_page_ota_set_done();  /* shows "REBOOTING" during apply's pre-reboot delay */
-              (void)bb_ota_apply_update();
-              /* Never returns */
-            } else {
-              ESP_LOGW(TAG, "OTA download+flash failed err=%s", esp_err_to_name(dl_err));
-              bb_page_ota_dismiss();
-            }
+            ESP_LOGI(TAG, "OTA update available: version=%s size=%u — queuing confirm",
+                     ota_info.version, ota_info.size);
+            s_pending_ota_info   = ota_info;
+            s_pending_ota_prompt = 1;
           }
+        }
+        /* If device is not locked, show the confirm page immediately.
+         * If locked, s_pending_ota_prompt will be consumed on unlock. */
+        if (s_pending_ota_prompt && !radio_app_is_locked()) {
+          s_pending_ota_prompt = 0;
+          bb_page_ota_confirm_show(bb_ota_get_current_version(),
+                                   s_pending_ota_info.version,
+                                   s_pending_ota_info.size,
+                                   ota_confirm_cb);
         }
       } else {
         ESP_LOGI(TAG, "cloud pairing requested and pending approval status=%d detail=%s", health_status,


### PR DESCRIPTION
Fixes #150

## 改动说明

### 新增文件

- `firmware/include/bb_page_ota_confirm.h` — 公开 API：show / dismiss / active / timed_out / handle_nav
- `firmware/src/bb_page_ota_confirm.c` — 提醒页实现，复用 bb_page_ota 点阵风格：
  - 标题 "UPDATE?"（accent teal）
  - 版本行 "vA.B.C -> vX.Y.Z"（cool white）
  - 大小行 KB/MB（dim）
  - 30 格倒计时点阵进度条（每秒熄灭一格）
  - 底部提示 "OK upgrade  BACK skip"（dim）
  - LVGL 1Hz timer 只更新 UI 并设置 timed_out 标志，不直接调用用户回调，避免 LVGL 锁持有期间的重入问题

### 修改文件

- `firmware/src/bb_radio_app.c`
  - 顶部新增 3 个 static 变量：s_pending_ota_prompt / s_pending_ota_info / s_ota_skipped_this_boot
  - ota_confirm_cb：accept=1 走原下载/烧写/重启流程；accept=0 置 skipped 标志
  - 原 silent OTA 块改为记录 pending；未锁屏立即弹 confirm 页，锁屏时挂起
  - set_radio_app_state：LOCKED→CHAT 解锁后若有 pending 提醒，弹 confirm 页
  - nav 路由层：bb_page_ota_confirm_active() 时拦截 OK/BACK，其余按键不消费
  - 主循环：bb_page_ota_confirm_timed_out() 触发 handle_nav(0) 处理超时跳过

- `firmware/src/CMakeLists.txt` — 加入 bb_page_ota_confirm.c
- `firmware/simulator/CMakeLists.txt` — 加入 bb_page_ota.c + bb_page_ota_confirm.c
- `firmware/simulator/main.c` — 新增 --mode ota_confirm 入口

## 验收行为

| 场景 | 行为 |
|---|---|
| cloud_saas，有新版本，未锁屏 | transport ready 后立即弹提醒页 |
| cloud_saas，有新版本，锁屏中 | check 后挂起，密语解锁完成后弹提醒页 |
| 用户按 OK | 进入现有下载/进度页/重启流程（不变） |
| 用户按 BACK | 跳过，本次开机不再提醒 |
| 30s 无操作 | 自动跳过，设备正常使用 |
| 跳过后重启 | 下次重启遇到同版本再次提醒 |
| local_home 模式 | 完全不影响（bb_transport_is_cloud_saas() 守门） |

## 未测试（需硬件）

实际 ESP32-S3 设备的 OTA check 网络请求和 UI 渲染需要物理设备验证。
锁屏→解锁→弹页序列需通过串口 monitor 确认。