### PR TITLE
feat: add device set-miyu CLI to toggle 密语模式 remotely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **adapter CLI 新增 `device set-miyu <on|off>` 子命令**(#190):对标 `set-volume`,
+  通过 `POST /v1/devices/{id}/config` 远程开关设备「密语模式」(即 `miyuEnabled`——
+  cloud_saas 锁屏语音解锁开关),Cloud 经 `config.update` 实时下发到设备,无需重启。
+  AI butler 的设备控制提示(`DeviceSystemPrompt`)同步加入 `set-miyu` 用法,可口头响应
+  「开/关密语模式」。`setConfigRequest` 改为指针字段 + `omitempty`,确保 `set-miyu` 不会
+  误发 `volumePct:0` 把设备静音。
+
 ## [0.5.11] - 2026-06-14
 
 ### Fixed

--- a/adapter/internal/butler/persona.go
+++ b/adapter/internal/butler/persona.go
@@ -37,8 +37,10 @@ func DeviceSystemPrompt(cwd, deviceID string) string {
 		b.WriteString("当前设备 ID:`" + id + "`\n")
 		b.WriteString("如需调节本设备音量,用 Bash 工具执行:\n")
 		b.WriteString("  bbclaw-adapter device set-volume <0-100> --device " + id + "\n")
-		b.WriteString("成功后用一句话朗读结果(例如「已把音量调到 50%,马上生效」)。\n")
-		b.WriteString("如果设备 ID 未知,不要尝试音量调节。\n")
+		b.WriteString("如需开关密语模式(锁屏语音解锁),用 Bash 工具执行:\n")
+		b.WriteString("  bbclaw-adapter device set-miyu <on|off> --device " + id + "\n")
+		b.WriteString("成功后用一句话朗读结果(例如「已把音量调到 50%,马上生效」「已开启密语模式」)。\n")
+		b.WriteString("如果设备 ID 未知,不要尝试设备控制。\n")
 	}
 	return b.String()
 }

--- a/adapter/internal/butler/persona_test.go
+++ b/adapter/internal/butler/persona_test.go
@@ -29,10 +29,16 @@ func TestDeviceSystemPrompt(t *testing.T) {
 	if !strings.Contains(withDevice, "set-volume") {
 		t.Errorf("expected set-volume CLI hint in prompt, got:\n%s", withDevice)
 	}
+	if !strings.Contains(withDevice, "set-miyu") {
+		t.Errorf("expected set-miyu CLI hint in prompt, got:\n%s", withDevice)
+	}
 
 	// Empty deviceID must omit device-control section.
 	noDevice := DeviceSystemPrompt("/some/cwd", "")
 	if strings.Contains(noDevice, "set-volume") {
 		t.Errorf("empty deviceID must omit set-volume hint, got:\n%s", noDevice)
+	}
+	if strings.Contains(noDevice, "set-miyu") {
+		t.Errorf("empty deviceID must omit set-miyu hint, got:\n%s", noDevice)
 	}
 }

--- a/adapter/internal/cmd/device.go
+++ b/adapter/internal/cmd/device.go
@@ -19,6 +19,7 @@ func NewDeviceCmd() *cobra.Command {
 		Short: "Control BBClaw device settings via cloud API",
 	}
 	cmd.AddCommand(newSetVolumeCmd())
+	cmd.AddCommand(newSetMiyuCmd())
 	return cmd
 }
 
@@ -47,15 +48,21 @@ Examples:
 	return cmd
 }
 
+// setConfigRequest is the body for POST /v1/devices/{id}/config. Fields are
+// pointers + omitempty so a command only ever sends the keys it intends to
+// change — otherwise set-miyu would emit volumePct:0 and the cloud would treat
+// it as a real value and mute the device.
 type setConfigRequest struct {
-	VolumePct int `json:"volumePct"`
+	VolumePct   *int  `json:"volumePct,omitempty"`
+	MiyuEnabled *bool `json:"miyuEnabled,omitempty"`
 }
 
 type setConfigResponse struct {
 	OK   bool `json:"ok"`
 	Data struct {
-		Version   int `json:"version"`
-		VolumePct int `json:"volumePct"`
+		Version     int  `json:"version"`
+		VolumePct   int  `json:"volumePct"`
+		MiyuEnabled bool `json:"miyuEnabled"`
 	} `json:"data"`
 	Error string `json:"error,omitempty"`
 }
