### PR TITLE
fix(adapter_v2): 让设备线（通道②）对真 claude 跑通

### DIFF
--- a/adapter_v2/DESIGN.md
+++ b/adapter_v2/DESIGN.md
@@ -137,10 +137,11 @@ PTT 音频 ─Recognizer.Transcribe─▶ Bridge.SubmitVoicePTT ─┐
 冒烟用 `e2e` build tag 隔离，默认 `go test ./...` 不会在测试期 `go build` 子进程、
 保持快且零外部依赖；重的进程冒烟只在 `make e2e` 按需跑。
 
-> 注意：冒烟用 ASCII transcript。服务端 VT 仿真器（`vtscreen` 底层 hinshun/vt10x）
-> 目前不渲染双宽 CJK 字形到 `VisibleText`（"你好" 回复会抽成空）——宽字符渲染是
-> `vtscreen` 的事，单独追踪，与本设备 e2e 解耦；round-trip 链路本身与文本无关，已被
-> ASCII 用例完整覆盖。
+> CJK：已对真 `claude` 验证中英文均正确（注入 "只回复两个字：你好" → 抽出 "你好"）。
+> 早期"CJK 抽成空"的根因不是 vt10x 不支持宽字符，而是 `vtscreen.Feed` 曾逐字节喂
+> vt10x，把多字节 UTF-8 序列拆碎丢弃；改为整块喂 + chunk 边界保留半个 rune 后即正确
+> 渲染。设备 e2e 冒烟仍用 ASCII（不依赖真 agent）；对真 `claude` 的中英文验证靠
+> 一次性探针手工跑（spawn 真 claude → 注入 → 看 deviceapi 抽出的播报文本）。
 
 ### Makefile 入口
 

--- a/adapter_v2/Makefile
+++ b/adapter_v2/Makefile
@@ -19,21 +19,48 @@ CURDIR  ?= $(shell pwd)
 BIN_DIR ?= $(CURDIR)/bin
 BIN_NAME ?= bbclaw-adapter-v2
 
-.PHONY: help build test e2e clean
+# `make run` knobs (all overridable):
+#   ADDR  listen address           (default :18090)
+#   CLI   CLI to drive under a PTY  (default claude; auto-resolves the install)
+#   CWD   working dir for that CLI  (default: inherit; set to a project root)
+ADDR ?= :18090
+CLI  ?= claude
+CWD  ?=
+
+.PHONY: help build run test e2e clean
 
 help:
 	@echo "BBClaw adapter_v2"
 	@echo ""
+	@echo "  make run     # build + start the server, then open http://localhost$(ADDR)"
 	@echo "  make build   # build $(BIN_DIR)/$(BIN_NAME)"
 	@echo "  make test    # go test ./... (fast, no external deps)"
 	@echo "  make e2e     # device end-to-end voice round-trip smoke"
 	@echo "  make clean   # remove build artifacts"
 	@echo ""
-	@echo "Override the Go toolchain: make test GO=/path/to/go"
+	@echo "  make run CLI=bash CWD=~/proj ADDR=:9000   # drive a shell instead of claude"
+	@echo "  Override the Go toolchain: make test GO=/path/to/go"
 
 build:
 	@mkdir -p "$(BIN_DIR)"
 	$(GO) build -o "$(BIN_DIR)/$(BIN_NAME)" ./cmd/bbclaw-adapter-v2
+
+# Build then run the server in the foreground (Ctrl-C to stop). Open
+# http://localhost$(ADDR) in a browser to take over the CLI's real terminal;
+# refresh the page to reconnect to the same live session.
+#
+# CLI is resolved to a real binary: PATH first, then the standard Claude Code
+# local install (~/.claude/local/claude), else used verbatim — so `make run`
+# works even though `claude` is often only a shell alias.
+run: build
+	@CLI_BIN="$$(command -v $(CLI) 2>/dev/null || true)"; \
+	if [ -z "$$CLI_BIN" ] && [ -x "$$HOME/.claude/local/claude" ] && [ "$(CLI)" = "claude" ]; then \
+		CLI_BIN="$$HOME/.claude/local/claude"; \
+	fi; \
+	[ -n "$$CLI_BIN" ] || CLI_BIN="$(CLI)"; \
+	echo "▶ adapter_v2  →  http://localhost$(ADDR)   (open it, then type to drive the CLI; refresh = reconnect)"; \
+	echo "  CLI=$$CLI_BIN   CWD=$${CWD:-<inherit>}"; \
+	ADAPTER_V2_ADDR="$(ADDR)" ADAPTER_V2_CLI="$$CLI_BIN" ADAPTER_V2_CWD="$(CWD)" "$(BIN_DIR)/$(BIN_NAME)"
 
 # Fast suite: every package's unit + integration tests, no process-spawn smoke.
 test:

