### PR TITLE
fix: flush_cb 改用 esp_lvgl_port 内置 swap，删除软件字节交换

### DIFF
--- a/firmware/boards/bbclaw/board_config.h
+++ b/firmware/boards/bbclaw/board_config.h
@@ -125,7 +125,9 @@
  * 若出现花屏/撕裂回退 20MHz —— 见 issue #149 Round 1。 */
 #define BBCLAW_ST7789_PCLK_HZ      (40 * 1000 * 1000)
 #define BBCLAW_ST7789_SWAP_XY       1
-#define BBCLAW_ST7789_SWAP_BYTES    1
+/* Byte-swapping is now handled by esp_lvgl_port (flags.swap_bytes=1 in disp_cfg).
+ * panel io layer must NOT also swap, or bytes would be double-swapped (issue #153). */
+#define BBCLAW_ST7789_SWAP_BYTES    0
 
 #if BBCLAW_ST7789_147_VARIANT == 2
 #define BBCLAW_ST7789_INVERT_COLOR  1

--- a/firmware/boards/breadboard/board_config.h
+++ b/firmware/boards/breadboard/board_config.h
@@ -127,7 +127,9 @@
  * 面包板杜邦线信号质量差，若花屏优先回退此处 —— 见 issue #149 Round 1。 */
 #define BBCLAW_ST7789_PCLK_HZ      (40 * 1000 * 1000)
 #define BBCLAW_ST7789_SWAP_XY       1
-#define BBCLAW_ST7789_SWAP_BYTES    1
+/* Byte-swapping is now handled by esp_lvgl_port (flags.swap_bytes=1 in disp_cfg).
+ * panel io layer must NOT also swap, or bytes would be double-swapped (issue #153). */
+#define BBCLAW_ST7789_SWAP_BYTES    0
 
 #if BBCLAW_ST7789_147_VARIANT == 2
 #define BBCLAW_ST7789_INVERT_COLOR  1

--- a/firmware/include/bb_config.h
+++ b/firmware/include/bb_config.h
@@ -1026,7 +1026,10 @@ const char *bbclaw_session_key(void);
 #endif
 
 #ifndef BBCLAW_ST7789_SWAP_BYTES
-#define BBCLAW_ST7789_SWAP_BYTES 1
+/* Default 0: byte-swapping is delegated to esp_lvgl_port via flags.swap_bytes.
+ * Set to 1 only if the board's panel io layer must also swap (would double-swap
+ * when used together with flags.swap_bytes — avoid unless intentional). */
+#define BBCLAW_ST7789_SWAP_BYTES 0
 #endif
 
 /**

--- a/firmware/src/bb_lvgl_display.c
+++ b/firmware/src/bb_lvgl_display.c
@@ -168,6 +168,10 @@ LV_FONT_DECLARE(lv_font_montserrat_48)
 #define DISP_SWAP_XY        BBCLAW_ST7789_SWAP_XY
 #define DISP_MIRROR_X       BBCLAW_ST7789_MIRROR_X
 #define DISP_MIRROR_Y       BBCLAW_ST7789_MIRROR_Y
+/* DISP_SWAP_BYTES is no longer consumed in flush_cb (software swap removed).
+ * Byte-swapping is now delegated to esp_lvgl_port via disp_cfg.flags.swap_bytes.
+ * BBCLAW_ST7789_SWAP_BYTES on board_config.h controls whether the panel io layer
+ * does a hardware swap; set to 0 to avoid double-swap. */
 #define DISP_SWAP_BYTES     BBCLAW_ST7789_SWAP_BYTES
 #define DISP_INVERT_COLOR   BBCLAW_ST7789_INVERT_COLOR
 #if BBCLAW_ST7789_RGB_ORDER_BGR
@@ -1056,20 +1060,10 @@ static esp_err_t init_panel(void) {
   return bb_panel_init(&s_panel_io, &s_panel);
 }
 