@@ -81,53 +88,9 @@ func runSetVolume(deviceID *string) func(*cobra.Command, []string) error {
 			return fmt.Errorf("--device is required")
 		}
 
-		// Load cloud config from env.
-		cfg, err := homeadapter.LoadFromEnv()
+		result, err := postDeviceConfig(cmd, id, setConfigRequest{VolumePct: &pct})
 		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "config load failed: %v\n", err)
 			return err
-		}
-
-		base, err := homeadapter.DeriveCloudHTTPBase(cfg.CloudWSURL)
-		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "cannot derive HTTP base from CLOUD_WS_URL: %v\n", err)
-			return err
-		}
-
-		// Build request.
-		body, _ := json.Marshal(setConfigRequest{VolumePct: pct})
-		url := base + "/v1/devices/" + id + "/config"
-		httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
-		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "构建请求失败: %v\n", err)
-			return err
-		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		if cfg.CloudAuthToken != "" {
-			httpReq.Header.Set("Authorization", "Bearer "+cfg.CloudAuthToken)
-		}
-
-		client := &http.Client{Timeout: 15 * time.Second}
-		resp, err := client.Do(httpReq)
-		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "请求云端失败: %v\n", err)
-			return err
-		}
-		defer resp.Body.Close()
-
-		var result setConfigResponse
-		if decErr := json.NewDecoder(resp.Body).Decode(&result); decErr != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "解析响应失败 (HTTP %d): %v\n", resp.StatusCode, decErr)
-			return decErr
-		}
-
-		if !result.OK || resp.StatusCode != http.StatusOK {
-			errMsg := result.Error
-			if errMsg == "" {
-				errMsg = fmt.Sprintf("HTTP %d", resp.StatusCode)
-			}
-			fmt.Fprintf(cmd.ErrOrStderr(), "云端返回错误: %s\n", errMsg)
-			return fmt.Errorf("cloud error: %s", errMsg)
 		}
 
 		out, _ := json.Marshal(map[string]any{
@@ -138,4 +101,125 @@ func runSetVolume(deviceID *string) func(*cobra.Command, []string) error {
 		fmt.Println(string(out))
 		return nil
 	}
+}
+
+func newSetMiyuCmd() *cobra.Command {
+	var deviceID string
+
+	cmd := &cobra.Command{
+		Use:   "set-miyu <on|off>",
+		Short: "Toggle 密语模式 (lock-screen voice unlock) via cloud config API",
+		Long: `Enable or disable 密语模式 (miyu / lock-screen voice unlock) for a BBClaw device.
+
+When enabled in cloud_saas mode, the device shows the LOCKED page and requires
+a spoken passphrase before use. This mirrors the toggle in the web console.
+
+The command reads CLOUD_WS_URL and CLOUD_AUTH_TOKEN from the environment
+(or .env file) and calls POST /v1/devices/{deviceId}/config on the cloud.
+
+Examples:
+  bbclaw-adapter device set-miyu on  --device <deviceId>
+  bbclaw-adapter device set-miyu off --device <deviceId>`,
+		Args: cobra.ExactArgs(1),
+		RunE: runSetMiyu(&deviceID),
+	}
+
+	cmd.Flags().StringVar(&deviceID, "device", "", "Target device ID (required)")
+	_ = cmd.MarkFlagRequired("device")
+
+	return cmd
+}
+
+func runSetMiyu(deviceID *string) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		enabled, err := parseOnOff(args[0])
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "invalid value %q: must be on or off\n", args[0])
+			return err
+		}
+
+		id := strings.TrimSpace(*deviceID)
+		if id == "" {
+			fmt.Fprintln(cmd.ErrOrStderr(), "--device is required")
+			return fmt.Errorf("--device is required")
+		}
+
+		result, err := postDeviceConfig(cmd, id, setConfigRequest{MiyuEnabled: &enabled})
+		if err != nil {
+			return err
+		}
+
+		out, _ := json.Marshal(map[string]any{
+			"ok":          true,
+			"miyuEnabled": result.Data.MiyuEnabled,
+			"version":     result.Data.Version,
+		})
+		fmt.Println(string(out))
+		return nil
+	}
+}
+
+// parseOnOff parses a human on/off toggle argument into a bool.
+func parseOnOff(s string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "on", "true", "1", "enable", "enabled", "yes":
+		return true, nil
+	case "off", "false", "0", "disable", "disabled", "no":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid on/off value: %s", s)
+	}
+}
+
+// postDeviceConfig sends a partial config update to the cloud for the given
+// device and returns the decoded response. Shared by set-volume and set-miyu.
+func postDeviceConfig(cmd *cobra.Command, deviceID string, reqBody setConfigRequest) (*setConfigResponse, error) {
+	cfg, err := homeadapter.LoadFromEnv()
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "config load failed: %v\n", err)
+		return nil, err
+	}
+
+	base, err := homeadapter.DeriveCloudHTTPBase(cfg.CloudWSURL)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "cannot derive HTTP base from CLOUD_WS_URL: %v\n", err)
+		return nil, err
+	}
+
+	body, _ := json.Marshal(reqBody)
+	url := base + "/v1/devices/" + deviceID + "/config"
+	httpReq, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "构建请求失败: %v\n", err)
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if cfg.CloudAuthToken != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+cfg.CloudAuthToken)
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "请求云端失败: %v\n", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result setConfigResponse
+	if decErr := json.NewDecoder(resp.Body).Decode(&result); decErr != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "解析响应失败 (HTTP %d): %v\n", resp.StatusCode, decErr)
+		return nil, decErr
+	}
+
+	if !result.OK || resp.StatusCode != http.StatusOK {
+		errMsg := result.Error
+		if errMsg == "" {
+			errMsg = fmt.Sprintf("HTTP %d", resp.StatusCode)
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "云端返回错误: %s\n", errMsg)
+		return nil, fmt.Errorf("cloud error: %s", errMsg)
+	}
+
+	return &result, nil
 }

