### PR TITLE
fix: OTA 升级死循环兜底护栏（issue #179）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **OTA 升级死循环兜底护栏（issue #179）**：cloud_saas 开机 OTA check 新增「重刷循环」
+  退避逻辑。设备在切分区重启前把目标版本写入 NVS（`ota/last_try`）；下次开机 check 时
+  若 cloud 给的目标版本 == 上次已烧录尝试过的版本，且当前运行版本仍未变成该目标版本，
+  判定上一次升级虽烧录成功但固件自报版本号未递增（典型：发布构建用了占位/dev 版本号），
+  于是抑制本次 `hasUpdate`、记 `WARN` 日志、正常进主流程，避免无限重刷弹窗。根因仍需
+  发布构建注入递增版本号（见 CLAUDE.md 发布约束 / `release_local.sh`），此为软件侧兜底。
+
 ### Added
 - **设备端切换 Home Adapter（机器）选择器（issue #176, ADR-027）**：cloud_saas 模式下
   Settings 新增 `Adapter` 行 + 选择器，可在已绑定的多台 home adapter 间就地切 active，

--- a/firmware/src/bb_ota.c
+++ b/firmware/src/bb_ota.c
@@ -19,6 +19,11 @@
 
 static const char* TAG = "bb_ota";
 
+// NVS 命名空间与键（OTA 状态持久化）
+#define OTA_NVS_NAMESPACE     "ota"
+#define OTA_NVS_KEY_JUST_UPD  "just_upd"   // 升级完成庆祝标志
+#define OTA_NVS_KEY_LAST_TRY  "last_try"   // 上次「已烧录并重启」尝试的目标版本
+
 // OTA 状态
 static ota_state_t s_state = OTA_STATE_IDLE;
 
@@ -56,6 +61,37 @@ static esp_err_t ota_http_event_handler(esp_http_client_event_t* evt) {
             break;
     }
     return ESP_OK;
+}
+
+// 读取上次尝试升级的目标版本（issue #179 死循环护栏）。
+// 成功返回 ESP_OK 且 out 填入版本字符串；无记录或出错返回非 ESP_OK。
+static esp_err_t ota_nvs_get_last_try(char* out, size_t out_size) {
+    if (out == NULL || out_size == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    out[0] = '\0';
+    nvs_handle_t nvsh;
+    if (nvs_open(OTA_NVS_NAMESPACE, NVS_READONLY, &nvsh) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    size_t len = out_size;
+    esp_err_t err = nvs_get_str(nvsh, OTA_NVS_KEY_LAST_TRY, out, &len);
+    nvs_close(nvsh);
+    return err;
+}
+
+// 记录本次「已烧录并准备重启」尝试的目标版本（issue #179 死循环护栏）。
+static void ota_nvs_set_last_try(const char* version) {
+    if (version == NULL || version[0] == '\0') {
+        return;
+    }
+    nvs_handle_t nvsh;
+    if (nvs_open(OTA_NVS_NAMESPACE, NVS_READWRITE, &nvsh) == ESP_OK) {
+        nvs_set_str(nvsh, OTA_NVS_KEY_LAST_TRY, version);
+        nvs_commit(nvsh);
+        nvs_close(nvsh);
+        ESP_LOGI(TAG, "OTA NVS last_try set to %s", version);
+    }
 }
 
 ota_state_t bb_ota_get_state(void) {
@@ -219,6 +255,27 @@ esp_err_t bb_ota_check(ota_update_info_t* info) {
                     info->release_notes[len] = '\0';
                 }
             }
+        }
+    }
+
+    // 死循环护栏（issue #179）：若 cloud 给出的目标版本与上次「已烧录并重启」
+    // 尝试过的版本相同，但当前运行版本仍未变成该目标版本，说明上一次升级虽然
+    // 烧录成功，新固件自报的 esp_app_desc.version 却没有递增（典型：发布构建用
+    // 了占位/dev 版本号）。cloud 因此持续 hasUpdate=true，继续弹窗只会无限重刷，
+    // 故在此退避，让设备正常进入主流程。这是软件侧兜底，根因仍需发布构建注入
+    // 递增版本号（见 CLAUDE.md 发布约束 / release_local.sh）。
+    if (info->has_update && info->version[0] != '\0') {
+        char last_try[sizeof(info->version)] = {0};
+        if (ota_nvs_get_last_try(last_try, sizeof(last_try)) == ESP_OK &&
+            last_try[0] != '\0' &&
+            strcmp(last_try, info->version) == 0 &&
+            strcmp(bb_ota_get_current_version(), info->version) != 0) {
+            ESP_LOGW(TAG,
+                     "OTA loop guard: target version=%s already flashed but running "
+                     "version=%s unchanged — suppressing update to break reflash loop "
+                     "(published firmware likely did not bump esp_app_desc.version)",
+                     info->version, bb_ota_get_current_version());
+            info->has_update = false;
         }
     }
 
