### PR TITLE
fix: TTS 播报期间字幕逐段更新，TTS 结束后保留再清除

### DIFF
--- a/adapter/internal/httpapi/server.go
+++ b/adapter/internal/httpapi/server.go
@@ -766,6 +766,9 @@ type ttsSynthesizeRequest struct {
 	Codec      string `json:"codec,omitempty"`
 	SampleRate int    `json:"sampleRate,omitempty"`
 	Channels   int    `json:"channels,omitempty"`
+	// Issue #169: optional segment index sent by firmware tts_playback_task so
+	// adapter logs can correlate each synth call with its subtitle cutover time.
+	SegIdx int `json:"segIdx,omitempty"`
 }
 
 func (s *Server) handleTTSSynthesize(w http.ResponseWriter, r *http.Request) {
@@ -791,6 +794,11 @@ func (s *Server) handleTTSSynthesize(w http.ResponseWriter, r *http.Request) {
 	tTTS := time.Now()
 	textChars := utf8.RuneCountInString(cleanText)
 	s.log.Infof("phase=tts_start elapsed_s=0 text_chars=%d raw_chars=%d", textChars, rawChars)
+	// Issue #169: structured per-segment log so adapter logs can be correlated
+	// with firmware subtitle cutover timestamps (firmware logs tts_subtitle:
+	// seg_idx=N wall_ms=M just before posting to the subtitle bar).
+	s.log.Infof("phase=tts_synth_seg seg_idx=%d text_len=%d wall_ms=%d",
+		req.SegIdx, textChars, time.Now().UnixMilli())
 	audioBytes, err := s.tts.Synthesize(r.Context(), cleanText)
 	if err != nil {
 		s.metrics.Inc("tts_failed")

--- a/firmware/include/bb_adapter_client.h
+++ b/firmware/include/bb_adapter_client.h
@@ -103,7 +103,7 @@ esp_err_t bb_adapter_stream_finish(const bb_stream_ctx_t* ctx, bb_finish_result_
 esp_err_t bb_adapter_stream_finish_stream(const bb_stream_ctx_t* ctx, bb_finish_result_t* out_result,
                                           bb_finish_stream_event_cb_t on_event, void* user_ctx);
 esp_err_t bb_adapter_voice_verify_pcm16(const uint8_t* pcm, size_t pcm_len, bb_voice_verify_result_t* out_result);
-esp_err_t bb_adapter_tts_synthesize_pcm16(const char* text, bb_tts_audio_t* out_audio);
+esp_err_t bb_adapter_tts_synthesize_pcm16(const char* text, bb_tts_audio_t* out_audio, int seg_idx);
 void bb_adapter_tts_audio_free(bb_tts_audio_t* audio);
 void bb_adapter_tts_chunks_free(bb_tts_chunk_t* head);
 esp_err_t bb_adapter_display_pull(bb_display_task_t* out_task);

--- a/firmware/include/bb_chat_transcript.h
+++ b/firmware/include/bb_chat_transcript.h
@@ -70,3 +70,20 @@ void bb_chat_transcript_clear(void);
  * `lines` follows bb_chat_transcript_scroll: <0 = up, >0 = down. */
 void bb_chat_scroll_worker_init(void);
 void bb_chat_scroll_request(int lines);
+
+/* Issue #169 — TTS subtitle bar.
+ *
+ * A fixed-height label overlaid on the transcript area that shows the
+ * current TTS segment being spoken.  Independent of the scrollable bubble
+ * history — the history stays intact while the subtitle reflects the live
+ * playback position.
+ *
+ * set_subtitle: replace the subtitle text with `text` and make it visible.
+ *               `text` is copied; caller may free/reuse after the call.
+ * clear_subtitle: hide the subtitle bar (called when TTS finishes or is
+ *               cancelled, after the N-second hold timeout).
+ *
+ * Both functions must be called from the LVGL task (via lv_async_call from
+ * worker tasks). */
+void bb_chat_transcript_set_subtitle(const char* text);
+void bb_chat_transcript_clear_subtitle(void);

--- a/firmware/src/bb_adapter_client.c
+++ b/firmware/src/bb_adapter_client.c
@@ -2124,7 +2124,7 @@ static char* tts_sanitize_alloc(const char* in) {
   return out;
 }
 
-esp_err_t bb_adapter_tts_synthesize_pcm16(const char* text, bb_tts_audio_t* out_audio) {
+esp_err_t bb_adapter_tts_synthesize_pcm16(const char* text, bb_tts_audio_t* out_audio, int seg_idx) {
   if (text == NULL || out_audio == NULL) {
     return ESP_ERR_INVALID_ARG;
   }
@@ -2151,9 +2151,11 @@ esp_err_t bb_adapter_tts_synthesize_pcm16(const char* text, bb_tts_audio_t* out_
     free(escaped);
     return ESP_ERR_NO_MEM;
   }
+  /* Issue #169: include segIdx so adapter logs can correlate each synth
+   * call with the firmware subtitle cutover timestamp. */
   snprintf(body, body_cap,
-           "{\"text\":\"%s\",\"codec\":\"pcm16\",\"sampleRate\":%d,\"channels\":%d,\"deviceId\":\"%s\"}",
-           escaped, BBCLAW_TTS_SAMPLE_RATE, BBCLAW_TTS_CHANNELS, BBCLAW_DEVICE_ID);
+           "{\"text\":\"%s\",\"codec\":\"pcm16\",\"sampleRate\":%d,\"channels\":%d,\"deviceId\":\"%s\",\"segIdx\":%d}",
+           escaped, BBCLAW_TTS_SAMPLE_RATE, BBCLAW_TTS_CHANNELS, BBCLAW_DEVICE_ID, seg_idx);
   free(escaped);
 
   bb_http_dyn_resp_t resp = {0};

--- a/firmware/src/bb_chat_transcript.c
+++ b/firmware/src/bb_chat_transcript.c
@@ -42,6 +42,15 @@ extern const lv_font_t lv_font_bbclaw_cjk;
 
 static lv_obj_t* s_transcript;
 static lv_obj_t* s_active_assistant;  /* current streaming bubble, NULL after finalize */
+/* Issue #169 — TTS subtitle bar. Overlay label sitting just above (or over)
+ * the transcript area; created lazily on first set_subtitle call.
+ * Positioned at the bottom of the transcript zone so it doesn't obscure
+ * ongoing history while still being prominent during playback. */
+static lv_obj_t* s_subtitle_label;    /* NULL until first set_subtitle */
+/* Transcript geometry captured at create time for subtitle positioning. */
+static lv_obj_t* s_transcript_parent;
+static int       s_transcript_y;
+static int       s_transcript_h;
 
 /* Last-seen timestamp for history replay, used to detect segment gaps.
  * Tracks the most-recently appended message; reset to 0 on transcript clear. */
@@ -142,6 +151,10 @@ static void follow_tail_if_active(void) {
 lv_obj_t* bb_chat_transcript_create(lv_obj_t* parent, int width, int height_px,
                                     int y_offset) {
   if (parent == NULL || s_transcript != NULL) return s_transcript;
+  /* Capture geometry for lazy subtitle creation (Issue #169). */
+  s_transcript_parent = parent;
+  s_transcript_y      = y_offset;
+  s_transcript_h      = height_px;
 
   s_transcript = lv_obj_create(parent);
   lv_obj_remove_style_all(s_transcript);
@@ -160,6 +173,7 @@ lv_obj_t* bb_chat_transcript_create(lv_obj_t* parent, int width, int height_px,
   lv_obj_set_scrollbar_mode(s_transcript, LV_SCROLLBAR_MODE_AUTO);
 
   s_active_assistant = NULL;
+  s_subtitle_label = NULL;
   /* Fresh transcript starts in follow mode. */
   s_follow_tail = 1;
   return s_transcript;
@@ -170,6 +184,10 @@ void bb_chat_transcript_destroy(void) {
    * so do NOT lv_obj_del(s_transcript) here — it would double-free. */
   s_transcript = NULL;
   s_active_assistant = NULL;
+  s_subtitle_label = NULL;
+  s_transcript_parent = NULL;
+  s_transcript_y = 0;
+  s_transcript_h = 0;
   s_follow_tail = 1;
 }
 
@@ -369,4 +387,62 @@ void bb_chat_transcript_clear(void) {
 void bb_chat_transcript_finalize_assistant(void) {
   s_active_assistant = NULL;
   bb_chat_cache_finalize_assistant();
+}
+
+/* ── Issue #169 — TTS subtitle bar ─────────────────────────────────────────
+ *
+ * The subtitle label is a child of the transcript's *parent* (the same
+ * parent passed to bb_chat_transcript_create), not a child of the scrollable
+ * transcript container.  That way it floats at a fixed position regardless of
+ * scroll state and does not participate in the flex-column layout that causes
+ * lv_label_ins_text / scroll-to-view to reflow the whole bubble list.
+ *
+ * Visual design (1.47" 172×320):
+ *   - bottom of the transcript zone = y_offset + transcript_h − subtitle_h
+ *   - full width minus the standard horizontal margin
+ *   - semi-transparent ghost surface background (same token as assistant
+ *     bubbles) so it reads as a card floating over the history
+ *   - single-line DOT mode to avoid reflow hang (same rule as bubble labels)
+ *   - hidden by default; bb_chat_transcript_set_subtitle shows it
+ *
+ * s_transcript_parent / s_transcript_y / s_transcript_h are declared at the
+ * top of the file alongside the other statics. */
+
+#define SUBTITLE_H       20   /* px — one line of text + MSG_PAD*2 */
+#define SUBTITLE_Y_ABOVE 0    /* offset above transcript bottom edge */
+
+static void ensure_subtitle_created(void) {
+  if (s_subtitle_label != NULL) return;
+  if (s_transcript_parent == NULL) return;
+
+  s_subtitle_label = lv_label_create(s_transcript_parent);
+  lv_label_set_long_mode(s_subtitle_label, LV_LABEL_LONG_MODE_DOTS);
+  lv_obj_set_size(s_subtitle_label, 320 - 2 * MSG_HMARGIN, SUBTITLE_H);
+  /* Anchor to bottom of transcript zone */
+  int y = s_transcript_y + s_transcript_h - SUBTITLE_H - SUBTITLE_Y_ABOVE;
+  lv_obj_set_pos(s_subtitle_label, MSG_HMARGIN, y);
+  lv_obj_set_style_text_font(s_subtitle_label, font(), 0);
+  lv_obj_set_style_text_color(s_subtitle_label, lv_color_hex(UI_TEXT_MAIN), 0);
+  lv_obj_set_style_text_align(s_subtitle_label, LV_TEXT_ALIGN_LEFT, 0);
+  lv_obj_set_style_bg_color(s_subtitle_label, lv_color_hex(UI_AI_SURFACE), 0);
+  lv_obj_set_style_bg_opa(s_subtitle_label, LV_OPA_COVER, 0);
+  lv_obj_set_style_radius(s_subtitle_label, MSG_RADIUS, 0);
+  lv_obj_set_style_pad_all(s_subtitle_label, MSG_PAD, 0);
+  /* Start hidden */
+  lv_obj_add_flag(s_subtitle_label, LV_OBJ_FLAG_HIDDEN);
+  /* Float above the transcript scrollable area */
+  lv_obj_move_foreground(s_subtitle_label);
+}
+
+void bb_chat_transcript_set_subtitle(const char* text) {
+  ensure_subtitle_created();
+  if (s_subtitle_label == NULL) return;
+  lv_label_set_text(s_subtitle_label, text != NULL ? text : "");
+  lv_obj_clear_flag(s_subtitle_label, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_move_foreground(s_subtitle_label);
+}
+
+void bb_chat_transcript_clear_subtitle(void) {
+  if (s_subtitle_label == NULL) return;
+  lv_obj_add_flag(s_subtitle_label, LV_OBJ_FLAG_HIDDEN);
 }

--- a/firmware/src/bb_ui_agent_chat.c
+++ b/firmware/src/bb_ui_agent_chat.c
@@ -119,6 +119,11 @@ static inline lv_result_t safe_lv_async_call(lv_async_cb_t cb, void* user_data) 
 #define BB_CHAT_AGENT_TASK_STACK 6144
 #define BB_CHAT_AGENT_TASK_PRIO  5
 #define BB_CHAT_HEART_THRESHOLD_MS 5000
+/* Issue #169 — how long (ms) to keep the last subtitle segment visible after
+ * TTS playback finishes before fading/hiding the subtitle bar.
+ * 2 seconds gives the user time to read the last segment without it
+ * disappearing the instant the audio ends. */
+#define BB_CHAT_SUBTITLE_HOLD_MS   2000
 
 /*
  * 屏幕静态状态。所有 LVGL 操作都必须在 LVGL 任务里完成；
@@ -303,6 +308,8 @@ typedef enum {
   BB_ASYNC_APPEND_ERROR,
   BB_ASYNC_SET_DRIVER,
   BB_ASYNC_SET_SESSION,
+  BB_ASYNC_SET_SUBTITLE,   /* Issue #169: push TTS segment to subtitle bar */
+  BB_ASYNC_CLEAR_SUBTITLE, /* Issue #169: hide subtitle bar after TTS done */
 } bb_async_kind_t;
 
 typedef struct {
@@ -403,6 +410,14 @@ static void on_lvgl_dispatch(void* user_data) {
       break;
     case BB_ASYNC_SET_SESSION:
       if (theme->set_session != NULL) theme->set_session(p->s1 != NULL ? p->s1 : "");
+      break;
+    case BB_ASYNC_SET_SUBTITLE:
+      /* Issue #169: update subtitle bar with current TTS segment text. */
+      bb_chat_transcript_set_subtitle(p->s1 != NULL ? p->s1 : "");
+      break;
+    case BB_ASYNC_CLEAR_SUBTITLE:
+      /* Issue #169: hide subtitle bar after TTS playback ends. */
+      bb_chat_transcript_clear_subtitle();
       break;
   }
   free(p->s1);
@@ -515,6 +530,22 @@ static void post_session(const char* sid_short) {
   bb_async_payload_t* p = async_alloc(BB_ASYNC_SET_SESSION);
   if (p == NULL) return;
   p->s1 = dup_str(sid_short);
+  async_post(p);
+}
+
+/* Issue #169 — TTS subtitle helpers.
+ * post_subtitle: push current segment text to the subtitle bar (LVGL task).
+ * post_clear_subtitle: hide the bar (called after TTS done + hold delay). */
+static void post_subtitle(const char* text) {
+  bb_async_payload_t* p = async_alloc(BB_ASYNC_SET_SUBTITLE);
+  if (p == NULL) return;
+  p->s1 = dup_str(text);
+  async_post(p);
+}
+
+static void post_clear_subtitle(void) {
+  bb_async_payload_t* p = async_alloc(BB_ASYNC_CLEAR_SUBTITLE);
+  if (p == NULL) return;
   async_post(p);
 }
 
@@ -1065,11 +1096,11 @@ static int tts_should_abort(void) {
 /* Synth + play a single chunk. Returns ESP_OK on a clean play, otherwise the
  * caller should treat as "skip and continue" (typically an interrupt or
  * synth failure — neither is fatal to the loop). */
-static esp_err_t tts_synth_and_play(const char* text) {
+static esp_err_t tts_synth_and_play(const char* text, int seg_idx) {
   if (text == NULL || text[0] == '\0') return ESP_OK;
-  ESP_LOGI(TAG, "tts: synth start len=%u", (unsigned)strlen(text));
+  ESP_LOGI(TAG, "tts: synth start len=%u seg_idx=%d", (unsigned)strlen(text), seg_idx);
   bb_tts_audio_t audio = {0};
-  esp_err_t syn = bb_adapter_tts_synthesize_pcm16(text, &audio);
+  esp_err_t syn = bb_adapter_tts_synthesize_pcm16(text, &audio, seg_idx);
   if (syn != ESP_OK || audio.pcm_data == NULL || audio.pcm_len == 0U) {
     ESP_LOGW(TAG, "tts: synth failed err=%s pcm=%p len=%u", esp_err_to_name(syn),
              (void*)audio.pcm_data, (unsigned)audio.pcm_len);
@@ -1117,6 +1148,8 @@ static void tts_playback_task(void* arg) {
    * have posted milliseconds earlier). */
   post_state(BB_AGENT_STATE_SPEAKING);
 
+  int seg_idx = 0;  /* Issue #169: subtitle segment counter for logging */
+
   /* Outer loop: drain reply_buf one sentence at a time. */
   while (!tts_should_abort()) {
     int turn_done = s_chat.reply_turn_complete ? 1 : 0;
@@ -1132,8 +1165,16 @@ static void tts_playback_task(void* arg) {
       vTaskDelay(pdMS_TO_TICKS(80));
       continue;
     }
-    esp_err_t err = tts_synth_and_play(chunk);
+    /* Issue #169: push subtitle before synthesis so the screen updates
+     * immediately when this segment starts, not after the blocking synth
+     * call returns. safe_lv_async_call has a 200 ms lock timeout; the
+     * segment text is heap-dup'd inside post_subtitle. */
+    post_subtitle(chunk);
+    ESP_LOGI(TAG, "tts_subtitle: seg_idx=%d text_len=%u wall_ms=%lld",
+             seg_idx, (unsigned)strlen(chunk), (long long)bb_now_ms());
+    esp_err_t err = tts_synth_and_play(chunk, seg_idx);
     free(chunk);
+    seg_idx++;
     if (err == ESP_ERR_INVALID_STATE) {
       /* Aborted mid-flight. Don't try the next sentence. */
       break;
@@ -1141,6 +1182,15 @@ static void tts_playback_task(void* arg) {
     /* ESP_FAIL / synth-fail: drop this sentence, keep going (next sentence
      * may still be useful). */
   }
+  /* Issue #169: subtitle hold — keep the last segment visible for
+   * BB_CHAT_SUBTITLE_HOLD_MS after TTS finishes, then clear.
+   * Skip the hold when cancelled (user interrupted) so the subtitle
+   * doesn't linger over the IDLE/HEART state that follows immediately. */
+  if (!s_chat.tts_cancel_requested && seg_idx > 0) {
+    vTaskDelay(pdMS_TO_TICKS(BB_CHAT_SUBTITLE_HOLD_MS));
+  }
+  post_clear_subtitle();
+
   /* Phase 4.8.x: TTS done — transition out of SPEAKING. Pick HEART if the
    * end-to-end turn was fast (< BB_CHAT_HEART_THRESHOLD_MS), otherwise
    * IDLE. We can't tell from inside the TTS task whether EvTurnEnd already
@@ -1158,9 +1208,10 @@ static void tts_playback_task(void* arg) {
   /* Phase 4.9: 通知 bb_state TTS 已完成或被取消，清掉 tts_in_flight */
   bb_state_dispatch_simple(s_chat.tts_cancel_requested ? BB_EVT_TTS_CANCELLED
                                                        : BB_EVT_TTS_DONE);
-  ESP_LOGI(TAG, "tts: streaming task done (cancel=%d turn=%d) → IDLE/HEART",
+  ESP_LOGI(TAG, "tts: streaming task done (cancel=%d turn=%d segs=%d) → IDLE/HEART",
            s_chat.tts_cancel_requested ? 1 : 0,
-           s_chat.reply_turn_complete ? 1 : 0);
+           s_chat.reply_turn_complete ? 1 : 0,
+           seg_idx);
   s_chat.tts_task = NULL;
   vTaskDelete(NULL);
 }
@@ -1203,6 +1254,9 @@ static void tts_cancel_in_flight(void) {
   if (s_chat.tts_task != NULL) {
     ESP_LOGW(TAG, "tts: cancel timeout, in-flight task still alive (will exit lazily)");
   }
+  /* Issue #169: on cancel, clear subtitle immediately so it doesn't linger
+   * while the new turn's BUSY/LISTENING state is displayed. */
+  post_clear_subtitle();
 }
 
 /* Phase 4.9: bb_state subscriber — buddy 主题的 SSoT 驱动入口。


### PR DESCRIPTION
Fixes #169

## 改动说明

### 问题
TTS 播报长回复时，固件屏幕字幕停留在播报开始时的完整文本（或更早的气泡内容），没有随音频进度逐段切换。

### 根因
`tts_playback_task` 在每次 `tts_synth_and_play(chunk)` 之前没有更新屏幕字幕。屏幕上显示的是 `append_assistant_chunk` 流式积累的全量文本，与当前正在播放的段落完全脱节。

### 解决方案（最小改动）

**字幕条（subtitle bar）**：在 `bb_chat_transcript.c` 新增一个固定在 transcript 区域底部的 overlay label。它是 transcript `parent` 的子节点（不在可滚动 flex 列里），因此：
- 不参与气泡历史的 flex 布局，不触发 LVGL reflow 挂死
- 不影响聊天历史气泡的显示和滚动
- 随时可独立更新/隐藏

**逐段推送**：`tts_playback_task` 在每次 `tts_synth_and_play` 之前先调 `post_subtitle(chunk)`，通过 `lv_async_call` 切到 LVGL 任务更新字幕。播放是阻塞的（`bb_audio_play_pcm_blocking`），所以字幕更新时机 ≈ 该段开始播放时刻，与音频基本同步。

**TTS 结束保留**：播放完所有段后延迟 2 s（`BB_CHAT_SUBTITLE_HOLD_MS`）再隐藏字幕，让用户有时间读完最后一段。取消（`tts_cancel_in_flight`）时立即清除。

**Adapter 日志埋点**：`handleTTSSynthesize` 新增 `phase=tts_synth_seg seg_idx=N text_len=L wall_ms=M` 日志行，固件侧也记录 `tts_subtitle: seg_idx=N wall_ms=M`，两者可对账同步偏差。

### 文件变动
- `firmware/src/bb_chat_transcript.c` — 新增 subtitle bar 静态变量、`ensure_subtitle_created()`、`bb_chat_transcript_set_subtitle()`、`bb_chat_transcript_clear_subtitle()`；`create` 时捕获几何参数；`destroy` 时重置所有新增指针
- `firmware/include/bb_chat_transcript.h` — 导出两个新接口
- `firmware/src/bb_ui_agent_chat.c` — `tts_playback_task` 加字幕推送 + 结束延迟清除；新增 `BB_ASYNC_SET_SUBTITLE` / `BB_ASYNC_CLEAR_SUBTITLE` async kind；`tts_cancel_in_flight` 取消时立即清除字幕；`tts_synth_and_play` 接受 `seg_idx` 并传给底层
- `firmware/include/bb_adapter_client.h` + `firmware/src/bb_adapter_client.c` — `bb_adapter_tts_synthesize_pcm16` 新增 `seg_idx` 参数写入请求 JSON
- `adapter/internal/httpapi/server.go` — `ttsSynthesizeRequest` 新增 `SegIdx`；新增 `phase=tts_synth_seg` 日志

### 测试
- adapter: `go test ./...` 全部通过
- firmware: `make build` 编译成功，binary 10% free（172×320 ESP32-S3 target）
- 硬件验证需要串口设备（ESP32-S3 + 1.47" 屏），已在 PR 说明中注明

### 未测试项（需硬件验证）
- 实际字幕与音频的感知延迟（I2S DMA 缓冲约几十 ms，预计在人耳可接受范围内）
- 字幕条在极短段落（1～2 字）时的视觉效果
- 字幕条与 SPEAKING 状态顶栏图标在 1.47" 屏实际尺寸下的遮挡情况