### PR TITLE
feat: 设备断网后支持定期轮询自动重连

### DIFF
--- a/firmware/include/bb_config.h
+++ b/firmware/include/bb_config.h
@@ -58,6 +58,30 @@
 #define BBCLAW_WIFI_STA_MAX_RETRY 2
 #endif
 
+/* ── 运行期自动重连（issue #170）──────────────────────────────────────────
+ * 设备在 STA 已连接状态下掉线后，先做 BBCLAW_WIFI_STA_MAX_RETRY 次快速重试
+ * （在事件回调里直接调 esp_wifi_connect()），耗尽后进入指数退避 backoff timer：
+ *   5s → 10s → 30s → 60s → 300s（封顶），持续重试直到 IP 取到为止。
+ * 只在运行期掉线时激活；首次启动失败后走原有逻辑（遍历 SSID → 进 AP 配网）。 */
+
+/* 退避起始间隔（毫秒） */
+#ifndef BBCLAW_WIFI_RECONNECT_BACKOFF_MIN_MS
+#ifdef CONFIG_BBCLAW_WIFI_RECONNECT_BACKOFF_MIN_MS
+#define BBCLAW_WIFI_RECONNECT_BACKOFF_MIN_MS CONFIG_BBCLAW_WIFI_RECONNECT_BACKOFF_MIN_MS
+#else
+#define BBCLAW_WIFI_RECONNECT_BACKOFF_MIN_MS 5000U
+#endif
+#endif
+
+/* 退避上限（毫秒） */
+#ifndef BBCLAW_WIFI_RECONNECT_BACKOFF_MAX_MS
+#ifdef CONFIG_BBCLAW_WIFI_RECONNECT_BACKOFF_MAX_MS
+#define BBCLAW_WIFI_RECONNECT_BACKOFF_MAX_MS CONFIG_BBCLAW_WIFI_RECONNECT_BACKOFF_MAX_MS
+#else
+#define BBCLAW_WIFI_RECONNECT_BACKOFF_MAX_MS 300000U
+#endif
+#endif
+
 #ifndef BBCLAW_WIFI_STA_CONNECT_TIMEOUT_MS
 #define BBCLAW_WIFI_STA_CONNECT_TIMEOUT_MS 30000
 #endif

--- a/firmware/include/bb_wifi.h
+++ b/firmware/include/bb_wifi.h
@@ -6,6 +6,7 @@ typedef enum {
   BB_WIFI_MODE_NONE = 0,
   BB_WIFI_MODE_STA_CONNECTED = 1,
   BB_WIFI_MODE_AP_PROVISIONING = 2,
+  BB_WIFI_MODE_STA_RECONNECTING = 3, /**< 运行期掉线，指数退避自动重连中 */
 } bb_wifi_mode_t;
 
 esp_err_t bb_wifi_init_and_connect(void);

--- a/firmware/src/Kconfig.projbuild
+++ b/firmware/src/Kconfig.projbuild
@@ -103,6 +103,23 @@ config BBCLAW_WIFI_PASSWORD
         Optional compile-time fallback Wi-Fi password paired with Default
         Wi-Fi SSID.
 
+config BBCLAW_WIFI_RECONNECT_BACKOFF_MIN_MS
+    int "Auto-reconnect initial backoff interval (ms)"
+    default 5000
+    range 1000 60000
+    help
+        When the device loses Wi-Fi during runtime, it will attempt to
+        reconnect using an exponential backoff timer. This sets the first
+        retry interval in milliseconds (default: 5000 ms = 5 s).
+
+config BBCLAW_WIFI_RECONNECT_BACKOFF_MAX_MS
+    int "Auto-reconnect maximum backoff interval (ms)"
+    default 300000
+    range 10000 3600000
+    help
+        Maximum backoff interval for the exponential backoff reconnect
+        timer in milliseconds (default: 300000 ms = 5 min).
+
 endmenu
 
 endmenu

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -2953,6 +2953,16 @@ static void stream_task(void* arg) {
         continue;
       }
 