--- a/adapter/internal/cmd/device_test.go
+++ b/adapter/internal/cmd/device_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseOnOff(t *testing.T) {
+	on := []string{"on", "On", "ON", "true", "1", "enable", "enabled", "yes", " on "}
+	for _, s := range on {
+		v, err := parseOnOff(s)
+		if err != nil {
+			t.Errorf("parseOnOff(%q) returned error: %v", s, err)
+		}
+		if !v {
+			t.Errorf("parseOnOff(%q) = false, want true", s)
+		}
+	}
+
+	off := []string{"off", "Off", "OFF", "false", "0", "disable", "disabled", "no", " off "}
+	for _, s := range off {
+		v, err := parseOnOff(s)
+		if err != nil {
+			t.Errorf("parseOnOff(%q) returned error: %v", s, err)
+		}
+		if v {
+			t.Errorf("parseOnOff(%q) = true, want false", s)
+		}
+	}
+
+	for _, s := range []string{"", "maybe", "2", "onoff"} {
+		if _, err := parseOnOff(s); err == nil {
+			t.Errorf("parseOnOff(%q) expected error, got nil", s)
+		}
+	}
+}
+
+func TestDeviceCmdRegistersSubcommands(t *testing.T) {
+	dev := NewDeviceCmd()
+	want := map[string]bool{"set-volume": false, "set-miyu": false}
+	for _, c := range dev.Commands() {
+		if _, ok := want[c.Name()]; ok {
+			want[c.Name()] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("device command missing subcommand %q", name)
+		}
+	}
+}
+
+// TestSetConfigRequestOmitsUnsetFields guards the partial-update contract: a
+// set-miyu request must NOT serialize volumePct (which would mute the device),
+// and vice-versa.
+func TestSetConfigRequestOmitsUnsetFields(t *testing.T) {
+	enabled := true
+	miyuBody, _ := json.Marshal(setConfigRequest{MiyuEnabled: &enabled})
+	if got := string(miyuBody); got != `{"miyuEnabled":true}` {
+		t.Errorf("miyu-only body = %s, want only miyuEnabled", got)
+	}
+
+	pct := 50
+	volBody, _ := json.Marshal(setConfigRequest{VolumePct: &pct})
+	if got := string(volBody); got != `{"volumePct":50}` {
+		t.Errorf("volume-only body = %s, want only volumePct", got)
+	}
+
+	// A zero volume must still serialize when explicitly set (mute is valid).
+	zero := 0
+	zeroBody, _ := json.Marshal(setConfigRequest{VolumePct: &zero})
+	if got := string(zeroBody); got != `{"volumePct":0}` {
+		t.Errorf("zero-volume body = %s, want volumePct:0", got)
+	}
+}


