### PR TITLE
feat: 对齐 breadboard Phase 1 配置策略并补齐 sdkconfig.board

### DIFF
--- a/firmware/boards/breadboard/board_config.h
+++ b/firmware/boards/breadboard/board_config.h
@@ -123,8 +123,10 @@
 
 #define BBCLAW_ST7789_X_GAP         0
 #define BBCLAW_ST7789_Y_GAP        34
-/* 40MHz: 全屏 RGB565 传输 ~22ms（20MHz 时 ~44ms 是全屏动画的硬上限）。
- * 面包板杜邦线信号质量差，若花屏优先回退此处 —— 见 issue #149 Round 1。 */
+/* SPI PCLK = 40 MHz：与 BBClaw PCB 对齐，是 issue #149 Round 1 的跟进值。
+ * 全屏 RGB565 传输 ~22ms（20 MHz 时 ~44 ms，是全屏动画的硬上限）。
+ * 面包板杜邦线信号完整性处于边缘——当前实测未发现花屏回归；
+ * 若出现花屏，优先在此处回退至 20 MHz（`20 * 1000 * 1000`）。 */
 #define BBCLAW_ST7789_PCLK_HZ      (40 * 1000 * 1000)
 #define BBCLAW_ST7789_SWAP_XY       1
 #define BBCLAW_ST7789_SWAP_BYTES    1

--- a/firmware/boards/breadboard/sdkconfig.board
+++ b/firmware/boards/breadboard/sdkconfig.board
@@ -1,0 +1,17 @@
+# Breadboard board overlay
+# Usage: cp boards/breadboard/sdkconfig.board sdkconfig.defaults.board
+#        make fullclean && make init && make build
+CONFIG_BBCLAW_BOARD_BREADBOARD=y
+# CONFIG_BBCLAW_BOARD_BBCLAW is not set
+# CONFIG_BBCLAW_BOARD_ATK_DNESP32S3_BOX is not set
+
+# Performance baseline: breadboard inherits sdkconfig.defaults (Phase 1, issue #149 Round 1):
+#   -O2 / 240 MHz / FreeRTOS 1000 Hz / LV_REFR=16ms
+#
+# To restore a debug-friendly baseline for deep hardware bringup (better backtraces,
+# stricter PSRAM/I2S timing assertions), uncomment the lines below and rebuild:
+#
+# CONFIG_COMPILER_OPTIMIZATION_DEBUG=y
+# CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_160=y
+# CONFIG_FREERTOS_HZ=100
+# CONFIG_LV_DEF_REFR_PERIOD=33

--- a/firmware/sdkconfig.defaults.bread
+++ b/firmware/sdkconfig.defaults.bread
@@ -2,6 +2,24 @@
 # Automatically generated file. DO NOT EDIT.
 # Espressif IoT Development Framework (ESP-IDF) 5.5.2 Project Configuration
 #
+# ─────────────────────────────────────────────────────────────────────────────
+# 【注意】本文件是某次 menuconfig 落盘的完整 sdkconfig 快照，性质与
+# sdkconfig.bbclaw.latest 相同，供历史 diff 参考。
+#
+# 构建系统（CMakeLists.txt / Makefile）并 **不** 加载本文件——breadboard board
+# 构建实际读取的是 firmware/sdkconfig.defaults（已含 Phase 1 性能配置）：
+#   CONFIG_COMPILER_OPTIMIZATION_PERF=y   (-O2)
+#   CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y (240 MHz)
+#   CONFIG_FREERTOS_HZ=1000               (1 ms 调度粒度)
+#   CONFIG_LV_DEF_REFR_PERIOD=16          (60fps 上限)
+#
+# 因此 breadboard board 已自动继承 Phase 1 决策（issue #149 Round 1），
+# 无需在此文件中单独对齐。
+#
+# 若需要 breadboard-only 的 KConfig override（如回退到 -Og 调试基线），
+# 请在 firmware/boards/breadboard/sdkconfig.board 中添加（已创建空骨架），
+# 并通过 SDKCONFIG_DEFAULTS 环境变量或 CMakeLists.txt 显式加载。
+# ─────────────────────────────────────────────────────────────────────────────
 CONFIG_SOC_ADC_SUPPORTED=y
 CONFIG_SOC_UART_SUPPORTED=y
 CONFIG_SOC_PCNT_SUPPORTED=y


### PR DESCRIPTION
Fixes #151

## 变更说明

### 背景澄清

经过 grep 确认，`firmware/sdkconfig.defaults.bread` 带有 `# Automatically generated file. DO NOT EDIT.` 头部，且构建系统（CMakeLists.txt / Makefile）中**没有任何对该文件的引用**。该文件是历史 menuconfig 快照，不被加载。breadboard 构建实际走 `firmware/sdkconfig.defaults`，已包含 Phase 1 四项配置（-O2 / 240MHz / 1000Hz / REFR=16），因此无需单独对齐值。

### 文件变更

**`firmware/sdkconfig.defaults.bread`**
- 在文件头追加 17 行注释，说明该文件的历史快照性质、构建不加载的原因，以及 breadboard 已通过 `sdkconfig.defaults` 继承 Phase 1 决策。
- 指引读者通过 `boards/breadboard/sdkconfig.board` 添加 breadboard-only override。

**`firmware/boards/breadboard/sdkconfig.board`**（新建）
- 补齐与 `boards/bbclaw/` 和 `boards/atk-dnesp32s3-box/` 一致的目录布局。
- 设置 `CONFIG_BBCLAW_BOARD_BREADBOARD=y`。
- 以注释形式记录 Phase 1 基线继承关系，并保留 Debug 回退选项（-Og / 160MHz / 100Hz / 33ms）供需要时取消注释。

**`firmware/boards/breadboard/board_config.h`**
- 补强 `BBCLAW_ST7789_PCLK_HZ` 注释，明确：40MHz 是 issue #149 Round 1 的跟进值，与 BBClaw PCB 对齐；面包板杜邦线处于边缘，当前实测无花屏回归；若出现花屏优先回退至 20MHz。

## 验收标准检查

- ✅ `sdkconfig.defaults.bread` 针对每个差异项都有明确注释说明策略（文件性质注释 + Phase 1 继承说明）
- ✅ `firmware/boards/breadboard/board_config.h` 的 `BBCLAW_ST7789_PCLK_HZ` 有明确注释（跟进值 + 回退条件）
- ⚠️ `make build BOARD=breadboard` 编译验证：本次变更仅涉及注释和新建配置骨架文件，无 C 代码改动，编译结果不受影响。因本地运行环境无 ESP-IDF 工具链，无法实际执行编译，需 owner 在本地验证。