+      /* 运行期 Wi-Fi 自动重连中（issue #170）：显示 RECONNECTING 状态，
+       * 暂停 transport heartbeat，等待 IP 恢复后由 BB_EVT_NET_UP 路径接管。 */
+      if (bb_wifi_get_mode() == BB_WIFI_MODE_STA_RECONNECTING) {
+        show_status_error("RECONNECTING");
+        s_transport_health_ok = 0;
+        adapter_health_is_up = 0;
+        vTaskDelay(pdMS_TO_TICKS(1000));
+        continue;
+      }
+
       int64_t now_ms = bb_now_ms();
       if (now_ms - last_adapter_heartbeat_ms >= adapter_heartbeat_interval_ms) {
         int health_status = 0;

--- a/firmware/src/bb_wifi.c
+++ b/firmware/src/bb_wifi.c
@@ -15,10 +15,12 @@
 #include "esp_mac.h"
 #include "esp_netif.h"
 #include "esp_system.h"
+#include "esp_timer.h"
 #include "esp_wifi.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 #include "freertos/task.h"
+#include "freertos/timers.h"
 #include "lwip/ip4_addr.h"
 #include "lwip/sockets.h"
 #include "nvs.h"
@@ -44,6 +46,12 @@ static char s_active_ssid[sizeof(((wifi_sta_config_t*)0)->ssid)] = {0};
 static char s_ap_ssid[sizeof(((wifi_ap_config_t*)0)->ssid)] = {0};
 static char s_ap_password[sizeof(((wifi_ap_config_t*)0)->password)] = BBCLAW_WIFI_AP_PASSWORD;
 static char s_ap_ip[16] = "192.168.4.1";
+
+/* ── 运行期自动重连状态（issue #170）── */
+static TimerHandle_t s_reconnect_timer;
+static uint32_t s_reconnect_backoff_ms;
+static int s_reconnect_attempt;   /* 自动重连累计尝试次数（快速重试 + backoff 合计） */
+static int64_t s_reconnect_start_ms; /* 开始自动重连的时间戳（esp_timer_get_time() / 1000） */
 
 static void on_wifi_event(void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data);
 
@@ -299,6 +307,70 @@ static esp_err_t save_sta_credentials(const char* ssid, const char* password) {
     return ESP_ERR_NO_MEM; /* all slots full */
   }
   return save_wifi_slot(slot, ssid, password);
+}
+
+/* ── 运行期自动重连辅助函数（issue #170）──────────────────────────────── */
+
+/* 计算下一档退避值（当前值 ×3，封顶 MAX）。
+ * 自然序列（从 MIN=5000ms 开始）：5s→15s→45s→135s→300s（封顶）。 */
+static uint32_t reconnect_next_backoff(uint32_t cur_ms) {
+  if (cur_ms == 0U) {
+    return BBCLAW_WIFI_RECONNECT_BACKOFF_MIN_MS;
+  }
+  uint32_t next = cur_ms * 3U;
+  if (next > BBCLAW_WIFI_RECONNECT_BACKOFF_MAX_MS || next < cur_ms /* overflow */) {
+    next = BBCLAW_WIFI_RECONNECT_BACKOFF_MAX_MS;
+  }
+  return next;
+}
+
+/* FreeRTOS timer 回调：backoff 超时后调一次 esp_wifi_connect()。
+ * 运行在 timer daemon task，不可阻塞。 */
+static void reconnect_timer_cb(TimerHandle_t timer) {
+  (void)timer;
+  s_reconnect_attempt++;
+  ESP_LOGW(TAG, "wifi auto-reconnect attempt=%d backoff_ms=%u ssid=%s",
+           s_reconnect_attempt, (unsigned)s_reconnect_backoff_ms, s_active_ssid);
+  (void)esp_wifi_connect();
+}
+
+/* 启动（或重启）backoff timer。在事件回调中调用，不可阻塞。 */
+static void reconnect_timer_start(void) {
+  if (s_reconnect_timer == NULL) {
+    s_reconnect_timer = xTimerCreate(
+        "wifi_reconnect",
+        pdMS_TO_TICKS(BBCLAW_WIFI_RECONNECT_BACKOFF_MIN_MS),
+        pdFALSE /* one-shot */, NULL, reconnect_timer_cb);
+  }
+  if (s_reconnect_timer == NULL) {
+    /* 极低概率：内存不足，降级直接重试 */
+    ESP_LOGE(TAG, "wifi reconnect timer create failed, retrying immediately");
+    s_reconnect_attempt++;
+    (void)esp_wifi_connect();
+    return;
+  }
+  s_reconnect_backoff_ms = reconnect_next_backoff(s_reconnect_backoff_ms);
+  (void)xTimerChangePeriod(s_reconnect_timer,
+                           pdMS_TO_TICKS(s_reconnect_backoff_ms), 0);
+  (void)xTimerStart(s_reconnect_timer, 0);
+  ESP_LOGW(TAG, "wifi reconnect backoff scheduled backoff_ms=%u ssid=%s",
+           (unsigned)s_reconnect_backoff_ms, s_active_ssid);
+}
+
+/* 停止 backoff timer 并重置所有重连状态。在 IP_EVENT_STA_GOT_IP 时调用。 */
+static void reconnect_timer_stop_and_reset(void) {
+  if (s_reconnect_timer != NULL) {
+    (void)xTimerStop(s_reconnect_timer, 0);
+  }
+  if (s_reconnect_attempt > 0) {
+    int64_t now_ms = (int64_t)(esp_timer_get_time() / 1000LL);
+    int64_t elapsed_ms = now_ms - s_reconnect_start_ms;
+    ESP_LOGI(TAG, "wifi recovered after %d attempts in %lld ms ssid=%s",
+             s_reconnect_attempt, (long long)elapsed_ms, s_active_ssid);
+  }
+  s_reconnect_backoff_ms = 0U;
+  s_reconnect_attempt = 0;
+  s_reconnect_start_ms = 0;
 }
 
 static void restart_task(void* arg) {
@@ -761,6 +833,8 @@ static esp_err_t ensure_wifi_stack_ready(void) {
 static esp_err_t start_sta_connection(const char* ssid, const char* password) {
   s_connected = 0;
   s_retry_num = 0;
+  /* 确保首次启动阶段不会触发运行期 backoff 逻辑 */
+  reconnect_timer_stop_and_reset();
   xEventGroupClearBits(s_wifi_event_group, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
   copy_string(s_active_ssid, sizeof(s_active_ssid), ssid);
 
@@ -856,20 +930,47 @@ static void on_wifi_event(void* arg, esp_event_base_t event_base, int32_t event_
     if (s_mode == BB_WIFI_MODE_AP_PROVISIONING) {
       return;
     }
+
+    /* 首次启动阶段（bb_wifi_init_and_connect 还在等待 event group）：
+     * 走原有快速重试逻辑，耗尽后置 WIFI_FAIL_BIT 让启动流程决策。 */
+    if (s_mode != BB_WIFI_MODE_STA_CONNECTED && s_mode != BB_WIFI_MODE_STA_RECONNECTING) {
+      if (s_retry_num < BBCLAW_WIFI_STA_MAX_RETRY) {
+        s_retry_num++;
+        ESP_LOGW(TAG, "wifi reconnect attempt=%d", s_retry_num);
+        (void)esp_wifi_connect();
+      } else {
+        ESP_LOGW(TAG, "wifi retries exhausted for current ssid=%s", s_active_ssid);
+        xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
+      }
+      return;
+    }
+
+    /* 运行期掉线（曾经已连接）：先用快速重试，耗尽后转 backoff timer。 */
     if (s_retry_num < BBCLAW_WIFI_STA_MAX_RETRY) {
       s_retry_num++;
-      ESP_LOGW(TAG, "wifi reconnect attempt=%d", s_retry_num);
+      ESP_LOGW(TAG, "wifi runtime disconnect fast-retry=%d ssid=%s",
+               s_retry_num, s_active_ssid);
       (void)esp_wifi_connect();
-    } else {
-      ESP_LOGW(TAG, "wifi retries exhausted for current ssid=%s", s_active_ssid);
-      xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
+      return;
     }
+
+    /* 快速重试耗尽，切到 backoff 自动重连模式 */
+    if (s_mode != BB_WIFI_MODE_STA_RECONNECTING) {
+      s_mode = BB_WIFI_MODE_STA_RECONNECTING;
+      s_reconnect_backoff_ms = 0U;
+      s_reconnect_attempt = 0;
+      s_reconnect_start_ms = (int64_t)(esp_timer_get_time() / 1000LL);
+      ESP_LOGW(TAG, "wifi entering backoff reconnect mode ssid=%s", s_active_ssid);
+    }
+    reconnect_timer_start();
     return;
   }
   if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
     const ip_event_got_ip_t* event = (const ip_event_got_ip_t*)event_data;
     s_retry_num = 0;
     s_connected = 1;
+    reconnect_timer_stop_and_reset();
+    s_mode = BB_WIFI_MODE_STA_CONNECTED;
     ESP_LOGI(TAG, "got ip: " IPSTR, IP2STR(&event->ip_info.ip));
     xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
     /* 记住本次成功的 SSID 及时间戳，下次启动按时间倒序优先尝试 */


### PR DESCRIPTION
Fixes #170

## 变更内容

### 问题
Wi-Fi STA 在运行期掉线后，原有代码仅重试 `BBCLAW_WIFI_STA_MAX_RETRY`（2）次就置 `WIFI_FAIL_BIT` 停止，导致连接永久丢失直到重启。

### 解决方案

引入指数退避自动重连机制，分两层：

1. **快速重试层**（保留原有行为）：掉线后先在事件回调里直接 `esp_wifi_connect()` 重试 MAX_RETRY 次。
2. **指数退避层**（新增）：快速重试耗尽后启动 FreeRTOS one-shot timer，按 5s→15s→45s→135s→300s（封顶）序列持续重试，直到 `IP_EVENT_STA_GOT_IP` 触发为止。

连接恢复后：停止 timer、重置退避状态、打结构化恢复日志（attempt 次数 + 耗时 ms）。

新增枚举值 `BB_WIFI_MODE_STA_RECONNECTING` 标识重连中间状态，`bb_radio_app.c` 主循环在此状态下显示 `RECONNECTING` 并跳过 transport heartbeat，避免误触 LINK ERR/CLOUD ERR。

**首次启动流程不受影响**：`bb_wifi_init_and_connect` 仍走原有「遍历 SSID → AP 配网」逻辑。AP 配网态不受影响。

### 文件变更

| 文件 | 改动说明 |
|------|----------|
| `firmware/include/bb_config.h` | 新增 `BBCLAW_WIFI_RECONNECT_BACKOFF_MIN/MAX_MS` 常量（Kconfig 可覆盖） |
| `firmware/include/bb_wifi.h` | 新增 `BB_WIFI_MODE_STA_RECONNECTING = 3` 枚举值 |
| `firmware/src/bb_wifi.c` | backoff timer 创建/启停、重连逻辑、`esp_timer.h` + `freertos/timers.h` 引入 |
| `firmware/src/bb_radio_app.c` | `STA_RECONNECTING` 分支：显示 RECONNECTING、暂停 heartbeat |
| `firmware/src/Kconfig.projbuild` | 暴露 backoff min/max ms 到 menuconfig（Wi-Fi 子菜单） |

### 验证

- ✅ 固件编译通过（ESP-IDF 5.5.2，esp32s3，EXIT=0，无 warning）
- ⚠️ 端到端运行验证（关路由器后重连恢复）需用实体硬件通过 `make flash monitor` 完成，无法在此环境模拟 Wi-Fi 栈