### PR TITLE
fix: firmware Settings 新增 cloud_saas 切换 Home Adapter 选择器 (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **设备端切换 Home Adapter（机器）选择器（issue #176, ADR-027）**：cloud_saas 模式下
+  Settings 新增 `Adapter` 行 + 选择器，可在已绑定的多台 home adapter 间就地切 active，
+  无需打开 Web 后台。列表经 cloud 终结的 WS `sites.list` 异步拉取（Loading→回包重绘），
+  选中发 `sites.activate`；离线机器标 `(offline)` 仍可切；切换成功后自动刷新 driver/model
+  与 chat session 上下文。仅 cloud_saas 可见，local_home 不渲染该行。
+
 ## [0.5.0] - 2026-06-12
 
 里程碑：**一轮完整的固件性能 / 稳定性优化定版**（汇总 0.4.16–0.4.18 的优化，并补齐本地发版工具）。

--- a/design/decisions/ADR-027-device-home-adapter-switching.md
+++ b/design/decisions/ADR-027-device-home-adapter-switching.md
@@ -49,9 +49,9 @@ ADR-019 的 sessions/cwd/drivers/models 数据都在 **home adapter 本地**，c
 **权威来源**：cloud 侧已实现并合并（`bbclaw-reference` PR #28，`router/sites.go` + `httpapi/server.go`）。以下契约以该实现为准，firmware 必须对齐。
 
 ```json
-// 请求 device→cloud（deviceId 由 WS 连接身份 peer.DeviceID 决定，请求带不带都被忽略）
-{"type":"request","kind":"sites.list","messageId":"<seq>"}
-{"type":"request","kind":"sites.activate","messageId":"<seq>","payload":{"homeSiteId":"<id>"}}
+// 请求 device→cloud（deviceId 由 WS 连接身份 peer.DeviceID 决定，cloud 忽略请求体里带的值；firmware 仍带上以对齐 router 解析）
+{"type":"request","kind":"sites.list","messageId":"<seq>","deviceId":"<id>"}
+{"type":"request","kind":"sites.activate","messageId":"<seq>","deviceId":"<id>","payload":{"homeSiteId":"<id>"}}
 // 成功回包 cloud→device：type="reply"（带回请求的 messageId 与 kind）
 {"type":"reply","kind":"sites.list","messageId":"<seq>","payload":{"sites":[{"homeSiteId":"hs-1","label":"家里 Mac","online":true,"active":true}]}}
 {"type":"reply","kind":"sites.activate","messageId":"<seq>","payload":{"result":"ok","activeHomeSiteId":"hs-2"}}
@@ -59,8 +59,9 @@ ADR-019 的 sessions/cwd/drivers/models 数据都在 **home adapter 本地**，c
 {"type":"error","kind":"sites.activate","messageId":"<seq>","error":"NOT_BOUND","payload":{"error":{"code":"NOT_BOUND","detail":"..."}}}
 ```
 
-- 成功 `type:"reply"`、失败 `type:"error"`（贴合 cloud 既有 `ack`/`error` 约定，非新造 `response`）。
-- firmware 靠 **`kind` + `messageId`** 对上 in-flight 请求；`messageId` 单调自增，过期回包丢弃。失败时读顶层 `error`（稳定 code）或 `payload.error.code`。
+- 成功 `type:"reply"`、失败 `type:"error"`（**以 cloud 已合并实现为权威**，bbclaw-reference PR #28 `router/sites.go`；贴合 cloud 既有 `ack`/`error` 约定，早期草案曾写 `type:"response"`，已废弃）。
+- firmware 靠 **`kind` + `messageId`** 对上 in-flight 请求；`messageId` 由设备维护、单调自增，过期回包丢弃。失败时优先读顶层 `error`（稳定 code），回退 `payload.error.code`。
+- 错误码全集：`NOT_BOUND` / `OWNER_MISMATCH` / `ADAPTER_OFFLINE` / `INTERNAL`（兜底）。
 - **firmware 侧注意**：现有 driver picker 走 HTTP 同步，本菜单走 WS 异步——必须改成「发请求 → Loading → 回包到达后重绘」，不能照搬同步 fetch。
 
 **为什么 WS 而非 HTTP**：firmware 在 cloud_saas 下的 HTTP agent API（`/v1/agent/*`）默认经 cloud relay 转发到 home adapter；本菜单恰恰不能 relay。WS 是 cloud 已终结、已认得设备身份的通道，复用它无需另开"不 relay 的 device HTTP 路径 + 设备态鉴权"，最省。
@@ -124,8 +125,8 @@ ADR-019 的 firmware `bb_menu_view` 渲染器尚未实现（checklist 末两项�
 - [ ] cloud: hub 设备态 `sites.list` / `sites.activate`（终结，不 relay）
 - [ ] cloud: `deviceId → owner → bindings` 反查 + 列表组装（label/online/active）
 - [ ] cloud: `ActivateBinding` 设备态调用 + 错误码（NOT_BOUND/OWNER_MISMATCH/ADAPTER_OFFLINE）+ 单测
-- [ ] firmware: WS `sites.list`/`sites.activate` 调用 + 回包解析
-- [ ] firmware: Settings `Adapter` 行（仅 cloud_saas）+ picker + commit
-- [ ] firmware: 切换后 agent 状态刷新
+- [x] firmware: WS `sites.list`/`sites.activate` 调用 + 回包解析（`bb_adapter_client.c`：`bb_adapter_sites_list`/`bb_adapter_sites_activate`，同步 reply/error 对账，复用 voice.verify EventGroup 模式）
+- [x] firmware: Settings `Adapter` 行（仅 cloud_saas）+ picker + commit（`bb_ui_settings.c`：`MAIN_ROW_ADAPTER` 动态行 + `LEVEL_ADAPTER_PICKER` + `COMMIT_KIND_ADAPTER`）
+- [x] firmware: 切换后 agent 状态刷新（`on_adapter_activated` → 重拉 driver/model + chat session 重绑）
 - [ ] design: ADR-019 / ADR-016 交叉引用更新
 - [ ] testing.md: 补 cloud_saas 多 adapter 切换验证步骤

--- a/firmware/include/bb_adapter_client.h
+++ b/firmware/include/bb_adapter_client.h
@@ -95,6 +95,15 @@ typedef struct {
   char message[128];
 } bb_voice_verify_result_t;
 
+/* ADR-027: a single Home Adapter ("机器") the device may switch its active
+ * binding to. Populated from the cloud-terminated WS `sites.list` reply. */
+typedef struct {
+  char home_site_id[40];
+  char label[40];
+  uint8_t online;
+  uint8_t active;
+} bb_site_info_t;
+
 esp_err_t bb_adapter_healthz(int* http_status);
 esp_err_t bb_adapter_stream_start(bb_stream_ctx_t* ctx);
 esp_err_t bb_adapter_stream_chunk(bb_stream_ctx_t* ctx, const uint8_t* data, size_t len, int64_t ts_ms);
@@ -111,3 +120,16 @@ esp_err_t bb_adapter_display_ack(const char* task_id, const char* action_id);
 
 /* Send a raw text frame over the adapter client WebSocket (cloud_saas mode). */
 esp_err_t bb_adapter_client_send_text(const char* payload);
+
+/* ADR-027 — device-side Home Adapter switching (cloud_saas only). Both calls
+ * are synchronous: they send a cloud-terminated WS control frame and block on
+ * the matching reply (or error / timeout). Call from a background task, not the
+ * LVGL thread.
+ *
+ * sites.list  — fills out_sites (up to max_sites) and *out_count.
+ * sites.activate — ESP_OK when the reply is result:"ok"; on failure returns
+ *   ESP_FAIL and fills out_err_code with the stable cloud error code
+ *   (NOT_BOUND / OWNER_MISMATCH / ADAPTER_OFFLINE / INTERNAL / TIMEOUT). */
+esp_err_t bb_adapter_sites_list(bb_site_info_t* out_sites, int max_sites, int* out_count);
+esp_err_t bb_adapter_sites_activate(const char* home_site_id, char* out_active_id, size_t active_len,
+                                    char* out_err_code, size_t err_len);

--- a/firmware/src/bb_adapter_client.c
+++ b/firmware/src/bb_adapter_client.c
@@ -96,6 +96,18 @@ typedef struct {
   int saw_error;
 } bb_finish_stream_accum_t;
 
+/* ADR-027: in-flight state for a synchronous sites.list / sites.activate WS
+ * request. Filled by ws_handle_text_message on the matching reply/error. */
+typedef struct {
+  int kind;              /* 0 = sites.list, 1 = sites.activate */
+  bb_site_info_t* sites; /* caller buffer (list only) */
+  int max;
+  int count;             /* out: parsed site count */
+  char active_id[40];    /* out: activate's activeHomeSiteId */
+  char err_code[32];     /* out: error code, empty on success */
+  int ok;                /* out: 1 = success */
+} bb_sites_req_t;
+
 typedef struct {
   esp_websocket_client_handle_t client;
   SemaphoreHandle_t lock;
@@ -112,6 +124,9 @@ typedef struct {
   bb_voice_verify_result_t* verify_result;
   int verify_waiting;
   char verify_message_id[64];
+  bb_sites_req_t* sites_req;
+  int sites_waiting;
+  char sites_message_id[64];
   uint8_t* text_buf;
   size_t text_len;
   size_t text_cap;
@@ -129,6 +144,7 @@ static bb_ws_state_t s_ws;
 #define BB_WS_EVENT_ERROR BIT2
 #define BB_WS_EVENT_DISCONNECTED BIT3
 #define BB_WS_EVENT_VERIFY_DONE BIT4
+#define BB_WS_EVENT_SITES_DONE BIT5
 
 static int body_contains_ok_true(const char* body);
 static int json_extract_string(const char* body, const char* key, char* out, size_t out_len);
@@ -141,6 +157,8 @@ static void parse_voice_verify_result(const char* body, bb_voice_verify_result_t
 static void parse_finish_stream_line(const char* line, bb_finish_stream_accum_t* accum);
 static void ws_finish_reset_locked(void);
 static void ws_verify_reset_locked(void);
+static void ws_sites_reset_locked(void);
+static int parse_sites_array(const char* body, bb_site_info_t* out, int max);
 static void ws_reset_client_locked(void);
 static esp_err_t ws_client_ensure_connected(void);
 static esp_err_t ws_send_text_message(const char* payload);
@@ -564,6 +582,12 @@ static void ws_verify_reset_locked(void) {
   s_ws.verify_message_id[0] = '\0';
 }
 
+static void ws_sites_reset_locked(void) {
+  s_ws.sites_req = NULL;
+  s_ws.sites_waiting = 0;
+  s_ws.sites_message_id[0] = '\0';
+}
+
 static void ws_reset_client_locked(void) {
   if (s_ws.client != NULL) {
     esp_websocket_client_destroy(s_ws.client);
@@ -789,6 +813,28 @@ static void ws_handle_text_message(const char* msg) {
     return;
   }
   if (strcmp(type, "error") == 0) {
+    /* ADR-027: sites.* failures arrive as type:"error" with a stable top-level
+     * `error` code (mirrored in payload.error.code). Route to the in-flight
+     * sites request before the generic finish/verify error handling. */
+    char ekind[48] = {0};
+    (void)json_extract_string(msg, "kind", ekind, sizeof(ekind));
+    if (strncmp(ekind, "sites.", 6) == 0) {
+      xSemaphoreTake(s_ws.lock, portMAX_DELAY);
+      if (s_ws.sites_req != NULL) {
+        s_ws.sites_req->ok = 0;
+        if (!json_extract_string(msg, "error", s_ws.sites_req->err_code,
+                                 sizeof(s_ws.sites_req->err_code)) ||
+            s_ws.sites_req->err_code[0] == '\0') {
+          (void)json_extract_string(msg, "code", s_ws.sites_req->err_code,
+                                    sizeof(s_ws.sites_req->err_code));
+        }
+        s_ws.sites_waiting = 0;
+        xSemaphoreGive(s_ws.lock);
+        xEventGroupSetBits(s_ws.events, BB_WS_EVENT_SITES_DONE);
+        return;
+      }
+      xSemaphoreGive(s_ws.lock);
+    }
     xSemaphoreTake(s_ws.lock, portMAX_DELAY);
     if (s_ws.finish_result != NULL) {
       (void)json_extract_string(msg, "error", s_ws.finish_result->error_code, sizeof(s_ws.finish_result->error_code));
@@ -806,6 +852,43 @@ static void ws_handle_text_message(const char* msg) {
     }
     xSemaphoreGive(s_ws.lock);
     xEventGroupSetBits(s_ws.events, BB_WS_EVENT_ERROR);
+    return;
+  }
+  /* ADR-027: cloud-terminated sites.list / sites.activate success replies. */
+  if (strcmp(type, "reply") == 0) {
+    char rkind[48] = {0};
+    (void)json_extract_string(msg, "kind", rkind, sizeof(rkind));
+    if (strncmp(rkind, "sites.", 6) != 0) {
+      return;
+    }
+    char mid[64] = {0};
+    (void)json_extract_string(msg, "messageId", mid, sizeof(mid));
+    xSemaphoreTake(s_ws.lock, portMAX_DELAY);
+    /* Match on messageId; tolerate a missing echo (kind already scoped to the
+     * in-flight sites request) so a non-echoing cloud build still resolves. */
+    if (s_ws.sites_req != NULL &&
+        (mid[0] == '\0' || s_ws.sites_message_id[0] == '\0' ||
+         strcmp(mid, s_ws.sites_message_id) == 0)) {
+      if (strcmp(rkind, "sites.list") == 0) {
+        s_ws.sites_req->count = parse_sites_array(msg, s_ws.sites_req->sites, s_ws.sites_req->max);
+        s_ws.sites_req->ok = 1;
+      } else { /* sites.activate */
+        char res[16] = {0};
+        (void)json_extract_string(msg, "result", res, sizeof(res));
+        (void)json_extract_string(msg, "activeHomeSiteId", s_ws.sites_req->active_id,
+                                  sizeof(s_ws.sites_req->active_id));
+        s_ws.sites_req->ok = (strcmp(res, "ok") == 0) ? 1 : 0;
+        if (!s_ws.sites_req->ok) {
+          (void)json_extract_string(msg, "error", s_ws.sites_req->err_code,
+                                    sizeof(s_ws.sites_req->err_code));
+        }
+      }
+      s_ws.sites_waiting = 0;
+      xSemaphoreGive(s_ws.lock);
+      xEventGroupSetBits(s_ws.events, BB_WS_EVENT_SITES_DONE);
+      return;
+    }
+    xSemaphoreGive(s_ws.lock);
     return;
   }
   if (strcmp(type, "event") != 0) {
@@ -1946,6 +2029,169 @@ esp_err_t bb_adapter_voice_verify_pcm16(const uint8_t* pcm, size_t pcm_len, bb_v
   xSemaphoreGive(s_ws.lock);
   ESP_LOGI(TAG, "ws voice.verify ok match=%d confidence=%.3f", out_result->match, (double)out_result->confidence);
   return ESP_OK;
+}
+
+/* ── ADR-027: Home Adapter ("机器") switching ───────────────────────────── */
+
+/* Parse the `sites` array out of a sites.list reply body. Walks each object in
+ * the array and extracts the per-site fields with the existing scalar helpers
+ * (scoped to a copy of the object so labels/ids don't bleed across entries). */
+static int parse_sites_array(const char* body, bb_site_info_t* out, int max) {
+  if (body == NULL || out == NULL || max <= 0) {
+    return 0;
+  }
+  const char* arr = strstr(body, "\"sites\"");
+  if (arr == NULL) {
+    return 0;
+  }
+  arr = strchr(arr, '[');
+  if (arr == NULL) {
+    return 0;
+  }
+  int n = 0;
+  const char* p = arr + 1;
+  while (n < max) {
+    const char* obj = strchr(p, '{');
+    if (obj == NULL) {
+      break;
+    }
+    int depth = 0;
+    const char* end = obj;
+    for (; *end != '\0'; end++) {
+      if (*end == '{') {
+        depth++;
+      } else if (*end == '}') {
+        depth--;
+        if (depth == 0) {
+          break;
+        }
+      }
+    }
+    if (*end != '}') {
+      break;
+    }
+    size_t len = (size_t)(end - obj + 1);
+    char tmp[224];
+    if (len >= sizeof(tmp)) {
+      len = sizeof(tmp) - 1;
+    }
+    memcpy(tmp, obj, len);
+    tmp[len] = '\0';
+    memset(&out[n], 0, sizeof(out[n]));
+    (void)json_extract_string(tmp, "homeSiteId", out[n].home_site_id, sizeof(out[n].home_site_id));
+    (void)json_extract_string(tmp, "label", out[n].label, sizeof(out[n].label));
+    out[n].online = (uint8_t)json_extract_bool(tmp, "online", 0);
+    out[n].active = (uint8_t)json_extract_bool(tmp, "active", 0);
+    if (out[n].home_site_id[0] != '\0') {
+      n++;
+    }
+    p = end + 1;
+    const char* q = p;
+    while (*q == ' ' || *q == ',' || *q == '\n' || *q == '\r' || *q == '\t') {
+      q++;
+    }
+    if (*q == ']' || *q == '\0') {
+      break;
+    }
+  }
+  return n;
+}
+
+/* Send a sites.* control frame and block on the matching reply/error. */
+static esp_err_t sites_request(int kind, const char* home_site_id, bb_sites_req_t* req) {
+  if (!bb_transport_is_cloud_saas()) {
+    return ESP_ERR_NOT_SUPPORTED;
+  }
+  ESP_RETURN_ON_ERROR(ws_client_ensure_connected(), TAG, "ws connect failed");
+
+  char message_id[64] = {0};
+  snprintf(message_id, sizeof(message_id), "sites-%lld", (long long)bb_now_ms());
+
+  char body[256];
+  if (kind == 0) {
+    snprintf(body, sizeof(body),
+             "{\"type\":\"request\",\"kind\":\"sites.list\",\"messageId\":\"%s\",\"deviceId\":\"%s\"}",
+             message_id, BBCLAW_DEVICE_ID);
+  } else {
+    snprintf(body, sizeof(body),
+             "{\"type\":\"request\",\"kind\":\"sites.activate\",\"messageId\":\"%s\",\"deviceId\":\"%s\","
+             "\"payload\":{\"homeSiteId\":\"%s\"}}",
+             message_id, BBCLAW_DEVICE_ID, home_site_id != NULL ? home_site_id : "");
+  }
+
+  xSemaphoreTake(s_ws.lock, portMAX_DELAY);
+  ws_sites_reset_locked();
+  s_ws.sites_req = req;
+  s_ws.sites_waiting = 1;
+  snprintf(s_ws.sites_message_id, sizeof(s_ws.sites_message_id), "%s", message_id);
+  xSemaphoreGive(s_ws.lock);
+  xEventGroupClearBits(s_ws.events, BB_WS_EVENT_SITES_DONE | BB_WS_EVENT_ERROR | BB_WS_EVENT_DISCONNECTED);
+
+  esp_err_t send_err = ws_send_text_message(body);
+  if (send_err != ESP_OK) {
+    xSemaphoreTake(s_ws.lock, portMAX_DELAY);
+    ws_sites_reset_locked();
+    xSemaphoreGive(s_ws.lock);
+    return send_err;
+  }
+
+  EventBits_t bits = xEventGroupWaitBits(s_ws.events,
+                                         BB_WS_EVENT_SITES_DONE | BB_WS_EVENT_DISCONNECTED,
+                                         pdFALSE, pdFALSE, pdMS_TO_TICKS(8000));
+  xSemaphoreTake(s_ws.lock, portMAX_DELAY);
+  ws_sites_reset_locked();
+  esp_err_t result;
+  if ((bits & BB_WS_EVENT_SITES_DONE) != 0U && req->ok) {
+    result = ESP_OK;
+  } else {
+    if (req->err_code[0] == '\0') {
+      snprintf(req->err_code, sizeof(req->err_code), "%s",
+               (bits & BB_WS_EVENT_DISCONNECTED) != 0U ? "DISCONNECTED" : "TIMEOUT");
+    }
+    result = ESP_FAIL;
+  }
+  xSemaphoreGive(s_ws.lock);
+  return result;
+}
+
+esp_err_t bb_adapter_sites_list(bb_site_info_t* out_sites, int max_sites, int* out_count) {
+  if (out_sites == NULL || max_sites <= 0 || out_count == NULL) {
+    return ESP_ERR_INVALID_ARG;
+  }
+  *out_count = 0;
+  bb_sites_req_t req;
+  memset(&req, 0, sizeof(req));
+  req.kind = 0;
+  req.sites = out_sites;
+  req.max = max_sites;
+  esp_err_t err = sites_request(0, NULL, &req);
+  *out_count = req.count;
+  if (err == ESP_OK) {
+    ESP_LOGI(TAG, "ws sites.list ok count=%d", req.count);
+  } else {
+    ESP_LOGW(TAG, "ws sites.list failed err=%s code=%s", esp_err_to_name(err), req.err_code);
+  }
+  return err;
+}
+
+esp_err_t bb_adapter_sites_activate(const char* home_site_id, char* out_active_id, size_t active_len,
+                                    char* out_err_code, size_t err_len) {
+  if (home_site_id == NULL || home_site_id[0] == '\0') {
+    return ESP_ERR_INVALID_ARG;
+  }
+  bb_sites_req_t req;
+  memset(&req, 0, sizeof(req));
+  req.kind = 1;
+  esp_err_t err = sites_request(1, home_site_id, &req);
+  if (out_active_id != NULL && active_len > 0U) {
+    snprintf(out_active_id, active_len, "%s", req.active_id);
+  }
+  if (out_err_code != NULL && err_len > 0U) {
+    snprintf(out_err_code, err_len, "%s", req.err_code);
+  }
+  ESP_LOGI(TAG, "ws sites.activate '%s' -> %s active=%s code=%s", home_site_id, esp_err_to_name(err),
+           req.active_id, req.err_code);
+  return err;
 }
 
 /* Strip markdown formatting and other characters that the TTS engine would

--- a/firmware/src/bb_ui_settings.c
+++ b/firmware/src/bb_ui_settings.c
@@ -37,10 +37,12 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "bb_adapter_client.h"
 #include "bb_agent_client.h"
 #include "bb_audio.h"
 #include "bb_device_config.h"
 #include "bb_session_store.h"
+#include "bb_transport.h"
 #include "bb_ui_agent_chat.h"
 #include "bb_ui_theme.h"
 #include "esp_log.h"
@@ -56,6 +58,7 @@ static const char* TAG = "bb_ui_settings";
 #define BB_SETTINGS_NVS_NS         "bbclaw"
 #define BB_SETTINGS_NVS_KEY_TTS    "agent/tts"
 #define BB_SETTINGS_DRIVER_CACHE_MAX 6
+#define BB_SETTINGS_SITE_CACHE_MAX   6
 
 #define BB_SETTINGS_FETCH_TASK_STACK 4096
 #define BB_SETTINGS_FETCH_TASK_PRIO  4
@@ -78,16 +81,22 @@ typedef enum {
   LEVEL_MAIN = 0,
   LEVEL_DRIVER_PICKER,
   LEVEL_MODEL_PICKER,
+  LEVEL_ADAPTER_PICKER,
   LEVEL_VOLUME_ADJUST,
 } settings_level_t;
 
+/* Logical main-page row ids. MAIN_ROW_ADAPTER (ADR-027) is only shown in
+ * cloud_saas mode, so the on-screen row order/count is dynamic — see
+ * main_visible_rows(). Cursor index (s_st.sel) indexes the *visible* list,
+ * not these ids directly. */
 typedef enum {
   MAIN_ROW_DRIVER = 0,
   MAIN_ROW_MODEL,
+  MAIN_ROW_ADAPTER,
   MAIN_ROW_VOLUME,
   MAIN_ROW_TTS,
   MAIN_ROW_BACK,
-  MAIN_ROW_COUNT,
+  MAIN_ROW_ID_COUNT,
 } main_row_t;
 
 /* ── State ── */
@@ -118,6 +127,15 @@ typedef struct {
   char active_driver[24];
   /* active_model is per-driver — we read it off
    * driver_cache[i].active_model directly. */
+
+  /* ADR-027: Home Adapter ("机器") catalog. Populated async (WS sites.list)
+   * when the Adapter picker is entered / Settings opened in cloud_saas. */
+  bb_site_info_t site_cache[BB_SETTINGS_SITE_CACHE_MAX];
+  int site_cache_count;
+  volatile int site_fetch_pending;
+  volatile uint32_t site_fetch_generation;
+  char active_site_id[40]; /* optimistic active selection for snappy UI */
+  int pending_chat_sync;   /* 1 = re-sync chat driver/session after site switch */
 
   int tts_enabled;
 
@@ -261,50 +279,108 @@ static const char* current_model_label(const bb_agent_driver_info_t* d) {
   return d->models[0].label[0] != '\0' ? d->models[0].label : d->models[0].id;
 }
 
+/* ── Dynamic main-row layout (ADR-027: Adapter row only in cloud_saas) ── */
+
+static int main_visible_rows(main_row_t* out) {
+  int n = 0;
+  out[n++] = MAIN_ROW_DRIVER;
+  out[n++] = MAIN_ROW_MODEL;
+  if (bb_transport_is_cloud_saas()) {
+    out[n++] = MAIN_ROW_ADAPTER;
+  }
+  out[n++] = MAIN_ROW_VOLUME;
+  out[n++] = MAIN_ROW_TTS;
+  out[n++] = MAIN_ROW_BACK;
+  return n;
+}
+
+static int main_visible_row_count(void) {
+  main_row_t rows[MAIN_ROW_ID_COUNT];
+  return main_visible_rows(rows);
+}
+
+/* Map a logical row id to its index in the current visible list (for cursor
+ * placement). Falls back to 0 if not visible. */
+static int main_row_to_index(main_row_t row) {
+  main_row_t rows[MAIN_ROW_ID_COUNT];
+  int n = main_visible_rows(rows);
+  for (int i = 0; i < n; ++i) {
+    if (rows[i] == row) return i;
+  }
+  return 0;
+}
+
+/* Label of the currently-active Home Adapter for the main-page Adapter row. */
+static const char* current_site_label(void) {
+  if (s_st.site_fetch_pending && s_st.site_cache_count == 0) return "(loading)";
+  for (int i = 0; i < s_st.site_cache_count; ++i) {
+    int is_active = s_st.site_cache[i].active ||
+                    (s_st.active_site_id[0] != '\0' &&
+                     strcmp(s_st.site_cache[i].home_site_id, s_st.active_site_id) == 0);
+    if (is_active) {
+      const char* lbl = s_st.site_cache[i].label[0] != '\0' ? s_st.site_cache[i].label
+                                                            : s_st.site_cache[i].home_site_id;
+      return s_st.site_cache[i].online ? lbl : "(offline)";
+    }
+  }
+  if (s_st.active_site_id[0] != '\0') return s_st.active_site_id;
+  return "(none)";
+}
+
 static void render_main(void) {
   if (s_st.root == NULL) return;
   lv_label_set_text(s_st.header_lbl, "Settings");
 
-  build_rows_box(MAIN_ROW_COUNT);
+  main_row_t rows[MAIN_ROW_ID_COUNT];
+  int n = main_visible_rows(rows);
+  build_rows_box(n);
   char buf[80];
 
   const bb_agent_driver_info_t* active = active_driver_entry();
 
-  /* Row: Driver */
-  const char* drv_name = (active != NULL) ? active->name :
-                          (s_st.driver_fetch_pending ? "loading..." : "(offline)");
-  snprintf(buf, sizeof(buf), "Driver: %s", drv_name);
-  lv_label_set_text(s_st.rows[MAIN_ROW_DRIVER], buf);
-
-  /* Row: Model */
-  snprintf(buf, sizeof(buf), "Model: %s", current_model_label(active));
-  lv_label_set_text(s_st.rows[MAIN_ROW_MODEL], buf);
-
-  /* Row: Volume — show mini bar as text art + percent */
-  {
-    int pct = s_st.volume_pct;
-    const int BLOCKS = 10;
-    int filled = (pct * BLOCKS + 50) / 100;
-    if (filled < 0) filled = 0;
-    if (filled > BLOCKS) filled = BLOCKS;
-    char mini[16];
-    int ci = 0;
-    mini[ci++] = '[';
-    for (int k = 0; k < BLOCKS; k++) {
-      mini[ci++] = (k < filled) ? '#' : '-';
+  for (int i = 0; i < n; ++i) {
+    switch (rows[i]) {
+      case MAIN_ROW_DRIVER: {
+        const char* drv_name = (active != NULL) ? active->name :
+                                (s_st.driver_fetch_pending ? "loading..." : "(offline)");
+        snprintf(buf, sizeof(buf), "Driver: %s", drv_name);
+        break;
+      }
+      case MAIN_ROW_MODEL:
+        snprintf(buf, sizeof(buf), "Model: %s", current_model_label(active));
+        break;
+      case MAIN_ROW_ADAPTER:
+        snprintf(buf, sizeof(buf), "Adapter: %s", current_site_label());
+        break;
+      case MAIN_ROW_VOLUME: {
+        int pct = s_st.volume_pct;
+        const int BLOCKS = 10;
+        int filled = (pct * BLOCKS + 50) / 100;
+        if (filled < 0) filled = 0;
+        if (filled > BLOCKS) filled = BLOCKS;
+        char mini[16];
+        int ci = 0;
+        mini[ci++] = '[';
+        for (int k = 0; k < BLOCKS; k++) {
+          mini[ci++] = (k < filled) ? '#' : '-';
+        }
+        mini[ci++] = ']';
+        mini[ci] = '\0';
+        snprintf(buf, sizeof(buf), "Vol: %s %d%%", mini, pct);
+        break;
+      }
+      case MAIN_ROW_TTS:
+        snprintf(buf, sizeof(buf), "TTS: %s", s_st.tts_enabled ? "On" : "Off");
+        break;
+      case MAIN_ROW_BACK:
+        snprintf(buf, sizeof(buf), "Back");
+        break;
+      default:
+        buf[0] = '\0';
+        break;
     }
-    mini[ci++] = ']';
-    mini[ci] = '\0';
-    snprintf(buf, sizeof(buf), "Vol: %s %d%%", mini, pct);
+    lv_label_set_text(s_st.rows[i], buf);
   }
-  lv_label_set_text(s_st.rows[MAIN_ROW_VOLUME], buf);
-
-  /* Row: TTS */
-  snprintf(buf, sizeof(buf), "TTS: %s", s_st.tts_enabled ? "On" : "Off");
-  lv_label_set_text(s_st.rows[MAIN_ROW_TTS], buf);
-
-  /* Row: Back */
-  lv_label_set_text(s_st.rows[MAIN_ROW_BACK], "Back");
 
   highlight_selected();
 }
@@ -330,6 +406,42 @@ static void render_driver_picker(void) {
     snprintf(buf, sizeof(buf), "%s%s",
              s_st.driver_cache[i].name,
              is_active ? "  *" : "");
+    lv_label_set_text(s_st.rows[i], buf);
+  }
+  highlight_selected();
+}
+
+/* ── Render: Adapter picker (ADR-027 — WS sites.list, async) ── */
+
+static void render_adapter_picker(void) {
+  if (s_st.root == NULL) return;
+  lv_label_set_text(s_st.header_lbl, "Adapter");
+
+  if (s_st.site_fetch_pending && s_st.site_cache_count == 0) {
+    build_rows_box(1);
+    lv_label_set_text(s_st.rows[0], "Loading...");
+    highlight_selected();
+    return;
+  }
+
+  if (s_st.site_cache_count == 0) {
+    build_rows_box(1);
+    lv_label_set_text(s_st.rows[0], "(none)");
+    highlight_selected();
+    return;
+  }
+
+  build_rows_box(s_st.site_cache_count);
+  for (int i = 0; i < s_st.site_cache_count; ++i) {
+    char buf[80];
+    const char* lbl = s_st.site_cache[i].label[0] != '\0' ? s_st.site_cache[i].label
+                                                          : s_st.site_cache[i].home_site_id;
+    int is_active = s_st.site_cache[i].active ||
+                    (s_st.active_site_id[0] != '\0' &&
+                     strcmp(s_st.site_cache[i].home_site_id, s_st.active_site_id) == 0);
+    snprintf(buf, sizeof(buf), "%s%s%s", lbl,
+             is_active ? "  *" : "",
+             s_st.site_cache[i].online ? "" : "  (offline)");
     lv_label_set_text(s_st.rows[i], buf);
   }
   highlight_selected();
@@ -468,6 +580,7 @@ static void rerender(void) {
     case LEVEL_MAIN:           render_main(); break;
     case LEVEL_DRIVER_PICKER:  render_driver_picker(); break;
     case LEVEL_MODEL_PICKER:   render_model_picker(); break;
+    case LEVEL_ADAPTER_PICKER: render_adapter_picker(); break;
     case LEVEL_VOLUME_ADJUST:  render_volume_adjust(); break;
   }
 }
@@ -511,6 +624,17 @@ static void on_driver_fetch_done(void* user_data) {
     s_st.active_driver[sizeof(s_st.active_driver) - 1] = '\0';
     ESP_LOGI(TAG, "driver fetch ok: %d drivers active='%s'",
              total, s_st.active_driver);
+  }
+  /* ADR-027 §4: a Home Adapter switch requested a chat context re-sync. The new
+   * adapter's active driver is now resolved above — flip the chat overlay over
+   * to it so the topbar label + session reflect the new machine. We run inside
+   * an lv_async_call (LVGL task), so direct chat calls are safe here. */
+  if (s_st.pending_chat_sync && s_st.active_driver[0] != '\0') {
+    s_st.pending_chat_sync = 0;
+    esp_err_t cerr = bb_ui_agent_chat_set_active_driver(s_st.active_driver);
+    if (cerr != ESP_OK) {
+      ESP_LOGW(TAG, "site switch: chat driver sync failed (%s)", esp_err_to_name(cerr));
+    }
   }
   rerender();
   free(r);
@@ -557,6 +681,107 @@ static void spawn_driver_fetch_task(void) {
   }
 }
 
+/* ── Site (Home Adapter) fetch — ADR-027, WS sites.list, async ── */
+
+typedef struct {
+  uint32_t gen;
+  esp_err_t err;
+  int count;
+  bb_site_info_t sites[BB_SETTINGS_SITE_CACHE_MAX];
+} site_fetch_result_t;
+
+static void on_site_fetch_done(void* user_data) {
+  site_fetch_result_t* r = (site_fetch_result_t*)user_data;
+  if (r == NULL) return;
+  s_st.site_fetch_pending = 0;
+  if (!s_st.active || r->gen != s_st.site_fetch_generation) {
+    free(r);
+    return;
+  }
+  if (r->err != ESP_OK || r->count <= 0) {
+    ESP_LOGW(TAG, "site fetch failed (%s) count=%d", esp_err_to_name(r->err), r->count);
+    s_st.site_cache_count = 0;
+  } else {
+    int total = r->count > BB_SETTINGS_SITE_CACHE_MAX ? BB_SETTINGS_SITE_CACHE_MAX : r->count;
+    memcpy(s_st.site_cache, r->sites, sizeof(r->sites[0]) * (size_t)total);
+    s_st.site_cache_count = total;
+    /* Seed active_site_id from the reply's active flag if we don't have one. */
+    for (int i = 0; i < total; ++i) {
+      if (r->sites[i].active) {
+        strncpy(s_st.active_site_id, r->sites[i].home_site_id, sizeof(s_st.active_site_id) - 1);
+        s_st.active_site_id[sizeof(s_st.active_site_id) - 1] = '\0';
+        break;
+      }
+    }
+    ESP_LOGI(TAG, "site fetch ok: %d sites active='%s'", total, s_st.active_site_id);
+  }
+  if (s_st.level == LEVEL_ADAPTER_PICKER || s_st.level == LEVEL_MAIN) {
+    rerender();
+  }
+  free(r);
+}
+
+static void site_fetch_task(void* arg) {
+  site_fetch_result_t* r = (site_fetch_result_t*)arg;
+  if (r == NULL) {
+    s_st.site_fetch_pending = 0;
+    vTaskDelete(NULL);
+    return;
+  }
+  r->err = bb_adapter_sites_list(r->sites, BB_SETTINGS_SITE_CACHE_MAX, &r->count);
+  if (lvgl_port_lock(200)) {
+    lv_async_call(on_site_fetch_done, r);
+    lvgl_port_unlock();
+  } else {
+    free(r);
+  }
+  vTaskDelete(NULL);
+}
+
+static void spawn_site_fetch_task(void) {
+  if (!bb_transport_is_cloud_saas()) return;
+  if (s_st.site_fetch_pending) return;
+  s_st.site_fetch_pending = 1;
+  uint32_t gen = ++s_st.site_fetch_generation;
+
+  site_fetch_result_t* r = (site_fetch_result_t*)calloc(1, sizeof(*r));
+  if (r == NULL) {
+    ESP_LOGE(TAG, "spawn_site_fetch_task: calloc failed");
+    s_st.site_fetch_pending = 0;
+    return;
+  }
+  r->gen = gen;
+  TaskHandle_t t = NULL;
+  BaseType_t ok = xTaskCreate(site_fetch_task, "site_fetch",
+                              BB_SETTINGS_FETCH_TASK_STACK, r,
+                              BB_SETTINGS_FETCH_TASK_PRIO, &t);
+  if (ok != pdPASS) {
+    ESP_LOGE(TAG, "spawn_site_fetch_task: xTaskCreate failed");
+    s_st.site_fetch_pending = 0;
+    free(r);
+  }
+}
+
+/* ADR-027 §4: after the active binding flips, re-pull agent state from the
+ * now-active adapter (driver/model catalog + chat session context) and refresh
+ * the site list so its `active` flag reflects cloud truth. Runs on the LVGL
+ * thread (dispatched via lv_async_call). */
+static void on_adapter_activated(void* arg) {
+  (void)arg;
+  if (!s_st.active) return;
+  s_st.pending_chat_sync = 1;
+  spawn_driver_fetch_task();
+  spawn_site_fetch_task();
+}
+
+/* sites.activate failed — reconcile the optimistic active mark against cloud
+ * truth by re-pulling the list (no driver/chat re-sync; binding didn't move). */
+static void on_adapter_activate_failed(void* arg) {
+  (void)arg;
+  if (!s_st.active) return;
+  spawn_site_fetch_task();
+}
+
 /* ── Commit task (async PUT) ── */
 
 typedef enum {
@@ -564,12 +789,14 @@ typedef enum {
   COMMIT_KIND_MODEL,
   COMMIT_KIND_VOLUME,  /* int_val = volume pct 0-100 */
   COMMIT_KIND_TTS,     /* int_val = 0/1 */
+  COMMIT_KIND_ADAPTER, /* site_id = target homeSiteId (WS sites.activate) */
 } commit_kind_t;
 
 typedef struct {
   commit_kind_t kind;
   char driver_name[24];
   char model_id[40];
+  char site_id[40];
   int int_val;
 } commit_payload_t;
 
@@ -622,6 +849,22 @@ static void commit_task(void* arg) {
   } else if (p->kind == COMMIT_KIND_TTS) {
     err = persist_tts_enabled(p->int_val);
     ESP_LOGI(TAG, "commit tts=%d -> %s", p->int_val, esp_err_to_name(err));
+  } else if (p->kind == COMMIT_KIND_ADAPTER) {
+    /* ADR-027: WS sites.activate (cloud-terminated). On success the active
+     * binding has flipped; refresh agent state from the new adapter. On
+     * failure the optimistic UI selection is left as-is and the next picker
+     * open / refresh will reconcile from cloud truth. */
+    char active_id[40] = {0};
+    char err_code[32] = {0};
+    err = bb_adapter_sites_activate(p->site_id, active_id, sizeof(active_id), err_code, sizeof(err_code));
+    ESP_LOGI(TAG, "commit adapter site='%s' -> %s (active='%s' code='%s')",
+             p->site_id, esp_err_to_name(err), active_id, err_code);
+    if (lvgl_port_lock(200)) {
+      lv_async_call(err == ESP_OK ? on_adapter_activated : on_adapter_activate_failed, NULL);
+      lvgl_port_unlock();
+    } else {
+      ESP_LOGW(TAG, "commit adapter: lvgl_port_lock timeout, agent state will sync on next entry");
+    }
   }
   free(p);
   vTaskDelete(NULL);
@@ -646,6 +889,27 @@ static void spawn_commit_task(commit_kind_t kind, const char* driver, const char
                               BB_SETTINGS_FETCH_TASK_PRIO, &t);
   if (ok != pdPASS) {
     ESP_LOGE(TAG, "spawn_commit_task: xTaskCreate failed");
+    free(p);
+  }
+}
+
+/* ADR-027: commit a Home Adapter switch (WS sites.activate) on a fresh task —
+ * the call blocks on the WS round-trip, so it must not run on the LVGL thread. */
+static void spawn_commit_adapter(const char* home_site_id) {
+  if (home_site_id == NULL || home_site_id[0] == '\0') return;
+  commit_payload_t* p = (commit_payload_t*)calloc(1, sizeof(*p));
+  if (p == NULL) {
+    ESP_LOGE(TAG, "spawn_commit_adapter: calloc failed");
+    return;
+  }
+  p->kind = COMMIT_KIND_ADAPTER;
+  strncpy(p->site_id, home_site_id, sizeof(p->site_id) - 1);
+  TaskHandle_t t = NULL;
+  BaseType_t ok = xTaskCreate(commit_task, "site_commit",
+                              BB_SETTINGS_FETCH_TASK_STACK, p,
+                              BB_SETTINGS_FETCH_TASK_PRIO, &t);
+  if (ok != pdPASS) {
+    ESP_LOGE(TAG, "spawn_commit_adapter: xTaskCreate failed");
     free(p);
   }
 }
@@ -702,13 +966,27 @@ static void enter_model_picker(void) {
   rerender();
 }
 
-static void return_to_main(int new_sel_row) {
-  s_st.level = LEVEL_MAIN;
-  if (new_sel_row >= 0 && new_sel_row < MAIN_ROW_COUNT) {
-    s_st.sel = new_sel_row;
-  } else {
-    s_st.sel = MAIN_ROW_DRIVER;
+/* ADR-027: open the Adapter picker. List arrives async (WS sites.list); show
+ * cached entries immediately and kick a refresh so online/active stay current. */
+static void enter_adapter_picker(void) {
+  s_st.level = LEVEL_ADAPTER_PICKER;
+  s_st.sel = 0;
+  for (int i = 0; i < s_st.site_cache_count; ++i) {
+    int is_active = s_st.site_cache[i].active ||
+                    (s_st.active_site_id[0] != '\0' &&
+                     strcmp(s_st.site_cache[i].home_site_id, s_st.active_site_id) == 0);
+    if (is_active) {
+      s_st.sel = i;
+      break;
+    }
   }
+  spawn_site_fetch_task();
+  rerender();
+}
+
+static void return_to_main(main_row_t row) {
+  s_st.level = LEVEL_MAIN;
+  s_st.sel = main_row_to_index(row);
   rerender();
 }
 
@@ -757,7 +1035,11 @@ void bb_ui_settings_show(lv_obj_t* parent) {
 
   /* Kick off async driver/model fetch. apply renders a stale (or empty)
    * snapshot in the meantime — on_driver_fetch_done re-renders when done. */
+  s_st.pending_chat_sync = 0;
   spawn_driver_fetch_task();
+  /* ADR-027: in cloud_saas, also pull the Home Adapter list so the main-page
+   * "Adapter: <label>" row shows the active machine on first paint. */
+  spawn_site_fetch_task();
   rerender();
 
   ESP_LOGI(TAG, "show level=MAIN tts=%d", s_st.tts_enabled);
@@ -767,6 +1049,7 @@ void bb_ui_settings_hide(void) {
   if (!s_st.active) return;
   s_st.active = 0;
   s_st.driver_fetch_generation++;
+  s_st.site_fetch_generation++;
   destroy_rows();
   if (s_st.root != NULL) {
     lv_obj_del(s_st.root);
@@ -801,10 +1084,13 @@ void bb_ui_settings_handle_rotate(int delta) {
   int row_count;
   switch (s_st.level) {
     case LEVEL_MAIN:
-      row_count = MAIN_ROW_COUNT;
+      row_count = main_visible_row_count();
       break;
     case LEVEL_DRIVER_PICKER:
       row_count = (s_st.driver_cache_count > 0) ? s_st.driver_cache_count : 1;
+      break;
+    case LEVEL_ADAPTER_PICKER:
+      row_count = (s_st.site_cache_count > 0) ? s_st.site_cache_count : 1;
       break;
     case LEVEL_MODEL_PICKER: {
       const bb_agent_driver_info_t* d = active_driver_entry();
@@ -825,8 +1111,11 @@ void bb_ui_settings_handle_rotate(int delta) {
 int bb_ui_settings_handle_click(void) {
   if (!s_st.active) return 0;
   switch (s_st.level) {
-    case LEVEL_MAIN:
-      switch ((main_row_t)s_st.sel) {
+    case LEVEL_MAIN: {
+      main_row_t vis[MAIN_ROW_ID_COUNT];
+      int vn = main_visible_rows(vis);
+      main_row_t logical = (s_st.sel >= 0 && s_st.sel < vn) ? vis[s_st.sel] : MAIN_ROW_BACK;
+      switch (logical) {
         case MAIN_ROW_DRIVER:
           enter_driver_picker();
           break;
@@ -840,6 +1129,9 @@ int bb_ui_settings_handle_click(void) {
           }
           break;
         }
+        case MAIN_ROW_ADAPTER:
+          enter_adapter_picker();
+          break;
         case MAIN_ROW_VOLUME:
           /* Enter volume adjust sub-level */
           s_st.level = LEVEL_VOLUME_ADJUST;
@@ -859,11 +1151,12 @@ int bb_ui_settings_handle_click(void) {
         }
         case MAIN_ROW_BACK:
           return 1; /* caller tears down + returns to chat */
-        case MAIN_ROW_COUNT:
+        case MAIN_ROW_ID_COUNT:
         default:
           break;
       }
       return 0;
+    }
 
     case LEVEL_DRIVER_PICKER:
       if (s_st.driver_cache_count <= 0) {
@@ -883,6 +1176,30 @@ int bb_ui_settings_handle_click(void) {
         }
       }
       return_to_main(MAIN_ROW_DRIVER);
+      return 0;
+
+    case LEVEL_ADAPTER_PICKER:
+      if (s_st.site_cache_count <= 0) {
+        return_to_main(MAIN_ROW_ADAPTER);
+        return 0;
+      }
+      if (s_st.sel >= 0 && s_st.sel < s_st.site_cache_count) {
+        const char* picked = s_st.site_cache[s_st.sel].home_site_id;
+        int already = s_st.site_cache[s_st.sel].active ||
+                      (s_st.active_site_id[0] != '\0' && strcmp(picked, s_st.active_site_id) == 0);
+        if (picked[0] != '\0' && !already) {
+          /* Optimistic local update — mark picked active so the main page +
+           * picker reflect the choice before the WS round-trip confirms. */
+          strncpy(s_st.active_site_id, picked, sizeof(s_st.active_site_id) - 1);
+          s_st.active_site_id[sizeof(s_st.active_site_id) - 1] = '\0';
+          for (int i = 0; i < s_st.site_cache_count; ++i) {
+            s_st.site_cache[i].active = (i == s_st.sel) ? 1 : 0;
+          }
+          spawn_commit_adapter(picked);
+          ESP_LOGI(TAG, "adapter picker -> '%s' (committed)", picked);
+        }
+      }
+      return_to_main(MAIN_ROW_ADAPTER);
       return 0;
 
     case LEVEL_MODEL_PICKER: {
@@ -937,6 +1254,9 @@ int bb_ui_settings_handle_back(void) {
       return 1; /* caller exits to chat */
     case LEVEL_DRIVER_PICKER:
       return_to_main(MAIN_ROW_DRIVER);
+      return 0;
+    case LEVEL_ADAPTER_PICKER:
+      return_to_main(MAIN_ROW_ADAPTER);
       return 0;
     case LEVEL_MODEL_PICKER:
       return_to_main(MAIN_ROW_MODEL);


### PR DESCRIPTION
Fixes #176

实现 ADR-027 的 firmware 侧：cloud_saas 模式下在 Settings 新增 Adapter（机器）选择器，让用户在已绑定的多台 home adapter 间就地切换 active，无需打开 Web 后台。

## 改动

### 传输层 `bb_adapter_client.{c,h}`
- 新增同步 WS 控制帧 `bb_adapter_sites_list` / `bb_adapter_sites_activate`，复用既有 voice.verify 的 EventGroup 请求/回包对账模式（后台任务阻塞发送、回包置位唤醒）。
- `ws_handle_text_message` 新增 `type:"reply"`（成功）与 `type:"error"`（失败）下 `sites.list`/`sites.activate` 回包解析，含 `messageId` 对账、过期回包丢弃、`sites` 数组解析。
- **契约以 cloud 已合并实现为权威**（Comment 5 / bbclaw-reference PR #28）：成功 `reply`、失败 `error`（顶层 `error` code，回退 `payload.error.code`），错误码 NOT_BOUND/OWNER_MISMATCH/ADAPTER_OFFLINE/INTERNAL。

### UI `bb_ui_settings.c`
- 新增 `MAIN_ROW_ADAPTER`，**仅 cloud_saas 可见**：引入动态可见行列表（`main_visible_rows`）+ 光标映射，local_home 下不渲染、不越界。
- 新增 `LEVEL_ADAPTER_PICKER`：WS 异步模型（Loading → 回包到达后重绘），区别于 driver picker 的 HTTP 同步 fetch。active 标 `*`、离线标 `(offline)`、空列表 `(none)`。
- 新增 `COMMIT_KIND_ADAPTER`：选中乐观更新 + 后台 `sites.activate`；成功后刷新 agent 状态（重拉 `/v1/agent/drivers` + 复用 driver 切换的 chat session 重绑），失败回滚乐观选中态。

### 设计 / 文档
- ADR-027 §2 契约回写 `response`→`reply`/`error`，消除与已合并 cloud 的分叉；勾选 firmware checklist。
- CHANGELOG Unreleased 增项。

## 测试
- 固件 `make build` 通过（EXIT=0，分区 9% 余量）；强制重编两处改动文件无 error/warning。
- ⚠️ **真机 cloud_saas 多 adapter 端到端验收待硬件**：需 cloud backend + 已绑定≥2 台 adapter 的真机，按 ADR-027 验收标准（看到 Adapter 行、切换后由新 adapter 应答、离线机器显示离线标记）。本环境无对应硬件，未执行。

## 备注
- NVS 缓存 `home_site_id`（ADR 标注「可选」）本次未实现，离线展示依赖内存缓存；可后续补。
- 技术债（ADR-027 §5 已认可）：待 ADR-019 `bb_menu_view` 落地，本地 picker 应迁为 cloud 组装的 server-driven `sites` 菜单。