### PR TITLE
feat(adapter_v2): bbwire/2 设备协议 Phase A(/v2/dev/ws)

### DIFF
--- a/adapter_v2/Makefile
+++ b/adapter_v2/Makefile
@@ -74,7 +74,7 @@ test:
 # -count=1 disables the test cache so the smoke really re-runs (it spawns a child
 # process and is the thing we want to actually exercise on demand).
 e2e:
-	$(GO) test -tags e2e -count=1 -run 'TestE2E' ./internal/deviceapi/...
+	$(GO) test -tags e2e -count=1 -run 'TestE2E' ./...
 
 clean:
 	@rm -rf "$(BIN_DIR)"

--- a/adapter_v2/cmd/bbclaw-adapter-v2/main.go
+++ b/adapter_v2/cmd/bbclaw-adapter-v2/main.go
@@ -31,6 +31,8 @@ import (
 	"nhooyr.io/websocket"
 
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/config"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/deviceapi"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/devicews"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/ptyhost"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/termchan"
@@ -90,6 +92,15 @@ func newRouter(mgr *session.Manager, cfg config.Config) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", wsHandler(mgr, cfg))
 	mux.HandleFunc("/healthz", healthzHandler)
+
+	// bbwire/2 device protocol, Phase A (adapter_v2/docs/device-protocol.md).
+	// Real ASR/TTS (with codec negotiation) arrive with the shared voice module;
+	// until then a placeholder recognizer (fixed transcript) + the codec-correct
+	// SilentSynthesizer (pcm16) keep the endpoint live so a device or the sim
+	// script can exercise the transport end to end. NB: we deliberately do NOT use
+	// SayTTS here — it emits WAV, which the Phase A sink would mislabel as pcm16.
+	devSrv := devicews.New(mgr, deviceapi.StaticRecognizer{Text: "你好"}, deviceapi.SilentSynthesizer{}, cfg.Argv, cfg.Cwd, devicews.Options{})
+	mux.HandleFunc("/v2/dev/ws", devSrv.Handler())
 	// The embedded web client at "/". ServeMux prefers the more specific "/ws"
 	// and "/healthz" patterns over this catch-all, so the file server only sees
 	// requests those two don't claim.

--- a/adapter_v2/docs/device-protocol.md
+++ b/adapter_v2/docs/device-protocol.md
@@ -1,0 +1,124 @@
+# adapter_v2 设备协议 bbwire/2（提案 — 待签字）
+
+> 状态：**提案,待维护者签字后实施**。由 3 版独立设计(latency / firmware-simplicity / SaaS-relay)评审综合而来。
+> 影响三方:**固件 / Cloud 中继 / adapter_v2**——签字后再动手。
+
+## 核心原则
+
+**一条设备主动拨出的 WebSocket;WS 帧的 opcode 即类型判别符。JSON 永不携带音频,二进制帧永不携带控制。**
+
+- LAN 直连:`wss://<adapter-host>/v2/dev/ws`
+- SaaS:`wss://bbclaw.daboluo.cc/v2/dev/ws`（仅 host 串不同,沿用 cloud_saas 出站姿态,家里不开入站口）
+
+一条 socket 取代 v1 的四个端点(`/v1/stream/start|chunk|finish` + `/v1/tts/synthesize`)。
+
+## 两种帧
+
+- **TEXT 帧(opcode 0x1)**= 一个 JSON 控制对象(`t` 字段为类型)。
+- **二进制帧(opcode 0x2)**= 8 字节小端头 + 原始编码音频(**无 base64**,省掉 v1 的 ~33% 开销):
+
+```
+byte 0    streamKind  0x01=上行麦克风  0x02=下行TTS
+byte 1    codec       0x01=opus  0x02=pcm16
+bytes 2-3 turnSeq     uint16,镜像 JSON 轮次的 u
+bytes 4-5 frameSeq    uint16,每轮单调递增(gap/重排/断线续传)
+bytes 6-7 flags       bit0=本轮末帧  bit1=opus-config/关键帧
+bytes 8.. 原始音频
+```
+
+(保留 8 字节头——断线续传 `ack upTo` 和中继路由都需要它;拒绝了无头方案和 16 字节过度设计。)
+
+## 帧 schema
+
+**上行(设备→adapter)**
+```
+{"t":"hello","proto":2,"dev":"<id>","auth":"<token>","mic":{"codec":"opus","rate":16000,"ch":1},"spk":{"codec":"pcm16","rate":16000},"resume":"<lastTurnId|空>"}
+{"t":"ptt.start","turnId":"u7","u":7}        // 按下PTT,开上行流 u=7
+   (二进制上行帧 streamKind=0x01,u=7 在说话过程中边录边传)
+{"t":"ptt.stop","turnId":"u7","u":7,"frames":42}
+{"t":"ack","forTurn":"u7","upTo":120}        // 已播下行到 frameSeq=120(流控/barge-in截断点)
+{"t":"ping"}
+```
+
+**下行(adapter→设备)**
+```
+{"t":"hello.ok","proto":2,"sessionId":"s_abc","spk":{...},"resumed":false}
+{"t":"asr.final","turnId":"u7","text":"play some jazz"}   // 注入PTY的转写(屏幕回显)
+{"t":"reply.start","turnId":"u7"}
+{"t":"reply.delta","turnId":"u7","seq":3,"text":"Sure, "} // 增量回复文本,喂1.47"屏
+{"t":"reply.end","turnId":"u7","text":"Sure, playing jazz now."} // 权威最终文本
+   (二进制下行帧 streamKind=0x02,u=7 携带TTS,逐句合成即流式下发;flags.final=末帧)
+{"t":"turn","turnId":"u7","state":"thinking|speaking|idle"} // 粗粒度忙/闲,idle=可PTT
+{"t":"interrupted","turnId":"u7","atSeq":118}
+{"t":"error","turnId":"u7","code":"ASR_EMPTY|ASR_TIMEOUT|TTS_FAILED|BUSY|UNAUTH","detail":"..."}
+```
+
+## PTT 一轮往返
+
+1. 空闲:设备持 WS(开机一次 hello/hello.ok,ping 保活)。
+2. 按 PTT → `ptt.start{u}`(若上一轮在回复 → 隐式打断,走现有 ESC 路径)。
+3. 按住时麦克风 Opus 包**边编码边以二进制帧上传**(说话同时上传,无 3-POST)。
+4. adapter 累积上行帧。
+5. 松 PTT → 末帧置 `flags.final` + `ptt.stop`。adapter `Recognizer.Transcribe(buf)` → `asr.final` → `Bridge.SubmitVoiceTurn` 注入 PTY(与今天完全同路)。
+6. PTY 渲染回复,extractor 抓增量 → 立即 `reply.delta` 下发(流式),小屏实时更新。
+7. 回复文本按句切分,逐句 `Synthesizer.Synthesize` → 即合即以二进制下发,**第一句已在播,第二句还在抓/合**。
+8. `Detector.TurnEnded` → `reply.end` + 末音频帧 + `turn{idle}`。
+
+## 鉴权 & 会话
+
+- **握手一次鉴权**(`hello.auth` = v1 的 Bearer),每连接一次,非每请求。
+- **会话 = 这条 socket,1:1 绑一个 `deviceapi.Bridge`(一设备=一PTY会话)**,退掉 v1 的 deviceId+sessionKey+streamId 三元组。`sessionId` 由 adapter 返回,**与手机/web termchan 客户端可 attach 的是同一个 PTY 会话**(单 PTY 双视图)。
+- **会话独立于连接存活**(Phase 1 已有的保证)。重连发 `hello{resume}`,adapter 补发未 ack 的下行,不重传音频。
+
+## 映射到 deviceapi(adapter_v2 实际改动)
+
+**接口签名不变**,协议是包在现有接口外的传输壳:
+- 上行二进制帧 → 每轮 buffer → `ptt.stop` 时 `Recognizer.Transcribe(audio)`(今天的批量接口)。
+- 转写 → `SubmitVoiceTurn` → `session.Write` — **不变**。
+- 隐式/显式 barge-in → 现有 `inFlight`/ESC/`interruptSettle`/`rearm` — **不变**。
+- **仅两处真改动**:
+  1. **流式 `reply.delta`**:今天 `maybeSpeak` 只在 `TurnEnded` 发一次;改为 `Run` 在每次 `OnOutput()` 推增量,`reply.end` 权威去重。**触及最脆的 extract 层**——增量是 cosmetic、`end` 兜底,关掉则退回 boundary-only 安全路径(flag 门控)。
+  2. **`DeviceSink` 变二进制帧 writer**:桩 `DiscardSink` 换成 `Play` 加 8 字节头 + `ws.Write`。
+
+## 固件改动(净更简单)
+
+cloud_saas 模式已有大部分:
+- **删**:三个 HTTP POST + 单独 TTS POST、麦克风 base64 编码、`audioBase64` 解码、seq/streamId/sessionKey 簿记、INVALID_SEQUENCE 重试。
+- **留并泛化**:`esp_websocket_client`、二进制收发、`tts_audio_buf` 累积、`bb_ogg_opus_decoder`、ping、自动重连。LAN 直连与 SaaS 收敛到**同一条代码路径**(仅 host 不同)。
+- 状态机缩到 3 态:IDLE/CAPTURING/BUSY。
+- 新增小逻辑:`u` 计数器、`reply.delta` 上屏、barge-in 停本地播放+`ack upTo`。
+
+## Cloud 改动(加性,且一举两得)
+
+设备语音 over SaaS 骑**现有出站中继**,只是帧格式变:
+- `router.Envelope` 加 `streamType`(`voice`/`terminal`)+ `seq`(加性,旧 peer 忽略)。**语音和 Phase-4 手机终端共用一条隧道**,按 `sessionId+streamType` 解复用——**这就是 saas-takeover §"帧 mux" 那条 ADR,语音和终端共享**。
+- 二进制帧按小 streamRef 边表 O(1) 路由(不逐包解 JSON),verbatim 透传保住免 base64。
+- ASR/TTS 位置做成**每设备能力位**(同一 schema):Cloud 终止(默认,今天的路径,base64→二进制)或 Home 终止(LAN 私有,Cloud 透传二进制给 HomeAdapter)。设备协议字节级一致。
+
+## 分期
+
+- **Phase A(LAN 直连,无 Cloud)**:adapter_v2 起 `/v2/dev/ws`,仅必需路径——批量 ASR、`reply.end`-only(暂无流式增量)、一次性 TTS。**零 deviceapi 接口改动**,证明传输契约。
+- **Phase B**:流式 `reply.delta` + 逐句 TTS。
+- **Phase C**:resume/`ack` + barge-in 截断。
+- **Phase D**:接 Cloud 中继(`streamType:voice` + 边表),Cloud-ASR/Home-ASR 能力位;Phase-4 终端 mux 落同一 envelope。
+
+## 首个里程碑(签字验收门)
+
+一个**冒充 ESP32 的 Go/Python WS 客户端**打 Phase-A `/v2/dev/ws`,无真 agent、无网络(复用 `cmd/mockcli` + `e2e` 套路):
+1. 拨 `/v2/dev/ws` → `hello` → 期望 `hello.ok`。
+2. `ptt.start{u:1}` → 几个二进制上行帧(canned PCM16,codec=0x02 免 Opus 依赖)→ `ptt.stop`(末帧 flags.final)。
+3. 背后 adapter 接 `StaticRecognizer`(转写="hello")→ `SubmitVoiceTurn` → `cmd/mockcli` PTY(渲染 `ANSWER: hello`)。
+4. 断言:收到 `asr.final{"hello"}` → `reply.end` 含 `ANSWER: hello` → ≥1 个 `streamKind=0x02` 二进制下行帧(flags.final)→ `turn{idle}`。
+
+`make -C adapter_v2 e2e` 可跑,无外部依赖。**这个测试锁死传输契约,在任何固件/Cloud 改动之前就能签字。**
+
+## 接受的取舍
+
+1. 流式 `reply.delta` 触及最脆的 extract 层(flag 门控,可退回 boundary-only)。
+2. 逐句 TTS 需对进行中的回复切句(可能韵律变碎;支持一次性合成兜底)。
+3. 二进制 framing 比 v1 无状态 POST 多点固件状态、不好 curl 调(但 cloud_saas 已付这成本)。
+4. 长连是语音线单点(ping ~15s 检出;resume 让恢复便宜)。
+5. Cloud 持每流边表状态(小,turn-end/掉线清理)。
+6. 两条 ASR 位置代码路径要测(换来"SaaS 近白送"+"LAN 私有"同一 schema)。
+7. 砍掉必需的 `asr.partial`(无接口改动;留作未来加性帧)。
+8. 固件+Cloud+adapter 协同改动,靠 `hello.proto:2` 能力握手保证半灰度不炸。

--- a/adapter_v2/internal/deviceapi/deviceapi.go
+++ b/adapter_v2/internal/deviceapi/deviceapi.go
@@ -102,6 +102,21 @@ type DeviceSink interface {
 	Play(ctx context.Context, audio []byte, format string) error
 }
 
+// Events lets a transport (e.g. the bbwire device WebSocket) observe the turn
+// lifecycle so it can emit its own protocol frames around the Bridge's autonomous
+// reply→TTS loop. All methods are invoked from Bridge.Run's goroutine, in order:
+// ReplyComplete (the boundary fired, final reply text) → the Synthesizer/Sink run
+// → TurnIdle (the device may speak again). A nil Events (the default) is a no-op,
+// so the voice-only Bridge is unaffected. Optional; set via SetEvents.
+type Events interface {
+	// ReplyComplete reports the final reply text of a turn, before it is spoken.
+	// The transport emits its reply.end frame here.
+	ReplyComplete(text string)
+	// TurnIdle reports the turn is fully done (spoken) and the device may PTT
+	// again. The transport emits its turn{idle} frame here.
+	TurnIdle()
+}
+
 // Config tunes the Bridge. The zero value is usable: cols/rows fall back to the
 // vtscreen defaults and pollInterval to a sane tick.
 type Config struct {
@@ -119,11 +134,12 @@ const defaultPollInterval = 150 * time.Millisecond
 // Bridge couples one device to one session: ASR transcripts in via
 // SubmitVoiceTurn, completed replies out via Run → Synthesizer → DeviceSink.
 type Bridge struct {
-	sess *session.Session
-	asr  Recognizer
-	tts  Synthesizer
-	sink DeviceSink
-	cfg  Config
+	sess   *session.Session
+	asr    Recognizer
+	tts    Synthesizer
+	sink   DeviceSink
+	cfg    Config
+	events Events // optional turn-lifecycle observer (set via SetEvents)
 
 	// screen is the Bridge's OWN VT mirror of the PTY output, fed by Run from the
 	// raw byte stream it receives as a session Client. It is separate from the
@@ -168,6 +184,10 @@ func New(sess *session.Session, asr Recognizer, tts Synthesizer, sink DeviceSink
 		rearm:  make(chan struct{}, 1),
 	}
 }
+
+// SetEvents attaches a turn-lifecycle observer. Call before Run. Passing nil
+// clears it. Used by the device-WS transport to emit reply.end / turn frames.
+func (b *Bridge) SetEvents(e Events) { b.events = e }
 
 // SubmitVoicePTT is the full PTT entry point: recognise the audio, then inject
 // the transcript as a user turn. Empty/whitespace transcripts are dropped (a
@@ -337,9 +357,25 @@ func (b *Bridge) maybeSpeak(ctx context.Context, det *extract.Detector, extP **e
 	det.Reset()
 
 	if isBlank(text) {
-		return nil // completed turn produced no speakable text (e.g. a tool-only turn)
+		// A completed turn with no speakable text (e.g. a tool-only turn) still
+		// hands control back: tell the transport the device may speak again.
+		if b.events != nil {
+			b.events.TurnIdle()
+		}
+		return nil
 	}
-	return b.speak(ctx, text)
+	// Emit the final text (transport sends reply.end) before synthesising, so the
+	// device screen shows the answer ahead of the audio; then speak; then idle.
+	if b.events != nil {
+		b.events.ReplyComplete(text)
+	}
+	if err := b.speak(ctx, text); err != nil {
+		return err
+	}
+	if b.events != nil {
+		b.events.TurnIdle()
+	}
+	return nil
 }
 
 // speak synthesises one reply and hands the audio to the device sink. A nil

--- a/adapter_v2/internal/devicews/e2e_test.go
+++ b/adapter_v2/internal/devicews/e2e_test.go
@@ -1,0 +1,202 @@
+//go:build e2e
+
+// bbwire/2 device protocol — Phase A acceptance gate (adapter_v2/docs/device-protocol.md).
+//
+// This is THE sign-off test: a WS client impersonates the ESP32 device and drives
+// one full PTT round-trip against the real /v2/dev/ws handler, with no hardware
+// and no network beyond loopback. The only mocks are the device's mouth/ear:
+//   - ASR is a StaticRecognizer (transcript = "hello") standing in for real ASR,
+//   - TTS is the SilentSynthesizer (zero-filled PCM16) standing in for real TTS,
+//   - the agent is cmd/mockcli, a real separately-compiled process under a PTY.
+// Everything between — the protocol framing, session/Bridge wiring, inject, PTY
+// reply scrape, boundary, and the binary-audio downlink — is the production path.
+//
+// Asserts the round-trip the protocol promises:
+//   hello → hello.ok
+//   ptt.start + BINARY mic frames + ptt.stop
+//     → asr.final{"hello"} → reply.end (contains "ANSWER: hello")
+//     → ≥1 BINARY downlink frame (streamKind=tts, flags.final) → turn{idle}
+//
+// Build-tagged `e2e` so plain `go test ./...` stays fast and dep-free; run via
+// `make -C adapter_v2 e2e`.
+package devicews
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/deviceapi"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
+)
+
+func TestE2EDeviceRoundTrip(t *testing.T) {
+	bin := buildMockCLI(t)
+
+	mgr := session.NewManager()
+	srv := New(mgr, deviceapi.StaticRecognizer{Text: "hello"}, deviceapi.SilentSynthesizer{}, []string{bin}, "", Options{})
+	httpSrv := httptest.NewServer(srv.Handler())
+	defer httpSrv.Close()
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http") + "/v2/dev/ws"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second)
+	defer cancel()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+	conn.SetReadLimit(maxFrame)
+
+	// hello → hello.ok
+	writeJSON(t, ctx, conn, map[string]any{
+		"t": "hello", "proto": Proto, "dev": "sim",
+		"mic": map[string]any{"codec": "pcm16", "rate": 16000, "ch": 1},
+		"spk": map[string]any{"codec": "pcm16", "rate": 16000},
+	})
+	if got := readCtrlType(t, ctx, conn); got != "hello.ok" {
+		t.Fatalf("first downlink frame t=%q, want hello.ok", got)
+	}
+
+	// PTT: start, two mic frames (last marked final), stop.
+	writeJSON(t, ctx, conn, map[string]any{"t": "ptt.start", "turnId": "u1", "u": 1})
+	pcm := make([]byte, 320) // a dummy ~10ms PCM16 mic frame; content is irrelevant (ASR is static)
+	writeBinFrame(t, ctx, conn, binHeader{StreamKind: streamUplinkMic, Codec: codecPCM16, TurnSeq: 1, FrameSeq: 0}, pcm)
+	writeBinFrame(t, ctx, conn, binHeader{StreamKind: streamUplinkMic, Codec: codecPCM16, TurnSeq: 1, FrameSeq: 1, Flags: flagFinal}, pcm)
+	writeJSON(t, ctx, conn, map[string]any{"t": "ptt.stop", "turnId": "u1", "u": 1, "frames": 2})
+
+	// Collect downlink frames until turn{idle} or the context expires.
+	var (
+		sawASR, sawReplyEnd, sawIdle bool
+		replyText                    string
+		ttsFinalFrames               int
+	)
+	for !sawIdle {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			break
+		}
+		if typ == websocket.MessageBinary {
+			if h, _, ok := decodeBinFrame(data); ok && h.StreamKind == streamDownlinkTTS && h.Flags&flagFinal != 0 {
+				ttsFinalFrames++
+			}
+			continue
+		}
+		var m map[string]any
+		if json.Unmarshal(data, &m) != nil {
+			continue
+		}
+		switch m["t"] {
+		case "asr.final":
+			if m["text"] == "hello" {
+				sawASR = true
+			}
+		case "reply.end":
+			if s, _ := m["text"].(string); s != "" {
+				replyText = s
+				sawReplyEnd = true
+			}
+		case "turn":
+			if m["state"] == "idle" {
+				sawIdle = true
+			}
+		case "error":
+			t.Fatalf("unexpected error frame: %v", m)
+		}
+	}
+
+	if !sawASR {
+		t.Errorf("never received asr.final{text:\"hello\"}")
+	}
+	if !sawReplyEnd || !strings.Contains(replyText, "ANSWER: hello") {
+		t.Errorf("reply.end text = %q, want a substring \"ANSWER: hello\"", replyText)
+	}
+	if ttsFinalFrames == 0 {
+		t.Errorf("never received a downlink TTS binary frame with flags.final")
+	}
+	if !sawIdle {
+		t.Errorf("never received turn{state:\"idle\"}")
+	}
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+func writeJSON(t *testing.T, ctx context.Context, conn *websocket.Conn, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal %v: %v", v, err)
+	}
+	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write text: %v", err)
+	}
+}
+
+func writeBinFrame(t *testing.T, ctx context.Context, conn *websocket.Conn, h binHeader, payload []byte) {
+	t.Helper()
+	if err := conn.Write(ctx, websocket.MessageBinary, h.encode(payload)); err != nil {
+		t.Fatalf("write binary: %v", err)
+	}
+}
+
+func readCtrlType(t *testing.T, ctx context.Context, conn *websocket.Conn) string {
+	t.Helper()
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal ctrl %q: %v", data, err)
+	}
+	s, _ := m["t"].(string)
+	return s
+}
+
+// buildMockCLI compiles cmd/mockcli into a temp dir and returns the binary path
+// (mirrors the deviceapi e2e helper; duplicated because that one is package-private).
+func buildMockCLI(t *testing.T) string {
+	t.Helper()
+	goBin := goToolPath()
+	bin := filepath.Join(t.TempDir(), "mockcli")
+	cmd := exec.Command(goBin, "build", "-o", bin, "./cmd/mockcli")
+	cmd.Dir = moduleRoot(t, goBin)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build mockcli: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func moduleRoot(t *testing.T, goBin string) string {
+	t.Helper()
+	out, err := exec.Command(goBin, "env", "GOMOD").Output()
+	if err != nil {
+		t.Fatalf("go env GOMOD: %v", err)
+	}
+	gomod := strings.TrimSpace(string(out))
+	if gomod == "" || gomod == os.DevNull {
+		t.Fatalf("no go.mod found from %s", goBin)
+	}
+	return filepath.Dir(gomod)
+}
+
+func goToolPath() string {
+	if p, err := exec.LookPath("go"); err == nil {
+		return p
+	}
+	for _, cand := range []string{"/opt/homebrew/bin/go", "/usr/local/go/bin/go", "/usr/local/bin/go"} {
+		if _, err := os.Stat(cand); err == nil {
+			return cand
+		}
+	}
+	return "go"
+}

--- a/adapter_v2/internal/devicews/frames.go
+++ b/adapter_v2/internal/devicews/frames.go
@@ -1,0 +1,172 @@
+// Package devicews implements the bbwire/2 device protocol (Phase A): one
+// client-dialed WebSocket per device, where the WS frame opcode is the type
+// discriminator — TEXT frames carry JSON control objects, BINARY frames carry an
+// 8-byte header + raw codec audio (no base64). See adapter_v2/docs/device-protocol.md.
+//
+// Phase A scope: the required path only — hello handshake, PTT uplink → batch
+// ASR → inject into the PTY (deviceapi.Bridge), reply.end-only screen text
+// (no streaming reply.delta), and one-shot TTS streamed back as BINARY frames.
+// Streaming deltas, resume/ack, and the Cloud relay are later phases.
+package devicews
+
+import "encoding/binary"
+
+// Proto is the bbwire protocol version announced in the hello handshake.
+const Proto = 2
+
+// streamKind — binary header byte 0.
+const (
+	streamUplinkMic   = 0x01 // device → adapter: mic audio
+	streamDownlinkTTS = 0x02 // adapter → device: synthesized reply audio
+)
+
+// codec — binary header byte 1.
+const (
+	codecOpus  = 0x01
+	codecPCM16 = 0x02
+)
+
+// flags — binary header bytes 6-7 (bitfield).
+const (
+	flagFinal    = 1 << 0 // last frame of this turn's stream
+	flagKeyframe = 1 << 1 // opus config / keyframe present
+)
+
+// binHeaderLen is the fixed little-endian header on every BINARY frame.
+const binHeaderLen = 8
+
+// binHeader is the 8-byte prefix of a BINARY audio frame.
+type binHeader struct {
+	StreamKind byte
+	Codec      byte
+	TurnSeq    uint16 // mirrors the JSON turn's `u`
+	FrameSeq   uint16 // per-turn monotonic; gap/reorder/resume
+	Flags      uint16
+}
+
+// encode prepends the header to payload, returning one BINARY frame body.
+func (h binHeader) encode(payload []byte) []byte {
+	b := make([]byte, binHeaderLen+len(payload))
+	b[0] = h.StreamKind
+	b[1] = h.Codec
+	binary.LittleEndian.PutUint16(b[2:4], h.TurnSeq)
+	binary.LittleEndian.PutUint16(b[4:6], h.FrameSeq)
+	binary.LittleEndian.PutUint16(b[6:8], h.Flags)
+	copy(b[binHeaderLen:], payload)
+	return b
+}
+
+// decodeBinFrame splits a BINARY frame into its header and raw audio payload.
+// ok is false if the frame is too short to hold a header.
+func decodeBinFrame(b []byte) (binHeader, []byte, bool) {
+	if len(b) < binHeaderLen {
+		return binHeader{}, nil, false
+	}
+	h := binHeader{
+		StreamKind: b[0],
+		Codec:      b[1],
+		TurnSeq:    binary.LittleEndian.Uint16(b[2:4]),
+		FrameSeq:   binary.LittleEndian.Uint16(b[4:6]),
+		Flags:      binary.LittleEndian.Uint16(b[6:8]),
+	}
+	return h, b[binHeaderLen:], true
+}
+
+// codecName maps a wire codec byte to the audio-package codec string.
+func codecName(c byte) string {
+	switch c {
+	case codecOpus:
+		return "opus"
+	case codecPCM16:
+		return "pcm16"
+	default:
+		return ""
+	}
+}
+
+// codecByte maps a codec string (e.g. a Synthesizer's OutputFormat) to the wire
+// byte. Anything that is not opus is marked pcm16 (the device's default speaker
+// codec); the actual transcode/format negotiation is a later phase.
+func codecByte(name string) byte {
+	if name == "opus" {
+		return codecOpus
+	}
+	return codecPCM16
+}
+
+// ── Control frames (TEXT/JSON) ──────────────────────────────────────────────
+
+// audioSpec describes a mic or speaker stream in the hello handshake.
+type audioSpec struct {
+	Codec string `json:"codec"`
+	Rate  int    `json:"rate"`
+	Ch    int    `json:"ch,omitempty"`
+}
+
+// ctrlIn is the union of every uplink (device → adapter) control object. Only
+// the fields relevant to its `t` are populated; the rest stay zero.
+type ctrlIn struct {
+	T      string     `json:"t"`
+	Proto  int        `json:"proto,omitempty"`
+	Dev    string     `json:"dev,omitempty"`
+	Auth   string     `json:"auth,omitempty"`
+	Mic    *audioSpec `json:"mic,omitempty"`
+	Spk    *audioSpec `json:"spk,omitempty"`
+	Resume string     `json:"resume,omitempty"`
+	TurnID string     `json:"turnId,omitempty"`
+	U      uint16     `json:"u,omitempty"`
+	Frames int        `json:"frames,omitempty"`
+	UpTo   uint16     `json:"upTo,omitempty"`
+}
+
+// Downlink (adapter → device) control objects. Each sets its own `t`.
+
+type helloOK struct {
+	T         string    `json:"t"`
+	Proto     int       `json:"proto"`
+	SessionID string    `json:"sessionId"`
+	Spk       audioSpec `json:"spk"`
+	Resumed   bool      `json:"resumed"`
+}
+
+type asrFinal struct {
+	T      string `json:"t"`
+	TurnID string `json:"turnId"`
+	Text   string `json:"text"`
+}
+
+type replyEnd struct {
+	T      string `json:"t"`
+	TurnID string `json:"turnId"`
+	Text   string `json:"text"`
+}
+
+type turnState struct {
+	T      string `json:"t"`
+	TurnID string `json:"turnId"`
+	State  string `json:"state"` // thinking | speaking | idle
+}
+
+type errFrame struct {
+	T      string `json:"t"`
+	TurnID string `json:"turnId,omitempty"`
+	Code   string `json:"code"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// turn states.
+const (
+	stateThinking = "thinking"
+	stateSpeaking = "speaking"
+	stateIdle     = "idle"
+)
+
+// error codes.
+const (
+	codeUnauth     = "UNAUTH"
+	codeASREmpty   = "ASR_EMPTY"
+	codeASRTimeout = "ASR_TIMEOUT"
+	codeTTSFailed  = "TTS_FAILED"
+	codeBadProto   = "BAD_PROTO"
+	codeBusy       = "BUSY" // a ptt.start arrived while a turn was still in flight
+)

--- a/adapter_v2/internal/devicews/server.go
+++ b/adapter_v2/internal/devicews/server.go
@@ -1,0 +1,345 @@
+package devicews
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"nhooyr.io/websocket"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/deviceapi"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/ptyhost"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
+)
+
+// maxFrame bounds a single inbound WS frame (mic audio frames can be a few KB).
+const maxFrame = 1 << 20
+
+// anonSeq names sessions for hello frames that omit a device id.
+var anonSeq atomic.Uint64
+
+// wsConn is the slice of *websocket.Conn devicews uses; an interface so tests can
+// drive serve() with an in-memory fake. *websocket.Conn satisfies it.
+type wsConn interface {
+	Read(ctx context.Context) (websocket.MessageType, []byte, error)
+	Write(ctx context.Context, typ websocket.MessageType, p []byte) error
+	Close(code websocket.StatusCode, reason string) error
+}
+
+// Server serves the bbwire/2 device protocol (Phase A) at one HTTP route. One
+// WebSocket connection = one device = one PTY session driven via a deviceapi.Bridge.
+type Server struct {
+	mgr  *session.Manager
+	asr  deviceapi.Recognizer // batch ASR over the buffered PTT utterance
+	tts  deviceapi.Synthesizer
+	argv []string // default CLI to spawn under the PTY
+	cwd  string
+	auth string // shared secret; "" disables auth (dev/LAN)
+	cols int
+	rows int
+}
+
+// Options carries the optional knobs for New.
+type Options struct {
+	Auth string // shared secret expected in hello.auth; "" disables the check
+	Cols int    // PTY grid; defaults to 80
+	Rows int    // PTY grid; defaults to 24
+}
+
+// New builds a device-WS server. asr/tts are the voice providers (a mock ASR and
+// local TTS suffice for Phase A); argv/cwd is the CLI each device session drives.
+func New(mgr *session.Manager, asr deviceapi.Recognizer, tts deviceapi.Synthesizer, argv []string, cwd string, opt Options) *Server {
+	if opt.Cols <= 0 {
+		opt.Cols = 80
+	}
+	if opt.Rows <= 0 {
+		opt.Rows = 24
+	}
+	return &Server{mgr: mgr, asr: asr, tts: tts, argv: argv, cwd: cwd, auth: opt.Auth, cols: opt.Cols, rows: opt.Rows}
+}
+
+// Handler upgrades GET /v2/dev/ws and runs one device session on it.
+func (s *Server) Handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{CompressionMode: websocket.CompressionDisabled})
+		if err != nil {
+			return // Accept wrote the HTTP error
+		}
+		conn.SetReadLimit(maxFrame)
+		s.serve(r.Context(), conn)
+	}
+}
+
+// deviceConn holds the per-connection state and is BOTH the deviceapi.DeviceSink
+// (downlink TTS → binary frames) AND the deviceapi.Events observer (turn lifecycle
+// → control frames). All writes go through writeMu since the read loop and
+// Bridge.Run write concurrently and a WS conn is not safe for concurrent writes.
+// Per-connection turn FSM. Phase A serves exactly ONE turn at a time: a new
+// ptt.start is refused (error BUSY) until the prior turn reaches idle. This is
+// what keeps the turn identity (curTurnID/curU) stable for the whole reply, so
+// Bridge.Run's ReplyComplete/Play/TurnIdle can't stamp an in-flight turn's frames
+// with a newer turn's id — and it bounds the uplink buffer to one utterance.
+// Barge-in (overlapping turns) is a later phase.
+const (
+	connIdle      = iota // ready for ptt.start
+	connCapturing        // ptt.start seen; buffering uplink mic frames
+	connBusy             // ptt.stop seen; reply in flight (ASR→inject→reply→TTS)
+)
+
+type deviceConn struct {
+	ctx  context.Context
+	conn wsConn
+	spk  audioSpec
+
+	writeMu sync.Mutex
+
+	mu        sync.Mutex
+	fsm       int
+	curTurnID string
+	curU      uint16
+	dnSeq     uint16 // downlink frame counter, reset per turn
+}
+
+// tryBeginCapture opens a new turn iff the connection is idle, recording its
+// identity. Returns false (caller should reply BUSY) if a turn is already open.
+func (c *deviceConn) tryBeginCapture(turnID string, u uint16) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.fsm != connIdle {
+		return false
+	}
+	c.fsm = connCapturing
+	c.curTurnID, c.curU, c.dnSeq = turnID, u, 0
+	return true
+}
+
+// captureMatch reports whether a mic frame belongs to the open turn — true only
+// while capturing and the frame's turnSeq matches. Stray frames (no open turn, or
+// a mismatched/zero turnSeq) are dropped, so the uplink buffer can't grow outside
+// a turn.
+func (c *deviceConn) captureMatch(turnSeq uint16) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.fsm == connCapturing && turnSeq == c.curU
+}
+
+// tryBeginReply transitions capturing → busy on ptt.stop. Returns false for a
+// stray ptt.stop with no turn open.
+func (c *deviceConn) tryBeginReply() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.fsm != connCapturing {
+		return false
+	}
+	c.fsm = connBusy
+	return true
+}
+
+// setIdle returns the connection to idle, re-enabling ptt.start.
+func (c *deviceConn) setIdle() {
+	c.mu.Lock()
+	c.fsm = connIdle
+	c.mu.Unlock()
+}
+
+func (c *deviceConn) turn() (string, uint16) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.curTurnID, c.curU
+}
+
+func (c *deviceConn) writeCtrl(v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.conn.Write(c.ctx, websocket.MessageText, b)
+}
+
+func (c *deviceConn) writeBin(b []byte) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return c.conn.Write(c.ctx, websocket.MessageBinary, b)
+}
+
+// Play implements deviceapi.DeviceSink: send one reply's synthesized audio as a
+// BINARY downlink frame. Phase A is one-shot per reply, so this single frame is
+// marked final; per-segment streaming is Phase B.
+func (c *deviceConn) Play(_ context.Context, audio []byte, format string) error {
+	c.mu.Lock()
+	u, seq := c.curU, c.dnSeq
+	c.dnSeq++
+	c.mu.Unlock()
+	h := binHeader{
+		StreamKind: streamDownlinkTTS,
+		Codec:      codecByte(format),
+		TurnSeq:    u,
+		FrameSeq:   seq,
+		Flags:      flagFinal,
+	}
+	return c.writeBin(h.encode(audio))
+}
+
+// ReplyComplete implements deviceapi.Events: the turn's final text → reply.end.
+func (c *deviceConn) ReplyComplete(text string) {
+	turnID, _ := c.turn()
+	_ = c.writeCtrl(replyEnd{T: "reply.end", TurnID: turnID, Text: text})
+}
+
+// TurnIdle implements deviceapi.Events: the turn is fully spoken → turn{idle},
+// and the connection returns to idle so the next ptt.start is accepted.
+func (c *deviceConn) TurnIdle() {
+	turnID, _ := c.turn()
+	_ = c.writeCtrl(turnState{T: "turn", TurnID: turnID, State: stateIdle})
+	c.setIdle()
+}
+
+// serve runs one device connection: hello handshake, then the PTT loop, until the
+// socket drops. The session/PTY outlives the connection (reaped by the session GC
+// once detached); Phase A has no resume, so a reconnect with the same device id
+// simply rejoins the live session.
+func (s *Server) serve(parent context.Context, conn wsConn) {
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+	dc := &deviceConn{ctx: ctx, conn: conn, spk: defaultSpk()}
+
+	// 1. hello handshake (first frame, TEXT).
+	typ, data, err := conn.Read(ctx)
+	if err != nil {
+		conn.Close(websocket.StatusNormalClosure, "")
+		return
+	}
+	var hello ctrlIn
+	if typ != websocket.MessageText || json.Unmarshal(data, &hello) != nil || hello.T != "hello" {
+		_ = dc.writeCtrl(errFrame{T: "error", Code: codeBadProto, Detail: "expected hello"})
+		conn.Close(websocket.StatusProtocolError, "bad hello")
+		return
+	}
+	if hello.Proto != Proto {
+		// The capability handshake hinges on a known proto; reject a mismatch
+		// rather than silently treating a v1/v3 device as v2.
+		_ = dc.writeCtrl(errFrame{T: "error", Code: codeBadProto, Detail: "unsupported proto"})
+		conn.Close(websocket.StatusProtocolError, "proto")
+		return
+	}
+	if s.auth != "" && hello.Auth != s.auth {
+		_ = dc.writeCtrl(errFrame{T: "error", Code: codeUnauth})
+		conn.Close(websocket.StatusPolicyViolation, "unauthorized")
+		return
+	}
+	if hello.Spk != nil && hello.Spk.Codec != "" {
+		dc.spk = *hello.Spk
+	}
+
+	deviceID := strings.TrimSpace(hello.Dev)
+	if deviceID == "" {
+		deviceID = "dev-anon-" + strconv.FormatUint(anonSeq.Add(1), 10)
+	}
+
+	// 2. session + bridge (the bridge's sink AND events are this conn).
+	sess, err := s.mgr.GetOrCreate(deviceID, ptyhost.Config{
+		Argv:        s.argv,
+		Cwd:         s.cwd,
+		InitialSize: ptyhost.Size{Cols: uint16(s.cols), Rows: uint16(s.rows)},
+	})
+	if err != nil {
+		_ = dc.writeCtrl(errFrame{T: "error", Code: codeBadProto, Detail: "session create failed"})
+		conn.Close(websocket.StatusInternalError, "session")
+		return
+	}
+	// asr is nil on the Bridge: the handler runs ASR itself (so it can emit
+	// asr.final between recognition and injection); the Bridge only needs tts+sink.
+	bridge := deviceapi.New(sess, nil, s.tts, dc, deviceapi.Config{Cols: s.cols, Rows: s.rows})
+	bridge.SetEvents(dc)
+	go bridge.Run(ctx)
+
+	// 3. hello.ok.
+	_ = dc.writeCtrl(helloOK{T: "hello.ok", Proto: Proto, SessionID: deviceID, Spk: dc.spk, Resumed: false})
+
+	// 4. PTT loop.
+	var uplink []byte
+	for {
+		typ, data, err := conn.Read(ctx)
+		if err != nil {
+			break
+		}
+		switch typ {
+		case websocket.MessageBinary:
+			h, payload, ok := decodeBinFrame(data)
+			if !ok || h.StreamKind != streamUplinkMic {
+				continue
+			}
+			if dc.captureMatch(h.TurnSeq) {
+				uplink = append(uplink, payload...)
+			}
+		case websocket.MessageText:
+			var m ctrlIn
+			if json.Unmarshal(data, &m) != nil {
+				continue
+			}
+			switch m.T {
+			case "ptt.start":
+				if !dc.tryBeginCapture(m.TurnID, m.U) {
+					// A turn is already in flight: Phase A serves one at a time.
+					_ = dc.writeCtrl(errFrame{T: "error", TurnID: m.TurnID, Code: codeBusy})
+					continue
+				}
+				uplink = uplink[:0]
+			case "ptt.stop":
+				if !dc.tryBeginReply() {
+					continue // stray stop with no turn open
+				}
+				if !s.finishTurn(ctx, dc, bridge, m.TurnID, uplink) {
+					// Nothing was injected (empty/failed ASR): hand control back.
+					_ = dc.writeCtrl(turnState{T: "turn", TurnID: m.TurnID, State: stateIdle})
+					dc.setIdle()
+				}
+				uplink = uplink[:0]
+			case "ping", "ack":
+				// Phase A: WS-layer keepalive covers ping; ack is Phase C.
+			}
+		}
+	}
+
+	cancel()
+	conn.Close(websocket.StatusNormalClosure, "")
+}
+
+// finishTurn transcribes the buffered utterance, emits asr.final + turn{thinking},
+// and injects the transcript into the PTY. Returns true iff a turn was actually
+// injected (so the caller leaves the connection BUSY until the Bridge fires
+// TurnIdle); false on empty/failed ASR or a failed inject, where the caller hands
+// control back to idle. The reply.end / TTS audio / turn{idle} frames of a
+// successful turn are emitted later by the Bridge through dc's Events/Sink.
+func (s *Server) finishTurn(ctx context.Context, dc *deviceConn, bridge *deviceapi.Bridge, turnID string, audio []byte) bool {
+	var text string
+	if s.asr != nil && len(audio) > 0 {
+		t, err := s.asr.Transcribe(ctx, audio)
+		if err != nil {
+			_ = dc.writeCtrl(errFrame{T: "error", TurnID: turnID, Code: codeASRTimeout, Detail: err.Error()})
+			return false
+		}
+		text = t
+	}
+	if strings.TrimSpace(text) == "" {
+		// Nothing recognised: do not poke the CLI.
+		_ = dc.writeCtrl(errFrame{T: "error", TurnID: turnID, Code: codeASREmpty})
+		return false
+	}
+	_ = dc.writeCtrl(asrFinal{T: "asr.final", TurnID: turnID, Text: text})
+	_ = dc.writeCtrl(turnState{T: "turn", TurnID: turnID, State: stateThinking})
+	if err := bridge.SubmitVoiceTurn(text); err != nil {
+		_ = dc.writeCtrl(errFrame{T: "error", TurnID: turnID, Code: codeTTSFailed, Detail: err.Error()})
+		return false
+	}
+	return true
+}
+
+// defaultSpk is the assumed device speaker stream when hello omits it.
+func defaultSpk() audioSpec { return audioSpec{Codec: "pcm16", Rate: 16000, Ch: 1} }

--- a/adapter_v2/internal/devicews/server_test.go
+++ b/adapter_v2/internal/devicews/server_test.go
@@ -1,0 +1,270 @@
+package devicews
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/deviceapi"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
+)
+
+func TestBinHeaderRoundTrip(t *testing.T) {
+	h := binHeader{StreamKind: streamDownlinkTTS, Codec: codecOpus, TurnSeq: 7, FrameSeq: 1234, Flags: flagFinal | flagKeyframe}
+	payload := []byte("audio-bytes")
+	frame := h.encode(payload)
+	if len(frame) != binHeaderLen+len(payload) {
+		t.Fatalf("frame len = %d, want %d", len(frame), binHeaderLen+len(payload))
+	}
+	got, gotPayload, ok := decodeBinFrame(frame)
+	if !ok {
+		t.Fatal("decodeBinFrame !ok on a well-formed frame")
+	}
+	if got != h {
+		t.Errorf("header roundtrip = %+v, want %+v", got, h)
+	}
+	if string(gotPayload) != string(payload) {
+		t.Errorf("payload roundtrip = %q, want %q", gotPayload, payload)
+	}
+}
+
+func TestDecodeBinFrameTooShort(t *testing.T) {
+	if _, _, ok := decodeBinFrame([]byte{0x02, 0x01, 0x00}); ok {
+		t.Error("decodeBinFrame returned ok for a frame shorter than the header")
+	}
+}
+
+func TestCodecMapping(t *testing.T) {
+	for _, tc := range []struct {
+		b    byte
+		name string
+	}{{codecOpus, "opus"}, {codecPCM16, "pcm16"}} {
+		if got := codecName(tc.b); got != tc.name {
+			t.Errorf("codecName(%#x) = %q, want %q", tc.b, got, tc.name)
+		}
+		if got := codecByte(tc.name); got != tc.b {
+			t.Errorf("codecByte(%q) = %#x, want %#x", tc.name, got, tc.b)
+		}
+	}
+	// Unknown formats default to the pcm16 marker (device's default speaker codec).
+	if got := codecByte("mp3"); got != codecPCM16 {
+		t.Errorf("codecByte(mp3) = %#x, want pcm16 marker %#x", got, codecPCM16)
+	}
+}
+
+// TestTurnFSM locks the one-turn-at-a-time guard that prevents the downlink
+// turn-misattribution race (a second ptt.start mid-reply rewriting the turn id)
+// and bounds the uplink buffer (mic frames accepted only while capturing).
+func TestTurnFSM(t *testing.T) {
+	c := &deviceConn{}
+
+	if !c.tryBeginCapture("u1", 1) {
+		t.Fatal("first ptt.start should open a turn from idle")
+	}
+	if c.tryBeginCapture("u2", 2) {
+		t.Error("a second ptt.start while capturing must be refused (BUSY)")
+	}
+	if !c.captureMatch(1) {
+		t.Error("a mic frame for the open turn (turnSeq=1) should match")
+	}
+	if c.captureMatch(2) {
+		t.Error("a mic frame for a different turnSeq must be dropped")
+	}
+
+	if !c.tryBeginReply() {
+		t.Fatal("ptt.stop should move capturing→busy")
+	}
+	if c.tryBeginReply() {
+		t.Error("a second ptt.stop must be refused")
+	}
+	if c.captureMatch(1) {
+		t.Error("no mic frames may be buffered while busy (turn in flight)")
+	}
+	if c.tryBeginCapture("u2", 2) {
+		t.Error("a ptt.start while busy must be refused (BUSY)")
+	}
+
+	c.setIdle()
+	if !c.tryBeginCapture("u2", 2) {
+		t.Error("after the turn reaches idle, a new ptt.start should open a turn")
+	}
+	if id, u := c.turn(); id != "u2" || u != 2 {
+		t.Errorf("turn() = (%q,%d) after reopen, want (\"u2\",2)", id, u)
+	}
+}
+
+func TestServeRejectsBadFirstFrame(t *testing.T) {
+	srv := New(session.NewManager(), deviceapi.StaticRecognizer{Text: "x"}, deviceapi.SilentSynthesizer{}, []string{"cat"}, "", Options{})
+	f := newFakeConn(inFrame{typ: websocket.MessageBinary, data: []byte{0x01, 0x02, 0x03}})
+
+	runServe(srv, f)
+
+	if got := f.firstCtrlType(t); got != "error" {
+		t.Fatalf("want an error frame for a non-hello first frame, got t=%q", got)
+	}
+}
+
+func TestServeRejectsBadAuth(t *testing.T) {
+	srv := New(session.NewManager(), deviceapi.StaticRecognizer{Text: "x"}, deviceapi.SilentSynthesizer{}, []string{"cat"}, "", Options{Auth: "s3cret"})
+	hello, _ := json.Marshal(map[string]any{"t": "hello", "proto": Proto, "auth": "wrong"})
+	f := newFakeConn(inFrame{typ: websocket.MessageText, data: hello})
+
+	runServe(srv, f)
+
+	got := f.findCtrl(t, "error")
+	if got["code"] != codeUnauth {
+		t.Fatalf("want error code %q, got %v", codeUnauth, got)
+	}
+}
+
+func TestServeHelloOK(t *testing.T) {
+	srv := New(session.NewManager(), deviceapi.StaticRecognizer{Text: "x"}, deviceapi.SilentSynthesizer{}, []string{"cat"}, "", Options{})
+	hello, _ := json.Marshal(map[string]any{"t": "hello", "proto": Proto, "dev": "unit"})
+	f := newFakeConn(inFrame{typ: websocket.MessageText, data: hello})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { srv.serve(ctx, f); close(done) }()
+
+	// After the hello, the read loop blocks; we only need to see hello.ok.
+	if got := f.waitForCtrl(t, "hello.ok", 3*time.Second); got["sessionId"] != "unit" {
+		t.Errorf("hello.ok sessionId = %v, want \"unit\"", got["sessionId"])
+	}
+	cancel()
+	f.close()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("serve did not return after cancel")
+	}
+}
+
+// ── fakeConn: an in-memory wsConn for driving serve() without a network ──────
+
+type inFrame struct {
+	typ  websocket.MessageType
+	data []byte
+}
+
+type fakeConn struct {
+	mu     sync.Mutex
+	in     []inFrame
+	idx    int
+	writes [][]byte // captured TEXT frame payloads (control); binary ignored here
+	closed chan struct{}
+}
+
+func newFakeConn(in ...inFrame) *fakeConn {
+	return &fakeConn{in: in, closed: make(chan struct{})}
+}
+
+func (f *fakeConn) Read(ctx context.Context) (websocket.MessageType, []byte, error) {
+	f.mu.Lock()
+	if f.idx < len(f.in) {
+		fr := f.in[f.idx]
+		f.idx++
+		f.mu.Unlock()
+		return fr.typ, fr.data, nil
+	}
+	f.mu.Unlock()
+	select {
+	case <-ctx.Done():
+		return 0, nil, ctx.Err()
+	case <-f.closed:
+		return 0, nil, io.EOF
+	}
+}
+
+func (f *fakeConn) Write(_ context.Context, typ websocket.MessageType, p []byte) error {
+	if typ == websocket.MessageText {
+		f.mu.Lock()
+		f.writes = append(f.writes, append([]byte(nil), p...))
+		f.mu.Unlock()
+	}
+	return nil
+}
+
+func (f *fakeConn) Close(websocket.StatusCode, string) error {
+	f.close()
+	return nil
+}
+
+func (f *fakeConn) close() {
+	select {
+	case <-f.closed:
+	default:
+		close(f.closed)
+	}
+}
+
+// runServe runs serve to completion against an already-terminating fake (the
+// fake's input is exhausted and serve will block then we close it). Used for the
+// rejection tests where serve returns on its own after writing the error+close.
+func runServe(srv *Server, f *fakeConn) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	done := make(chan struct{})
+	go func() { srv.serve(ctx, f); close(done) }()
+	// Rejection paths Close() themselves; for safety also close after a beat.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		f.close()
+		<-done
+	}
+}
+
+func (f *fakeConn) ctrls(t *testing.T) []map[string]any {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]map[string]any, 0, len(f.writes))
+	for _, w := range f.writes {
+		var m map[string]any
+		if json.Unmarshal(w, &m) == nil {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func (f *fakeConn) firstCtrlType(t *testing.T) string {
+	t.Helper()
+	c := f.ctrls(t)
+	if len(c) == 0 {
+		t.Fatal("no control frame was written")
+	}
+	s, _ := c[0]["t"].(string)
+	return s
+}
+
+func (f *fakeConn) findCtrl(t *testing.T, typ string) map[string]any {
+	t.Helper()
+	for _, m := range f.ctrls(t) {
+		if m["t"] == typ {
+			return m
+		}
+	}
+	t.Fatalf("no %q control frame written; got %v", typ, f.ctrls(t))
+	return nil
+}
+
+func (f *fakeConn) waitForCtrl(t *testing.T, typ string, d time.Duration) map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		for _, m := range f.ctrls(t) {
+			if m["t"] == typ {
+				return m
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("control frame %q not written within %s; got %v", typ, d, f.ctrls(t))
+	return nil
+}


### PR DESCRIPTION
## 概述

实现新设备协议 **bbwire/2 的 Phase A**（必需路径），方案详见 `adapter_v2/docs/device-protocol.md`（由 3 版独立设计评审综合、已签字）。取代 v1 的 4 个 HTTP 端点：**一条设备拨出的 WebSocket;WS 帧 opcode 即类型——TEXT 帧走 JSON 控制,二进制帧走 8 字节头 + 原始编码音频(无 base64)。**

## Phase A 往返(由签字门 e2e 锁定)

```
hello → hello.ok
ptt.start + 二进制麦克风帧 + ptt.stop
  → 批量 ASR → asr.final → SubmitVoiceTurn(注入 PTY)
  → reply.end(boundary-only 屏幕文本)→ 二进制 TTS 帧(flags.final)
  → turn{idle}
```

## 实现

- `internal/devicews/frames.go` — bbwire/2 帧编解码(8 字节二进制头 + 控制 JSON)。
- `internal/devicews/server.go` — `/v2/dev/ws` 处理器。一个 `deviceConn` 兼任 `deviceapi.DeviceSink`(下行 TTS→二进制帧)与 `deviceapi.Events`(reply.end/turn→控制帧)。**一次一轮 FSM(idle/capturing/busy)**:重叠 `ptt.start` 回 `error{BUSY}`——保证整轮 turn 标识稳定(下行不错配)、上行 buffer 有界。hello 校验 proto + 可选鉴权。
- `internal/deviceapi`:加性 `Events` 接口 + `SetEvents`;`maybeSpeak` 在现有 speak 路径两侧调 `ReplyComplete/TurnIdle`。语音-only Bridge 不受影响(nil Events = no-op)。
- `cmd/.../main.go`:接 `/v2/dev/ws`。占位 ASR(固定转写)+ codec 正确的 `SilentSynthesizer`(pcm16),真 ASR/TTS 等共享 voice module。

## 测试

- 帧编解码 + 握手/鉴权 + **turn-FSM** 单测(快、无依赖)
- **签字门 e2e**(`e2e_test.go`,build tag `e2e`):冒充 ESP32 打真处理器 + `cmd/mockcli`,`make -C adapter_v2 e2e` 可跑
- `go build / vet / test / -race` 全绿
- 三视角对抗式 review(并发/协议/生命周期),major 项全修(turn 错配竞态、proto 校验、TTS codec 标签、上行无界 buffer)

## 范围

仅 `adapter_v2/`,不动 v1。后续阶段(B 流式增量+逐句TTS / C resume+barge-in / D Cloud 中继)与真 ASR/TTS(共享 module)单独跟踪。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)