### PR TITLE
fix: 设备 LED 升级为红绿蓝三色状态灯

### DIFF
--- a/firmware/include/bb_state.h
+++ b/firmware/include/bb_state.h
@@ -121,6 +121,11 @@ typedef enum {
   BB_EVT_FORCE_AGENT_STATE,
   BB_EVT_FORCE_PTT_PHASE,        /* payload.error_code = (int)bb_ptt_phase_t */
 
+  /* Worker 长任务状态 */
+  BB_EVT_WORKER_BUSY_SET,        /* dispatch_status phase=started：进入 worker_busy */
+  BB_EVT_WORKER_BUSY_CLEAR,      /* dispatch_status phase=done/async/error / 超时：退出 */
+  BB_EVT_WORKER_BUSY_TIMEOUT,    /* 超时兜底：worker_busy_until_ms 到期 */
+
   /* 自检 / 内部 */
   BB_EVT_LVGL_LOCK_TIMEOUT,      /* subscriber 报告 LVGL 锁超时 */
   BB_EVT_DIZZY_TIMEOUT,          /* DIZZY one-shot 超时：自动恢复到 IDLE */
@@ -164,6 +169,12 @@ typedef struct {
   bool     tts_in_flight;
   bool     agent_in_flight;
   bool     adapter_offline;           /* adapter 端 502 标志（local_home 探测） */
+
+  /* Worker 长任务派发中：dispatch_status phase=started 时置位，
+   * phase=done/async/error 时清除。LED 显示红色，PTT 按下被忽略。
+   * worker_busy_until_ms 为超时兜底（ms）；0 = 无超时。 */
+  bool     worker_busy;
+  uint64_t worker_busy_until_ms;
 
   uint32_t lvgl_lock_failures;        /* 累计计数，便于诊断 */
   uint32_t dropped_events;            /* 累计 DROPPED 事件数 */

--- a/firmware/src/bb_led.c
+++ b/firmware/src/bb_led.c
@@ -299,6 +299,14 @@ static effect_t compose_from_state(const bb_state_t* st, const bb_power_state_t*
     e.period_ms = 0;
     return e;
   }
+  /* worker_busy: 红色呼吸，优先级高于 BUSY 青色脉动。
+   * 用户从颜色即可知道「长任务运行中，PTT 不可用」。 */
+  if (st->worker_busy) {
+    e.color = (rgb_t){220, 20, 0};
+    e.mode = ANIM_BREATHE;
+    e.period_ms = 1500;
+    return e;
+  }
   if (st->agent == BB_AGENT_STATE_ATTENTION) {
     e.color = (rgb_t){255, 200, 0};
     e.mode = ANIM_BLINK_FAST;

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -1218,6 +1218,18 @@ static void on_finish_stream_event(bb_finish_stream_event_t* event, void* user_c
     if (strcmp(ds->phase, "started") == 0 && ds->cwd[0] != '\0') {
       bb_display_set_butler_cwd(ds->cwd);
     }
+    /* Issue #166: worker_busy LED 状态切换
+     * phase=started → 红色呼吸 + PTT 门控
+     * phase=done/async/error → 清除红态，恢复正常状态灯 */
+    if (strcmp(ds->phase, "started") == 0) {
+      ESP_LOGI(TAG, "phase=worker_busy_set taskId=%s", ds->task_id);
+      bb_state_dispatch_simple(BB_EVT_WORKER_BUSY_SET);
+    } else if (strcmp(ds->phase, "done") == 0 ||
+               strcmp(ds->phase, "async") == 0 ||
+               strcmp(ds->phase, "error") == 0) {
+      ESP_LOGI(TAG, "phase=worker_busy_clear taskId=%s reason=%s", ds->task_id, ds->phase);
+      bb_state_dispatch_simple(BB_EVT_WORKER_BUSY_CLEAR);
+    }
     return;
   }
 
@@ -1369,6 +1381,24 @@ static void on_finish_stream_event_tts_only(bb_finish_stream_event_t* event, voi
       };
       /* DONE 是结束信号，队列变浅后更易撞满——给足背压超时，丢了消费者收不到结束。 */
       (void)xQueueSend(ui->tts_queue, &evt, pdMS_TO_TICKS(BB_TTS_STREAM_ENQUEUE_TIMEOUT_MS));
+    }
+    return;
+  }
+
+  /* Issue #166: cloud_saas 路径的 dispatch_status → worker_busy LED */
+  if (event->type == BB_FINISH_STREAM_EVENT_DISPATCH_STATUS && event->dispatch != NULL) {
+    const bb_dispatch_status_t* ds = event->dispatch;
+    ESP_LOGI(TAG, "phase=dispatch_status(agent) phase=%s taskId=%s", ds->phase, ds->task_id);
+    bb_display_set_dispatch_status(ds->phase, ds->cwd, ds->task_id, ds->elapsed_ms);
+    if (strcmp(ds->phase, "started") == 0 && ds->cwd[0] != '\0') {
+      bb_display_set_butler_cwd(ds->cwd);
+    }
+    if (strcmp(ds->phase, "started") == 0) {
+      bb_state_dispatch_simple(BB_EVT_WORKER_BUSY_SET);
+    } else if (strcmp(ds->phase, "done") == 0 ||
+               strcmp(ds->phase, "async") == 0 ||
+               strcmp(ds->phase, "error") == 0) {
+      bb_state_dispatch_simple(BB_EVT_WORKER_BUSY_CLEAR);
     }
     return;
   }

--- a/firmware/src/bb_state.c
+++ b/firmware/src/bb_state.c
@@ -101,6 +101,9 @@ static const char* k_event_names[BB_EVT__COUNT] = {
   [BB_EVT_DRIVER_NAME_UPDATE]     = "DRV_NAME",
   [BB_EVT_FORCE_AGENT_STATE]      = "FORCE_AGENT",
   [BB_EVT_FORCE_PTT_PHASE]        = "FORCE_PTT",
+  [BB_EVT_WORKER_BUSY_SET]        = "WORKER_BUSY_SET",
+  [BB_EVT_WORKER_BUSY_CLEAR]      = "WORKER_BUSY_CLR",
+  [BB_EVT_WORKER_BUSY_TIMEOUT]    = "WORKER_BUSY_TO",
   [BB_EVT_LVGL_LOCK_TIMEOUT]      = "LVGL_TO",
   [BB_EVT_DIZZY_TIMEOUT]          = "DIZZY_TO",
 };
@@ -146,9 +149,17 @@ static bb_state_listener_t s_listeners[BB_STATE_LISTENER_MAX];
 static int s_listener_count = 0;
 
 static esp_timer_handle_t s_dizzy_timer = NULL;
+static esp_timer_handle_t s_worker_busy_timer = NULL;
+
+/* Worker busy 超时兜底：超过此时间未收到 clear 事件则自动清除 */
+#define BB_WORKER_BUSY_TIMEOUT_MS 120000
 
 static void dizzy_timer_cb(void* arg) {
   bb_state_dispatch_simple(BB_EVT_DIZZY_TIMEOUT);
+}
+
+static void worker_busy_timer_cb(void* arg) {
+  bb_state_dispatch_simple(BB_EVT_WORKER_BUSY_TIMEOUT);
 }
 
 /* ================ 不变量检查 ================ */
@@ -453,6 +464,23 @@ static void apply_side_effects(bb_state_t* st, const bb_event_payload_t* evt) {
       st->lvgl_lock_failures++;
       break;
 
+    case BB_EVT_WORKER_BUSY_SET:
+      st->worker_busy = true;
+      /* 超时兜底：120s 未收到 clear 则自动清除 */
+      st->worker_busy_until_ms = (uint64_t)bb_now_ms() + BB_WORKER_BUSY_TIMEOUT_MS;
+      ESP_LOGI(TAG, "worker_busy=1 until_ms=%" PRIu64, st->worker_busy_until_ms);
+      break;
+
+    case BB_EVT_WORKER_BUSY_CLEAR:
+    case BB_EVT_WORKER_BUSY_TIMEOUT:
+      if (st->worker_busy) {
+        ESP_LOGI(TAG, "worker_busy=0 reason=%s",
+                 evt->type == BB_EVT_WORKER_BUSY_TIMEOUT ? "timeout" : "clear");
+      }
+      st->worker_busy = false;
+      st->worker_busy_until_ms = 0;
+      break;
+
     case BB_EVT_ASR_RESULT:
       /* PTT 流结束 + ASR 完成；agent_in_flight 已在 send_message 时置位 */
       break;
@@ -469,6 +497,10 @@ static const char* should_drop(const bb_state_t* st, const bb_event_payload_t* e
   /* PTT_DOWN 在 SETTINGS 页：永远丢弃 */
   if (evt->type == BB_EVT_PTT_DOWN && st->page == BB_PAGE_SETTINGS) {
     return "page_settings";
+  }
+  /* PTT_DOWN 在 worker_busy 红态：忽略，避免抢话 */
+  if (evt->type == BB_EVT_PTT_DOWN && st->worker_busy) {
+    return "worker_busy";
   }
   /* PTT_DOWN 在 CHAT 但 net offline：丢弃 */
   if (evt->type == BB_EVT_PTT_DOWN && st->page == BB_PAGE_CHAT &&
@@ -501,6 +533,11 @@ static const char* should_drop(const bb_state_t* st, const bb_event_payload_t* e
    * 的 race）则丢弃。 */
   if (evt->type == BB_EVT_DIZZY_TIMEOUT && st->agent != BB_AGENT_STATE_DIZZY) {
     return "dizzy_timeout_stale";
+  }
+
+  /* WORKER_BUSY_TIMEOUT：只在 worker_busy=true 时有意义；若已 clear 则丢弃 */
+  if (evt->type == BB_EVT_WORKER_BUSY_TIMEOUT && !st->worker_busy) {
+    return "worker_busy_timeout_stale";
   }
 
   return NULL;
@@ -565,6 +602,18 @@ static void dispatch_on_lvgl(void* user_data) {
                            (uint64_t)BB_DIZZY_TIMEOUT_MS * 1000);
     } else if (was_dizzy) {
       esp_timer_stop(s_dizzy_timer);
+    }
+  }
+
+  /* 3d) worker_busy 进入/离开时启停超时兜底 timer */
+  if (s_worker_busy_timer != NULL) {
+    bool was_busy = prev.worker_busy;
+    bool is_busy  = next.worker_busy;
+    if (is_busy && !was_busy) {
+      esp_timer_start_once(s_worker_busy_timer,
+                           (uint64_t)BB_WORKER_BUSY_TIMEOUT_MS * 1000);
+    } else if (!is_busy && was_busy) {
+      esp_timer_stop(s_worker_busy_timer);
     }
   }
 
@@ -679,6 +728,8 @@ void bb_state_init(void) {
   s_state.tts_in_flight = false;
   s_state.agent_in_flight = false;
   s_state.adapter_offline = false;
+  s_state.worker_busy = false;
+  s_state.worker_busy_until_ms = 0;
   s_state.lvgl_lock_failures = 0;
   s_state.dropped_events = 0;
 
@@ -695,6 +746,18 @@ void bb_state_init(void) {
   if (esp_timer_create(&dizzy_args, &s_dizzy_timer) != ESP_OK) {
     ESP_LOGE(TAG, "init: failed to create dizzy timer");
     s_dizzy_timer = NULL;
+  }
+
+  /* Worker busy 超时兜底 timer */
+  esp_timer_create_args_t worker_busy_args = {
+    .callback = worker_busy_timer_cb,
+    .arg = NULL,
+    .dispatch_method = ESP_TIMER_TASK,
+    .name = "bb_state_worker_busy",
+  };
+  if (esp_timer_create(&worker_busy_args, &s_worker_busy_timer) != ESP_OK) {
+    ESP_LOGE(TAG, "init: failed to create worker_busy timer");
+    s_worker_busy_timer = NULL;
   }
 
   ESP_LOGI(TAG, "init: page=%s agent=%s net=%s transport=%s",


### PR DESCRIPTION
Fixes #166

## 变更说明

### 颜色语义（优先级从高到低）

| 优先级 | 状态 | LED 表现 |
|--------|------|----------|
| 1 | DIZZY / 错误 | 红色快闪 1000ms |
| 2 | 离线 / adapter 失联 | 橙色呼吸 |
| 3 | 倾听中（PTT 按住） | 蓝色常亮 |
| **4** | **Worker 长任务派发中** | **红色呼吸 1500ms（新增）** |
| 5 | AI 思考 / BUSY | 青色脉动（保留，不和蓝撞色） |
| 6 | TTS 播报 | 青绿呼吸 |
| 7 | 空闲 | 绿色慢呼吸 |

### 信号链路

adapter 下发 `dispatch_status` 事件 → 固件 `on_finish_stream_event` / `on_finish_stream_event_tts_only` → `BB_EVT_WORKER_BUSY_SET/CLEAR` → `bb_state.worker_busy` → `compose_from_state()` 红色呼吸

### PTT 门控

`should_drop()` 在 `worker_busy=true` 时软忽略 PTT_DOWN（记 drop reason=worker_busy），不断开硬件中断，方便调试。

### 超时兜底

新增 120s 超时 timer（`bb_state_worker_busy`），防止 done/error 事件丢失时红灯卡死。

### 覆盖范围

- Local 模式（`on_finish_stream_event`）✅
- Cloud SaaS 模式（`on_finish_stream_event_tts_only`）✅
- 板级：WS2812（bbclaw 板）和 3-line PWM 回退路径均通过同一 `output_rgb()` 入口 ✅

## 测试

- 固件编译通过（ESP-IDF 5.5，ESP32-S3，bin size 0x243080 bytes，10% 余量）
- `go build ./...` adapter 编译通过
- 运行时验证需要硬件（串口）+ adapter dispatch 触发，无法在本地自动完成，请 owner 在设备上确认红灯切换