### PR TITLE
fix(adapter/web): FilesPanel 周期刷新，MEMORY 更新后页面立即可见

### DIFF
--- a/adapter/web/src/components/FilesPanel.vue
+++ b/adapter/web/src/components/FilesPanel.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, onUnmounted, ref } from "vue";
 import { workspaceFiles, workspaceFile, type WorkspaceFileMeta } from "../api";
 
 interface Entry { meta: WorkspaceFileMeta; content: string; loading: boolean }
 
+const REFRESH_MS = 5000;
+
 const entries = ref<Entry[]>([]);
 const loading = ref(false);
+let timer: ReturnType<typeof setInterval> | null = null;
 
 async function fill(entry: Entry) {
   entry.loading = true;
@@ -34,7 +37,17 @@ async function load() {
   }
 }
 
-onMounted(load);
+onMounted(() => {
+  load();
+  timer = setInterval(load, REFRESH_MS);
+});
+
+onUnmounted(() => {
+  if (timer !== null) {
+    clearInterval(timer);
+    timer = null;
+  }
+});
 </script>
 
 <template>


### PR DESCRIPTION
## 问题

`adapter/web` admin 页的 FilesPanel 之前只在 `onMounted` 拉一次工作区文件列表。
后台 `butler-memory` 追加新条目后，页面要手动刷新才能看到新内容。

## 修复

- 加一个 5 秒的 `setInterval(load)` 轮询
- 组件 `onUnmounted` 时 `clearInterval` 清理

## 影响

- 仅影响 admin 页 `/files` 面板
- 每 5 秒多打两次 HTTP（`workspaceFiles` + `workspaceFile` ×N 文件），量小

## 测试

- 在 admin 页面打开 FilesPanel
- 触发 butler 写一条 memory
- ≤ 5 秒内页面应自动显示新内容
- 切到其他 tab 几秒再切回来，loading 状态正常

## 备注

- 不影响云端协议 / 设备侧
- 后续可改成 `EventSource` / SSE 或基于 mtime 的条件请求，进一步降流量