--- a/adapter_v2/internal/deviceapi/deviceapi.go
+++ b/adapter_v2/internal/deviceapi/deviceapi.go
@@ -39,6 +39,7 @@ package deviceapi
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"time"
 
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/extract"
@@ -61,6 +62,15 @@ const interruptKey = "\x1b"
 // enterKey terminates an injected transcript so the CLI treats it as a submitted
 // user turn (carriage return is what a real Enter sends over a PTY).
 const enterKey = "\r"
+
+// interruptSettle is the gap between an interrupt ESC and the following
+// transcript. A terminal distinguishes a lone ESC key from an escape SEQUENCE by
+// timing: an ESC immediately followed by a byte is read as Alt+<byte> / a
+// sequence, which would swallow the transcript's first character — harmless-ish
+// for ASCII ("reply"→"eply") but fatal for a multibyte CJK rune (ESC eats the
+// lead byte, leaving invalid UTF-8 that the CLI drops). So when we do send an
+// interrupt, we let it land as its own keystroke before typing.
+const interruptSettle = 60 * time.Millisecond
 
 // Recognizer turns a PTT audio buffer into transcript text. It is the device
 // line's ASR entry point. Kept deliberately narrower than v1's asr.Provider
@@ -119,6 +129,14 @@ type Bridge struct {
 	// raw byte stream it receives as a session Client. It is separate from the
 	// Session's broadcast screen so the device-line extraction state is isolated.
 	screen *vtscreen.Screen
+
+	// inFlight is true while a turn we injected is still being worked by the CLI
+	// (set when SubmitVoiceTurn injects, cleared when maybeSpeak sees the turn
+	// complete). It gates the interrupt: we only send ESC to abort a turn that is
+	// actually running. At an idle prompt there is nothing to interrupt, and a
+	// gratuitous ESC there corrupts the next keystroke (see interruptSettle), so
+	// the common sequential case (and the first turn) injects cleanly with no ESC.
+	inFlight atomic.Bool
 
 	// rearm is the cross-goroutine signal that a new user turn was just injected,
 	// so Run must re-baseline the Extractor and reset the Detector for that turn.
@@ -189,15 +207,22 @@ func (b *Bridge) SubmitVoiceTurn(transcript string) error {
 	if isBlank(transcript) {
 		return nil
 	}
-	// Interrupt any in-flight turn first so the new turn lands at a clean prompt.
-	// Best-effort: a failed ESC still lets the transcript through (the CLI may
-	// already be idle, in which case ESC is harmless).
-	if err := b.sess.Write([]byte(interruptKey)); err != nil {
-		return mapErr(err)
+	// Interrupt ONLY a turn that is actually in flight (a barge-in). At an idle
+	// prompt there is nothing to abort, and a gratuitous ESC there is read as the
+	// start of an escape sequence that swallows the transcript's first character
+	// (fatal for a leading CJK rune). When we do interrupt, let the ESC land as
+	// its own keystroke before typing (interruptSettle) so it is not glued to the
+	// first byte of the transcript.
+	if b.inFlight.Load() {
+		if err := b.sess.Write([]byte(interruptKey)); err != nil {
+			return mapErr(err)
+		}
+		time.Sleep(interruptSettle)
 	}
 	if err := b.sess.Write([]byte(transcript + enterKey)); err != nil {
 		return mapErr(err)
 	}
+	b.inFlight.Store(true)
 	// A new user turn is now in flight. Signal Run to re-baseline the Extractor on
 	// the (possibly interrupted) current screen and reset the Detector's settle
 	// clock, so this turn's reply is isolated from the prior one and a barge-in
@@ -300,6 +325,9 @@ func (b *Bridge) maybeSpeak(ctx context.Context, det *extract.Detector, extP **e
 	if !det.TurnEnded(time.Now()) {
 		return nil
 	}
+	// The turn the user injected is done; a later barge-in now has nothing to
+	// interrupt, so the next SubmitVoiceTurn injects cleanly without an ESC.
+	b.inFlight.Store(false)
 	reply, _ := (*extP).OnOutput()
 	text := reply.Text
 	// Re-arm for the next turn regardless of whether this one had speakable text:

--- a/adapter_v2/internal/deviceapi/deviceapi_test.go
+++ b/adapter_v2/internal/deviceapi/deviceapi_test.go
@@ -419,9 +419,11 @@ while IFS= read -r line; do
 done
 `
 
-// TestSubmitVoiceTurnInterruptsInFlight asserts the documented in-flight policy:
-// SubmitVoiceTurn prepends the ESC interrupt key so a previous turn is aborted
-// before the new transcript lands. We observe ESC reaching stdin via a probe CLI.
+// TestSubmitVoiceTurnInterruptsInFlight asserts the in-flight policy: ESC is
+// injected ONLY to abort a turn that is actually running (a barge-in), never at
+// an idle prompt — where a gratuitous ESC would be read as an escape sequence and
+// swallow the transcript's first character (fatal for a leading CJK rune). We
+// observe ESC reaching stdin via a probe CLI.
 func TestSubmitVoiceTurnInterruptsInFlight(t *testing.T) {
 	m := session.NewManager()
 	s, err := m.Create("probe", ptyhost.Config{
@@ -433,12 +435,23 @@ func TestSubmitVoiceTurnInterruptsInFlight(t *testing.T) {
 	}
 	client, _, _ := s.Attach()
 	defer s.Detach(client)
+	br := b(s)
 
-	if err := b(s).SubmitVoiceTurn("second turn"); err != nil {
-		t.Fatalf("SubmitVoiceTurn: %v", err)
+	// At an idle prompt there is nothing to interrupt: no ESC precedes the text.
+	if err := br.SubmitVoiceTurn("first turn"); err != nil {
+		t.Fatalf("SubmitVoiceTurn (idle): %v", err)
+	}
+	if !drainContains(client.Out, "NO_ESC:first turn", 3*time.Second) {
+		t.Fatalf("idle SubmitVoiceTurn must NOT inject an ESC ahead of the transcript")
+	}
+
+	// With a turn in flight, a barge-in interrupts: ESC precedes the new text.
+	br.inFlight.Store(true)
+	if err := br.SubmitVoiceTurn("second turn"); err != nil {
+		t.Fatalf("SubmitVoiceTurn (in-flight): %v", err)
 	}
 	if !drainContains(client.Out, "SAW_ESC:second turn", 3*time.Second) {
-		t.Fatalf("interrupt key (ESC) was not injected ahead of the transcript")
+		t.Fatalf("in-flight SubmitVoiceTurn must inject ESC ahead of the transcript")
 	}
 }
 

--- a/adapter_v2/internal/extract/boundary.go
+++ b/adapter_v2/internal/extract/boundary.go
@@ -129,9 +129,17 @@ func (d *Detector) TurnEnded(now time.Time) bool {
 	if d.spinnerOnScreen {
 		return false // CLI is still working (e.g. a mid-reply network pause)
 	}
-	// Spinner is gone and output settled. Require the idle prompt to confirm the
-	// CLI handed control back, which is what cleanly separates a real turn end
-	// from a transient repaint that merely happened to drop the spinner line.
+	// Output settled and the working spinner is gone. The primary completion
+	// signal is "the CLI was working this turn (a spinner appeared) and it is now
+	// gone" — robust across CLIs whose idle prompt we cannot pin down: real claude
+	// renders a "❯" box with a rotating "Try …" placeholder, never a bare ">", so
+	// keying on idle-prompt text alone never fired against the real TUI.
+	if d.sawSpinner {
+		return true
+	}
+	// Fallback for a CLI/turn that never showed a spinner (a very fast reply):
+	// require the idle prompt to have returned, so we do not fire in the gap
+	// before the CLI even started working.
 	return d.idlePromptOnScreen
 }
 
@@ -186,5 +194,5 @@ func isIdlePromptLine(t string) bool {
 	t = strings.TrimLeft(t, "│|")
 	t = strings.TrimRight(t, "│|")
 	t = strings.TrimSpace(t)
-	return t == ">" // bare ">" with no trailing user text
+	return t == ">" || t == "❯" // bare prompt glyph with no trailing user text
 }

--- a/adapter_v2/internal/extract/extract.go
+++ b/adapter_v2/internal/extract/extract.go
@@ -85,14 +85,21 @@ func (e *Extractor) OnOutput() (Reply, bool) {
 	return Reply{Text: text}, true
 }
 
-// extract computes the newest-reply text from the current screen: take the
-// visible content lines (noise already removed), drop any that were present in
-// the baseline, and join the remainder. Leading/trailing blank lines are
-// trimmed; trailing whitespace per line is trimmed (the acceptance criterion
-// allows trailing-whitespace differences).
-func (e *Extractor) extract() string {
-	lines := contentLines(e.screen.VisibleText())
+// replyMarker is claude's assistant-turn bullet (U+23FA): every assistant block
+// is rendered "⏺ <text>" at column 0, continuation lines indented two spaces.
+const replyMarker = "⏺"
 
+// extract computes the newest-reply text from the current screen. Preferred path:
+// anchor on claude's "⏺" reply marker and take that block (#claude). Fallback for
+// CLIs without the marker: diff the visible content against the per-turn baseline
+// so only the newest lines survive.
+func (e *Extractor) extract() string {
+	visible := e.screen.VisibleText()
+	if reply, ok := extractMarkerBlock(visible); ok {
+		return reply
+	}
+
+	lines := contentLines(visible)
 	// Keep only lines not already present in the baseline. A reply line that
 	// happens to duplicate baseline text verbatim is rare and harmless to drop;
 	// isolating the newest turn matters more for the device/voice line.
@@ -103,8 +110,58 @@ func (e *Extractor) extract() string {
 		}
 		kept = append(kept, l)
 	}
-
 	return strings.Join(kept, "\n")
+}
+
+// extractMarkerBlock isolates the newest claude assistant reply by anchoring on
+// the "⏺" bullet: take the LAST marker line (bullet stripped) plus the indented
+// continuation lines that follow it, stopping at the first non-indented line or
+// noise line (spinner/status/prompt/box-rule). This keeps the surrounding footer
+// chrome and the "✻ … for Ns" completion summary out of the reply, regardless of
+// how their values churn. ok is false when no marker is on screen (a non-claude
+// CLI), so the caller falls back to diff-based extraction.
+func extractMarkerBlock(visible string) (string, bool) {
+	raw := strings.Split(visible, "\n")
+	last := -1
+	for i, l := range raw {
+		if strings.HasPrefix(strings.TrimLeft(l, " "), replyMarker) {
+			last = i
+		}
+	}
+	if last < 0 {
+		return "", false
+	}
+
+	block := []string{stripReplyMarker(strings.TrimRight(raw[last], " \t"))}
+	for k := last + 1; k < len(raw); k++ {
+		l := strings.TrimRight(raw[k], " \t")
+		if l == "" {
+			block = append(block, "") // keep interior blanks (paragraph breaks)
+			continue
+		}
+		// A continuation line is indented; anything flush-left, or any noise line,
+		// ends the reply block (the "✻ … for Ns" summary, box rules, prompt, footer).
+		if isNoiseLine(l) || !strings.HasPrefix(raw[k], "  ") {
+			break
+		}
+		block = append(block, l)
+	}
+	for len(block) > 0 && block[len(block)-1] == "" {
+		block = block[:len(block)-1]
+	}
+	return strings.Join(block, "\n"), true
+}
+
+// stripReplyMarker removes claude's assistant-turn bullet ("⏺ ", U+23FA) from the
+// start of a line so the extracted/spoken text is clean prose. The marker only
+// leads the first line of a reply; continuation lines (claude indents them with
+// spaces) carry no marker and are returned untouched, so their indentation is
+// preserved. A line whose only lead is the marker collapses to its text.
+func stripReplyMarker(l string) string {
+	if rest, ok := strings.CutPrefix(strings.TrimLeft(l, " "), "⏺"); ok {
+		return strings.TrimLeft(rest, " ")
+	}
+	return l
 }
 
 // contentLines splits VisibleText into lines, drops noise lines (prompt region,
@@ -121,7 +178,7 @@ func contentLines(visible string) []string {
 		if isNoiseLine(l) {
 			continue
 		}
-		out = append(out, strings.TrimRight(l, " \t"))
+		out = append(out, stripReplyMarker(strings.TrimRight(l, " \t")))
 	}
 	// Trim leading/trailing empties left behind after noise removal.
 	for len(out) > 0 && out[0] == "" {

--- a/adapter_v2/internal/extract/noise.go
+++ b/adapter_v2/internal/extract/noise.go
@@ -41,10 +41,47 @@ func isNoiseLine(line string) bool {
 	if isSpinnerLine(t) {
 		return true
 	}
+	if isStatusLine(t) {
+		return true
+	}
 	if isBoxDrawingOnly(t) {
 		return true
 	}
 	return false
+}
+
+// isStatusLine matches claude's persistent footer / completion chrome that sits
+// below the reply and whose values mutate every turn (so it slips past the diff
+// baseline): the "✻ Worked for Ns" completion summary, the "[Opus … (… context)]"
+// model line, the "Context …" / "Usage …" meters, and the "… for agents" hint.
+// These are never reply content, so dropping them keeps the spoken text clean.
+func isStatusLine(t string) bool {
+	// A leading dingbat star (U+2722–U+2747) is claude's animated spinner /
+	// completion-summary glyph: "✻ Cogitating…", "✶ Worked for 2s", etc. The verb
+	// and glyph both cycle, but the leading star is stable, so a range check is
+	// far more robust than blocklisting each phrase.
+	if r := firstRune(t); r >= 0x2722 && r <= 0x2747 {
+		return true
+	}
+	switch {
+	case strings.Contains(t, "Worked for") || strings.Contains(t, "Cogitated for"):
+		return true // completion summary without a star glyph
+	case strings.HasPrefix(t, "Context ") || strings.HasPrefix(t, "Usage "):
+		return true // footer progress meters
+	case strings.HasPrefix(t, "[") && strings.Contains(t, "context)]"):
+		return true // "[Opus 4.8 (1M context)] │ …" model status
+	case strings.Contains(t, "for agents"):
+		return true // "… ← for agents" footer hint
+	}
+	return false
+}
+
+// firstRune returns the first rune of s, or 0 for the empty string.
+func firstRune(s string) rune {
+	for _, r := range s {
+		return r
+	}
+	return 0
 }
 
 // isPromptLine matches the CLI input line where the user types. claude renders
@@ -55,11 +92,15 @@ func isPromptLine(t string) bool {
 	// Strip a leading left-border glyph if the emulator kept it.
 	t = strings.TrimLeft(t, "│|")
 	t = strings.TrimSpace(t)
-	if t == ">" {
-		return true // empty idle prompt
-	}
-	if strings.HasPrefix(t, "> ") {
-		return true // "> what the user typed"
+	// claude renders the prompt glyph as "❯" (U+276F); older/other CLIs use a
+	// plain ">". Match both, empty (idle) or holding the user's typed text.
+	for _, p := range []string{">", "❯"} {
+		if t == p {
+			return true // empty idle prompt
+		}
+		if strings.HasPrefix(t, p+" ") {
+			return true // "❯ what the user typed"
+		}
 	}
 	return false
 }

--- a/adapter_v2/internal/extract/testdata/claude_reply.expected.txt
+++ b/adapter_v2/internal/extract/testdata/claude_reply.expected.txt
@@ -1,3 +1,3 @@
- The capital of France is Paris.
+The capital of France is Paris.
   It has been the country's capital since the 12th century
   and is its largest city.

--- a/adapter_v2/internal/vtscreen/vtscreen.go
+++ b/adapter_v2/internal/vtscreen/vtscreen.go
@@ -74,6 +74,14 @@ type Screen struct {
 	// oldest first, capped at maxScrollback. Each entry is one fully-resolved
 	// grid row (length == cols at the time it scrolled off).
 	scrollback []scrollLine
+
+	// pending holds the trailing bytes of an incomplete UTF-8 sequence carried
+	// over from the previous Feed. vt10x does NOT buffer a partial rune across
+	// Write calls (a multibyte rune split across writes is dropped), and a PTY
+	// read can split a rune at the chunk boundary, so we hold the incomplete
+	// tail here and prepend it to the next chunk. ≤3 bytes (the max UTF-8
+	// continuation length).
+	pending []byte
 }
 
 // scrollLine is one captured scrollback row.
@@ -97,45 +105,103 @@ func New(cols, rows int) *Screen {
 // Feed advances the emulator by parsing raw PTY output bytes, capturing any
 // rows that scroll off the top of the primary screen into the scrollback ring.
 //
-// vt10x discards scrolled-off lines, so to recover them we watch for the moment
-// a scroll can happen — the cursor sitting on the bottom row of the primary
-// screen — and snapshot the top rows around that byte to diff what shifted off.
-// Bytes that cannot trigger a primary-screen scroll are written in bulk runs so
-// the common case (no pending scroll) stays cheap.
+// The whole chunk is written to vt10x in ONE call (after prepending any partial
+// rune held from the previous Feed). This is essential for correctness: vt10x
+// does not buffer an incomplete UTF-8 sequence across Write calls, so feeding
+// byte-by-byte — or splitting a multibyte rune (❯, …, box-drawing, CJK …) at a
+// chunk boundary — silently drops that rune. claude's TUI is dense with
+// multibyte glyphs, so a faithful device-line scrape requires whole-rune writes.
+//
+// vt10x discards lines that scroll off the top, so to recover them for the
+// scrollback ring we snapshot the grid before the write and diff it against the
+// result, pushing any rows that shifted off. This captures a clean upward scroll
+// of one chunk; a single chunk that scrolls more than a screenful (rare for the
+// ~KB PTY reads we get) keeps only the most recent screen of evicted rows, which
+// is acceptable for best-effort reconnect history.
 func (s *Screen) Feed(p []byte) {
-	for i := 0; i < len(p); {
-		// Fast path: accumulate a run of bytes that cannot scroll the primary
-		// screen, then write it in one call. A scroll is only possible once the
-		// cursor reaches the bottom row of the primary screen.
-		if !s.scrollPossible() {
-			j := i
-			for j < len(p) && !s.scrollPossible() {
-				// vt10x.Terminal implements io.Writer; Write never errors for an
-				// in-memory terminal, so we ignore the result.
-				_, _ = s.term.Write(p[j : j+1])
-				j++
-			}
-			i = j
-			continue
-		}
+	data := p
+	if len(s.pending) > 0 {
+		data = append(s.pending, p...)
+		s.pending = nil
+	}
 
-		// Slow path: a scroll might occur. Snapshot the top region, feed one
-		// byte, then capture whatever rolled off the top.
-		before := s.copyGrid()
-		_, _ = s.term.Write(p[i : i+1])
-		i++
-		s.captureScroll(before)
+	// Hold back a trailing incomplete UTF-8 sequence for the next Feed.
+	n := completeUTF8Prefix(data)
+	if n < len(data) {
+		s.pending = append([]byte(nil), data[n:]...) // fresh copy: never aliases data
+	}
+	data = data[:n]
+	if len(data) == 0 {
+		return
+	}
+
+	// Feed the line CONTENT up to each '\n' first, then the '\n' on its own with a
+	// before/after diff. A '\n' at the bottom row is what scrolls a line off the
+	// top; isolating it means the just-written line is already on screen when we
+	// snapshot, so captureScroll's diff cleanly recovers the evicted row. Writing
+	// the content first (in bulk) keeps multibyte runes and ANSI escapes intact —
+	// '\n' (0x0A) never appears inside either. (A line that scrolls by wrapping,
+	// with no '\n', is not captured; that is an acceptable best-effort gap for
+	// reconnect history.)
+	start := 0
+	for i := 0; i < len(data); i++ {
+		if data[i] == '\n' {
+			if i > start {
+				_, _ = s.term.Write(data[start:i]) // line content; no scroll yet
+			}
+			s.feedNewline(data[i : i+1]) // the '\n' alone, with scroll capture
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		_, _ = s.term.Write(data[start:]) // trailing content after the last '\n'
 	}
 }
 
-// scrollPossible reports whether the next byte could push a line off the top of
-// the primary screen: only when we are on the primary screen with the cursor on
-// (or below) the last row.
-func (s *Screen) scrollPossible() bool {
-	if s.onAlternate() {
-		return false
+// feedNewline writes a single '\n' (the byte that scrolls a line off the bottom),
+// capturing the evicted row into the scrollback ring via a before/after diff.
+func (s *Screen) feedNewline(nl []byte) {
+	before := s.copyGrid()
+	// vt10x.Terminal implements io.Writer; Write never errors for an in-memory
+	// terminal, so we ignore the result.
+	_, _ = s.term.Write(nl)
+	s.captureScroll(before)
+}
+
+// completeUTF8Prefix returns the length of the longest prefix of b that ends on
+// a UTF-8 rune boundary — i.e. it excludes a trailing incomplete multibyte
+// sequence (but never an ASCII byte or a complete rune). Escape sequences are
+// all single-byte and so are never held back; only a split multibyte rune is.
+func completeUTF8Prefix(b []byte) int {
+	if len(b) == 0 {
+		return 0
 	}
-	return s.term.Cursor().Y >= s.rows-1
+	// Walk back over trailing continuation bytes (10xxxxxx) to find the lead.
+	i := len(b) - 1
+	for i >= 0 && b[i]&0xC0 == 0x80 {
+		i--
+	}
+	if i < 0 {
+		return len(b) // all continuation bytes (malformed) — feed as-is
+	}
+	c := b[i]
+	var need int
+	switch {
+	case c&0x80 == 0x00:
+		need = 1
+	case c&0xE0 == 0xC0:
+		need = 2
+	case c&0xF0 == 0xE0:
+		need = 3
+	case c&0xF8 == 0xF0:
+		need = 4
+	default:
+		return len(b) // invalid lead byte — let vt10x deal with it
+	}
+	if len(b)-i >= need {
+		return len(b) // the final rune is complete
+	}
+	return i // incomplete final rune starts at i; cut before it
 }
 
 // captureScroll compares the grid before the last byte against the grid after

--- a/adapter_v2/web/index.html
+++ b/adapter_v2/web/index.html
@@ -26,10 +26,16 @@
     "reconnected" frame arrives so the replay paints onto a clean grid.
   -->
 
-  <!-- xterm.js core + fit addon, pinned so the CDN can't drift under us. -->
+  <!-- xterm.js core + addons, pinned so the CDN can't drift under us.
+       The WebGL/Canvas renderer addons matter: WITHOUT one, xterm.js falls back
+       to its DOM renderer, which mis-paints SGR backgrounds (claude's light input
+       field bled into a full-width bar) and decoration lines. WebGL rasterizes
+       backgrounds/decorations to the measured cell box; Canvas is the fallback. -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-webgl@0.18.0/lib/addon-webgl.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-canvas@0.7.0/lib/addon-canvas.min.js"></script>
 
   <style>
     :root { color-scheme: dark; }
@@ -104,15 +110,71 @@
     // ── xterm.js setup ─────────────────────────────────────────────────────
     const term = new Terminal({
       cursorBlink: true,
-      fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+      fontFamily: "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
       fontSize: 14,
       // Let the alternate-screen TUIs (claude, etc.) use proposed APIs.
       allowProposedApi: true,
-      theme: { background: "#1a1a1a", foreground: "#c7c7c7" },
+      // A COMPLETE theme: without the 16 ANSI colors + cursor/selection, xterm.js
+      // resolves claude's palette against its own defaults, which (with no
+      // renderer addon) showed claude's light input field as a near-white bar and
+      // the cursor as a hollow box. These values are a calm dark scheme.
+      theme: {
+        background: "#1a1a1a",
+        foreground: "#c7c7c7",
+        cursor: "#c7c7c7",
+        cursorAccent: "#1a1a1a",
+        selectionBackground: "#3a3a3a",
+        black: "#1a1a1a",
+        red: "#e06c75",
+        green: "#98c379",
+        yellow: "#e5c07b",
+        blue: "#61afef",
+        magenta: "#c678dd",
+        cyan: "#56b6c2",
+        white: "#c7c7c7",
+        brightBlack: "#5c6370",
+        brightRed: "#e06c75",
+        brightGreen: "#98c379",
+        brightYellow: "#e5c07b",
+        brightBlue: "#61afef",
+        brightMagenta: "#c678dd",
+        brightCyan: "#56b6c2",
+        brightWhite: "#ffffff",
+      },
     });
     const fitAddon = new FitAddon.FitAddon();
     term.loadAddon(fitAddon);
     term.open(document.getElementById("terminal"));
+
+    // Renderer: prefer WebGL (crisp SGR backgrounds/decorations), fall back to
+    // Canvas, then xterm's built-in DOM renderer — so it works where WebGL is
+    // unavailable (some mobile browsers) or its context is lost. Must run AFTER
+    // term.open().
+    (function loadRenderer() {
+      if (typeof WebglAddon !== "undefined" && WebglAddon.WebglAddon) {
+        try {
+          const webgl = new WebglAddon.WebglAddon();
+          webgl.onContextLoss(() => {
+            webgl.dispose();
+            loadCanvas();
+          });
+          term.loadAddon(webgl);
+          return;
+        } catch (e) {
+          /* fall through to canvas */
+        }
+      }
+      loadCanvas();
+      function loadCanvas() {
+        if (typeof CanvasAddon !== "undefined" && CanvasAddon.CanvasAddon) {
+          try {
+            term.loadAddon(new CanvasAddon.CanvasAddon());
+          } catch (e) {
+            /* DOM renderer remains */
+          }
+        }
+      }
+    })();
 
     const statusEl = document.getElementById("status");
     function setStatus(text) {


### PR DESCRIPTION
## 背景

合并 #214 后，用真实 `claude` 2.1（而非 mockcli fixture）验证通道②（设备/语音抽取），发现它**对真 claude 完全不工作**——boundary 永不触发、设备永不开口，且屏幕渲染花、中文被吞。`mockcli` 模拟的是简化版 claude，正好匹配启发式，所以单测全绿但真机失败。

本 PR 修掉四个根因，并以真 claude 为准重新验证。

## 四个根因

1. **vtscreen 逐字节喂 vt10x → 丢多字节 UTF-8**
   `Feed` 逐字节 `Write(p[i:i+1])`，而 vt10x 不跨调用缓存半个 rune，导致 claude TUI 里的 `❯ ⏺ ✻ …`、方框、CJK 全被丢弃，屏幕损坏、中文抽成空。改为整块喂、仅在 `\n` 切段做滚动捕获、chunk 边界保留半个 rune。**这才是"CJK 抽成空"的真因，不是 vt10x 不支持宽字符。**

2. **boundary 死等 `>` 空闲提示符**
   真 claude 渲染的是 `❯` + 轮换的 `Try …` 占位提示，永远不是裸 `>`，所以 turn 永不结束。改为「本轮出现过 spinner 且现已消失 + 输出停顿」(sawSpinner) 判定，空闲提示符降为兜底。

3. **抽取把 footer/摘要扫进回复**
   改用 claude 的 `⏺` 回复标记锚定（取该块 + 缩进续行，遇非缩进/噪声行即止），`✻ … for Ns` 摘要和 Context/Usage footer 不再泄漏。`isStatusLine` 用 dingbat 星形字符范围匹配；prompt 分类器认 `❯`。

4. **deviceapi 每轮都先发 ESC → 吞掉首字符**
   空闲态发 ESC 会被当转义序列起始，吞掉文本首字节（英文 `reply`→`eply`，中文首 rune 被毁→整轮丢弃）。改为**仅在真有在飞的轮**（`inFlight` 跟踪）才发 ESC，且 ESC 与文本间留间隔。

## 验证（对真 claude）

| 注入 | 设备抽出的播报文本 |
|---|---|
| `reply with exactly: PONG` | `PONG` |
| `只回复两个字：你好` | `你好` |

`go build / vet / test / -race` 全绿（含 deviceapi/extract/vtscreen），`-tags e2e` mockcli 冒烟通过。

## 范围

仅改 `adapter_v2/`（vtscreen / extract / deviceapi + DESIGN 注释更正），不动 v1。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)