-static void lvgl_flush_cb(lv_display_t* disp, const lv_area_t* area, uint8_t* color_map) {
-  if (disp == NULL || area == NULL || color_map == NULL) {
-    if (disp != NULL) lvgl_port_flush_ready(disp);
-    return;
-  }
-#if DISP_SWAP_BYTES
-  lv_draw_sw_rgb565_swap(color_map, lv_area_get_size(area));
-#endif
-  esp_err_t e = esp_lcd_panel_draw_bitmap(s_panel, area->x1, area->y1, area->x2 + 1, area->y2 + 1, color_map);
-  if (e != ESP_OK) {
-    ESP_LOGW(TAG, "draw failed: %s", esp_err_to_name(e));
-    lvgl_port_flush_ready(disp);
-  }
-}
+/* lvgl_flush_cb removed: esp_lvgl_port's internal flush callback (registered by
+ * lvgl_port_add_disp) handles draw_bitmap and byte-swapping via flags.swap_bytes.
+ * The application no longer overrides lv_display_set_flush_cb, so the port-owned
+ * callback runs directly — eliminating the per-frame CPU swap scan that was here. */
 #endif /* !BBCLAW_SIMULATOR */
 
 /* ── create_ui ── */
@@ -1692,7 +1686,11 @@ esp_err_t bb_display_init(void) {
     ESP_LOGE(TAG, "lvgl_port_add_disp failed");
     return ESP_FAIL;
   }
-  lv_display_set_flush_cb(disp, lvgl_flush_cb);
+  /* NOTE: do NOT override lv_display_set_flush_cb here.
+   * esp_lvgl_port registers its own flush callback (lvgl_port_flush_callback)
+   * which handles esp_lcd_panel_draw_bitmap and, when flags.swap_bytes is set,
+   * calls lv_draw_sw_rgb565_swap internally.  Overriding it would bypass that
+   * logic and force the application to duplicate it (the old approach). */
 
   if (!lvgl_port_lock(2000)) return ESP_ERR_TIMEOUT;
   create_ui();


### PR DESCRIPTION
Fixes #153

## 改动说明

### 问题
 在每帧 flush 时通过  做全 buffer CPU 遍历字节交换，同时应用层用  覆盖了 esp_lvgl_port 内部注册的 flush 回调，导致 port 自带的 swap 逻辑和 draw_bitmap 调用被绕过。

### 修复

**核心改动：**
- 删除 `lvgl_flush_cb` 函数（含 `#if DISP_SWAP_BYTES … lv_draw_sw_rgb565_swap … #endif` 块）
- 移除 `lv_display_set_flush_cb(disp, lvgl_flush_cb)` 覆盖调用，让 esp_lvgl_port 自身的 `lvgl_port_flush_callback` 接管
- 保留 `disp_cfg.flags.swap_bytes = 1`，esp_lvgl_port 的 flush_cb 通过此 flag 在内部调用 `lv_draw_sw_rgb565_swap`

**配套改动（防止双重 swap）：**
- `firmware/boards/bbclaw/board_config.h`：`BBCLAW_ST7789_SWAP_BYTES 1 → 0`，加注释
- `firmware/boards/breadboard/board_config.h`：同上
- `firmware/include/bb_config.h`：fallback 默认值 `1 → 0`，加注释

**未改动（已确认）：**
- `atk-dnesp32s3-box/board_config.h`：已为 0，无需变更
- `firmware/src/bb_display_bitmap.c`：走独立直写路径，未调用 `lv_draw_sw_rgb565_swap`，不受影响
- simulator 路径：`#endif /* !BBCLAW_SIMULATOR */` 宏覆盖，不受影响

### 验证
- ✅ `make build` 编译通过（EXIT=0，无新增错误/警告）
- ⚠️ **实机颜色验证为必须步骤**：烧录后需确认 lockscreen/chat 页面颜色正常（红色不变蓝、文字背景对比正常），以排除双重 swap 或缺失 swap 导致的颜色错乱
- 硬件验证无法在 CI 环境自动完成，需人工烧录到 bbclaw 实机验证