### PR DESCRIPTION
Fixes #190

## 改动

在 `bbclaw-adapter device` 下新增对标 `set-volume` 的 `set-miyu <on|off>` 子命令,用于远程开关指定设备的「密语模式」。经 owner 在 issue 评论澄清,该模式即现有的 `miyuEnabled`(cloud_saas 锁屏语音解锁开关)——固件、Cloud `POST/GET /v1/devices/{id}/config`、Web 控制台均已就绪,本仓库唯一缺口是 adapter CLI。原 issue 正文「不持久化、不上云」属误写,不在范围。

### 文件
- `adapter/internal/cmd/device.go`
  - `setConfigRequest` 字段改为指针 + `omitempty`(`VolumePct *int`、`MiyuEnabled *bool`),避免 `set-miyu` 复用时误发 `volumePct:0` 把设备静音
  - 抽出共享 `postDeviceConfig` helper,`set-volume`/`set-miyu` 复用同一 `LoadFromEnv → DeriveCloudHTTPBase → POST` 链路
  - 新增 `newSetMiyuCmd()` / `runSetMiyu()` / `parseOnOff()`,`NewDeviceCmd()` 注册
  - `setConfigResponse.Data` 加 `MiyuEnabled` 回显
- `adapter/internal/butler/persona.go`:`DeviceSystemPrompt` 设备控制段加 `set-miyu` 用法,butler 可口头响应「开/关密语模式」
- `adapter/internal/cmd/device_test.go`(新增):`parseOnOff`、子命令注册、部分更新序列化(确认 `set-miyu` 不发 volumePct)
- `adapter/internal/butler/persona_test.go`:补 `set-miyu` 断言
- `CHANGELOG.md`:Unreleased Added

### 用法
```bash
bbclaw-adapter device set-miyu on  --device <DEVICE_ID>
bbclaw-adapter device set-miyu off --device <DEVICE_ID>
```

## 测试
- `go build ./...` 通过
- `go test ./...`(adapter)全绿
- 手动验证:`device --help` 列出 set-miyu;无效参数 `set-miyu badvalue` 被拒绝并提示 on/off

## 未覆盖 / 待人工
- 端到端云端契约(`POST /v1/devices/{id}/config` 是否真的接受 `miyuEnabled` 并经 `config.update` 下发)位于 closed-source `bbclaw-reference`,本仓库快照无法核实;owner 评论确认已就绪,建议合并后用真实 cloud 端点 + 设备做一次端到端冒烟。
- 按发布策略,adapter 二进制新增 user-facing 功能 → 需打 `v*` tag 出新 adapter(单 tag 同时构建 firmware + adapter)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)