@@ -392,12 +449,18 @@ esp_err_t bb_ota_apply_update(void) {
 
     /* Mark "just updated" flag in NVS so first-boot celebration can be shown */
     nvs_handle_t nvsh;
-    if (nvs_open("ota", NVS_READWRITE, &nvsh) == ESP_OK) {
-        nvs_set_u32(nvsh, "just_upd", 1);
+    if (nvs_open(OTA_NVS_NAMESPACE, NVS_READWRITE, &nvsh) == ESP_OK) {
+        nvs_set_u32(nvsh, OTA_NVS_KEY_JUST_UPD, 1);
         nvs_commit(nvsh);
         nvs_close(nvsh);
         ESP_LOGI(TAG, "OTA NVS just_upd flag set");
     }
+
+    /* Record the version we are about to flash+reboot into, so the next boot's
+     * OTA check can detect a reflash loop if the running version doesn't change
+     * (issue #179). Only versions that actually reach reboot are recorded —
+     * transient download failures never call this function. */
+    ota_nvs_set_last_try(s_pending_update.version);
 
     // 标记待启动的分区
     esp_err_t err = esp_ota_set_boot_partition(update_partition);
@@ -417,13 +480,13 @@ esp_err_t bb_ota_apply_update(void) {
 
 int bb_ota_was_just_updated(void) {
     nvs_handle_t nvsh;
-    if (nvs_open("ota", NVS_READONLY, &nvsh) != ESP_OK) {
+    if (nvs_open(OTA_NVS_NAMESPACE, NVS_READONLY, &nvsh) != ESP_OK) {
         return 0;
     }
     uint32_t val = 0;
-    nvs_get_u32(nvsh, "just_upd", &val);
+    nvs_get_u32(nvsh, OTA_NVS_KEY_JUST_UPD, &val);
     if (val == 1) {
-        nvs_erase_key(nvsh, "just_upd");
+        nvs_erase_key(nvsh, OTA_NVS_KEY_JUST_UPD);
         nvs_commit(nvsh);
         ESP_LOGI(TAG, "OTA celebration flag cleared");
     }


### PR DESCRIPTION
Fixes #179

## 问题
cloud_saas 开机弹 OTA 升级确认，按 OK 烧录重启后**仍回到升级确认**，反复死循环。

## 根因
- **根因 1（构建/发布，本 PR 不改代码）**：发布固件若用裸 `make build` 出占位/dev 版本号，升级后 `esp_app_desc.version` 未递增，cloud `/v1/ota/check` 持续 `hasUpdate=true` → 死循环。修复方式是发布走 `release_local.sh` 注入递增 `version.txt`。
- **根因 2（固件缺持久化护栏，本 PR 修复）**：`s_ota_skipped_this_boot` 是内存变量、重启即丢；`bb_ota_apply_update` 只写 `just_upd`，无「已尝试升级到 version X」记录，固件完全信任 cloud 的 `hasUpdate`、自身不做版本比较。即便版本号修了，任何升级未真正生效也会每次开机重复弹窗。

## 改动（`firmware/src/bb_ota.c`）
1. 新增 NVS 辅助函数 `ota_nvs_get_last_try` / `ota_nvs_set_last_try`（命名空间 `ota`，键 `last_try`）。
2. `bb_ota_apply_update`：切 boot 分区重启前，把目标 `s_pending_update.version` 写入 NVS。仅「真正烧录成功并准备重启」的版本会被记录——下载失败不会污染记录。
3. `bb_ota_check`：解析出 `has_update` + `version` 后加死循环护栏——若 `cloud 目标版本 == NVS last_try` 且 `当前运行版本 != 目标版本`（说明上次升级烧录成功但版本号没递增），则抑制本次 `has_update`、记 `WARN` 日志、正常进主流程。
4. 顺手把散落的 `"ota"` / `"just_upd"` 字面量收敛为宏常量。

护栏不影响正常升级：版本号正确递增时，新固件自报 == active，cloud 直接返回 `hasUpdate=false`，护栏分支根本不触发；真正的新版本（target != last_try）也不会被抑制。

## 测试
- ✅ `make build`（bbclaw 板 + cloud_saas 配置）编译通过，固件 0x244bc0 bytes，分区 9% 余量。
- ⚠️ **未做真机验证**：死循环复现需 cloud_saas 真机 + cloud 端把某版本设 active 制造 `hasUpdate=true`，本环境无对应硬件/cloud active 配置。建议人工在真机上验证两次开机日志出现 `OTA loop guard: target version=... suppressing` 后不再弹窗。

🤖 Generated with [Claude Code](https://claude.com/claude-code)