### PR TITLE
feat(adapter_v2): bbwire/2 Phase B — 流式 reply.delta + 逐句 TTS

### DIFF
--- a/adapter_v2/cmd/bbclaw-adapter-v2/main.go
+++ b/adapter_v2/cmd/bbclaw-adapter-v2/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -107,14 +108,35 @@ func newRouter(mgr *session.Manager, cfg config.Config) http.Handler {
 	// the endpoint is always live for the sim script / a device. Opus mic audio is
 	// decoded to PCM16 before ASR (ffmpeg).
 	rec, syn, asrMode, ttsMode := voicekit.FromEnv()
-	log.Printf("bbclaw-adapter-v2: device line ASR=%s TTS=%s", asrMode, ttsMode)
-	devSrv := devicews.New(mgr, rec, syn, cfg.Argv, cfg.Cwd, devicews.Options{Decode: voicekit.DecodeUplink})
+	// Phase B streaming: reply.delta on by default (cosmetic, reply.end is
+	// authoritative); per-segment TTS opt-in (ADAPTER_V2_SEGMENT_TTS=1).
+	streamDelta := envBool("ADAPTER_V2_STREAM_DELTA", true)
+	segmentTTS := envBool("ADAPTER_V2_SEGMENT_TTS", false)
+	log.Printf("bbclaw-adapter-v2: device line ASR=%s TTS=%s streamDelta=%v segmentTTS=%v", asrMode, ttsMode, streamDelta, segmentTTS)
+	devSrv := devicews.New(mgr, rec, syn, cfg.Argv, cfg.Cwd, devicews.Options{
+		Decode:           voicekit.DecodeUplink,
+		StreamReplyDelta: streamDelta,
+		SegmentTTS:       segmentTTS,
+	})
 	mux.HandleFunc("/v2/dev/ws", devSrv.Handler())
 	// The embedded web client at "/". ServeMux prefers the more specific "/ws"
 	// and "/healthz" patterns over this catch-all, so the file server only sees
 	// requests those two don't claim.
 	mux.Handle("/", web.Handler())
 	return mux
+}
+
+// envBool reads a boolean env var (1/true/yes/on = true, 0/false/no/off = false),
+// returning def when unset or unrecognised.
+func envBool(name string, def bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return def
+	}
 }
 
 // healthzHandler is the liveness probe.

--- a/adapter_v2/docs/device-protocol.md
+++ b/adapter_v2/docs/device-protocol.md
@@ -22,11 +22,13 @@ byte 0    streamKind  0x01=上行麦克风  0x02=下行TTS
 byte 1    codec       0x01=opus  0x02=pcm16
 bytes 2-3 turnSeq     uint16,镜像 JSON 轮次的 u
 bytes 4-5 frameSeq    uint16,每轮单调递增(gap/重排/断线续传)
-bytes 6-7 flags       bit0=本轮末帧  bit1=opus-config/关键帧
+bytes 6-7 flags       bit0=可播单元末帧  bit1=opus-config/关键帧
 bytes 8.. 原始音频
 ```
 
 (保留 8 字节头——断线续传 `ack upTo` 和中继路由都需要它;拒绝了无头方案和 16 字节过度设计。)
+
+> **`flags.final` 语义**:标记**一个可播音频单元的末帧**——一次性 TTS 下是整段回复,逐句 TTS（Phase B）下是**一句**(每句一个 final 帧,设备收到即播该句、清累积缓冲)。**turn 结束由 `turn{idle}` 控制帧定,不是 `flags.final`**:设备必须在 `turn{idle}` 重新允许 PTT,绝不能在 `flags.final` 上结束(否则逐句 TTS 只会播第一句就停)。
 
 ## 帧 schema
 
@@ -97,8 +99,8 @@ cloud_saas 模式已有大部分:
 
 ## 分期
 
-- **Phase A(LAN 直连,无 Cloud)**:adapter_v2 起 `/v2/dev/ws`,仅必需路径——批量 ASR、`reply.end`-only(暂无流式增量)、一次性 TTS。**零 deviceapi 接口改动**,证明传输契约。
-- **Phase B**:流式 `reply.delta` + 逐句 TTS。
+- **Phase A ✅（已实现）**:adapter_v2 起 `/v2/dev/ws`,必需路径——批量 ASR、`reply.end`、一次性 TTS。零 deviceapi 接口改动,签字门 e2e 锁契约。
+- **Phase B ✅（已实现）**:**流式 `reply.delta`**（快照模型——每帧带当前完整回复,设备替换字幕,稳健于 TUI 重绘;默认开 `ADAPTER_V2_STREAM_DELTA=1`,`reply.end` 仍权威）+ **逐句 TTS**（append-only 分句 `nextSentence`,切句即合即播,turn 末播尾巴;opt-in `ADAPTER_V2_SEGMENT_TTS=1`,默认关=Phase A 一次性 TTS）。e2e 验 `reply.delta` 到达。
 - **Phase C**:resume/`ack` + barge-in 截断。
 - **Phase D**:接 Cloud 中继(`streamType:voice` + 边表),Cloud-ASR/Home-ASR 能力位;Phase-4 终端 mux 落同一 envelope。
 

--- a/adapter_v2/internal/deviceapi/deviceapi.go
+++ b/adapter_v2/internal/deviceapi/deviceapi.go
@@ -39,6 +39,7 @@ package deviceapi
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -109,6 +110,13 @@ type DeviceSink interface {
 // → TurnIdle (the device may speak again). A nil Events (the default) is a no-op,
 // so the voice-only Bridge is unaffected. Optional; set via SetEvents.
 type Events interface {
+	// ReplyDelta reports the assistant reply text AS IT GROWS during a turn (Phase
+	// B streaming), so the device screen can update live before the turn ends. The
+	// text is the FULL current reply (a snapshot, not an append-delta): the device
+	// replaces its subtitle with it, which is robust to the TUI rewriting/reflowing
+	// the line. Only emitted when Config.StreamReplyDelta is set; ReplyComplete is
+	// always the authoritative final text. The transport emits its reply.delta frame.
+	ReplyDelta(text string)
 	// ReplyComplete reports the final reply text of a turn, before it is spoken.
 	// The transport emits its reply.end frame here.
 	ReplyComplete(text string)
@@ -127,6 +135,18 @@ type Config struct {
 	// chunks, so a turn that ends on a quiet screen (no final byte to wake us) is
 	// still detected promptly. Defaults to a fraction of extract.Quiet.
 	PollInterval time.Duration
+
+	// StreamReplyDelta (Phase B) emits Events.ReplyDelta as the reply grows, for a
+	// live device subtitle. Low risk — ReplyComplete remains authoritative — so
+	// it is safe to default on. Off → the device only sees the reply at turn end.
+	StreamReplyDelta bool
+
+	// SegmentTTS (Phase B) speaks the reply sentence-by-sentence as it streams, so
+	// the speaker starts on sentence 1 while sentence 2 is still being scraped.
+	// Higher risk (sentence segmentation of in-progress text; a TUI rewrite can
+	// cause a re-speak), so it is opt-in. Off → one-shot TTS of the full reply at
+	// turn end (the safe Phase A behaviour).
+	SegmentTTS bool
 }
 
 const defaultPollInterval = 150 * time.Millisecond
@@ -295,9 +315,26 @@ func (b *Bridge) Run(ctx context.Context) error {
 
 	ext := extract.New(b.screen)
 	det := &extract.Detector{}
+	ts := &turnStream{}
 
 	ticker := time.NewTicker(b.cfg.PollInterval)
 	defer ticker.Stop()
+
+	// rebaseline starts a fresh turn: a new Extractor baselined on the current
+	// screen, a reset Detector, and cleared streaming state. It also captures the
+	// reply currently on screen as the turn's `seed`: claude's extractor surfaces
+	// the LAST "⏺" reply block regardless of baseline, so the PRIOR turn's reply is
+	// still extracted until this turn paints its own. onProgress suppresses its
+	// streaming side-effects while the extracted text equals that seed, so a new
+	// turn (or a barge-in) never streams/speaks the previous turn's answer — the
+	// Phase B analogue of the rearm guard in DESIGN.md §8. The boundary path
+	// (maybeSpeak) is unaffected, so an identical repeated reply is still spoken.
+	rebaseline := func() {
+		ext = extract.New(b.screen)
+		det.Reset()
+		seed, _ := ext.OnOutput()
+		*ts = turnStream{seed: seed.Text}
+	}
 
 	for {
 		select {
@@ -309,20 +346,23 @@ func (b *Bridge) Run(ctx context.Context) error {
 			// Re-baseline on the current screen — which, after the injected ESC, has
 			// the interrupted prior reply cleared back toward the idle prompt — so
 			// extract() excludes it, and restart the Detector's settle clock so the
-			// boundary fires on THIS turn, not the partial we just interrupted. This
-			// is the same re-arm maybeSpeak runs after a completed turn.
-			ext = extract.New(b.screen)
-			det.Reset()
+			// boundary fires on THIS turn, not the partial we just interrupted.
+			rebaseline()
 
 		case chunk, ok := <-client.Out:
 			if !ok {
 				return ErrClosed // PTY exited; session closed the channel
 			}
 			b.screen.Feed(chunk)
-			ext.OnOutput() // advance extracted text; we read it at boundary time
+			reply, _ := ext.OnOutput()
 			det.Observe(time.Now(), b.screen, len(chunk) > 0)
-			if err := b.maybeSpeak(ctx, det, &ext); err != nil {
+			if err := b.onProgress(ctx, reply.Text, ts); err != nil {
 				return err
+			}
+			if spoke, err := b.maybeSpeak(ctx, det, reply.Text, ts); err != nil {
+				return err
+			} else if spoke {
+				rebaseline()
 			}
 
 		case <-ticker.C:
@@ -330,31 +370,71 @@ func (b *Bridge) Run(ctx context.Context) error {
 			// screen (the settle window elapsing after the last chunk) is still
 			// detected without waiting for the next unrelated chunk.
 			det.Observe(time.Now(), b.screen, false)
-			if err := b.maybeSpeak(ctx, det, &ext); err != nil {
+			reply, _ := ext.OnOutput()
+			if spoke, err := b.maybeSpeak(ctx, det, reply.Text, ts); err != nil {
 				return err
+			} else if spoke {
+				rebaseline()
 			}
 		}
 	}
 }
 
-// maybeSpeak checks the turn boundary and, if the turn just completed, speaks the
-// extracted reply and re-arms the extractor for the next turn. extP points at the
-// caller's Extractor slot so a fresh Extractor (re-baselined on the current
-// screen) replaces it once the turn is consumed.
-func (b *Bridge) maybeSpeak(ctx context.Context, det *extract.Detector, extP **extract.Extractor) error {
-	if !det.TurnEnded(time.Now()) {
+// turnStream is Run's per-turn streaming state for Phase B: what reply text has
+// been pushed as a delta, and what text has already been spoken sentence-by-
+// sentence. Reset at the start of every turn.
+type turnStream struct {
+	seed      string // the prior turn's reply, still on screen until this turn paints; suppressed by onProgress
+	lastDelta string // last full reply text emitted via Events.ReplyDelta
+	spoken    string // reply prefix already synthesised by per-segment TTS
+}
+
+// onProgress runs the Phase B streaming side-effects on each extraction advance:
+// emit a live reply.delta (snapshot of the full current reply) and, if per-
+// segment TTS is on, speak any newly-completed sentence. Both are no-ops under
+// the safe defaults (StreamReplyDelta off → no delta; SegmentTTS off → all audio
+// happens once at turn end in maybeSpeak).
+func (b *Bridge) onProgress(ctx context.Context, text string, ts *turnStream) error {
+	// Suppress while the screen still shows the PRIOR turn's reply (the seed): this
+	// turn hasn't produced its own output yet, so streaming it would leak the
+	// previous answer (or, on a barge-in, the just-interrupted one). Once this turn
+	// paints distinct text the guard clears for the rest of the turn.
+	if text == ts.seed {
 		return nil
+	}
+	if b.cfg.StreamReplyDelta && text != ts.lastDelta {
+		ts.lastDelta = text
+		if b.events != nil && !isBlank(text) {
+			b.events.ReplyDelta(text)
+		}
+	}
+	if b.cfg.SegmentTTS {
+		// Append-only segmentation: only speak a sentence when the new text extends
+		// what we've already spoken (a TUI rewrite that breaks the prefix is left
+		// for the turn-end speak in maybeSpeak, avoiding mid-turn double audio).
+		if rest, ok := strings.CutPrefix(text, ts.spoken); ok {
+			seg, consumed := nextSentence(rest)
+			if seg != "" && !isBlank(seg) {
+				ts.spoken += consumed
+				if err := b.speak(ctx, seg); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// maybeSpeak checks the turn boundary and, if the turn just completed, speaks the
+// reply (or its unspoken tail under per-segment TTS) and reports spoke=true so the
+// caller re-baselines for the next turn. text is the latest extracted reply.
+func (b *Bridge) maybeSpeak(ctx context.Context, det *extract.Detector, text string, ts *turnStream) (bool, error) {
+	if !det.TurnEnded(time.Now()) {
+		return false, nil
 	}
 	// The turn the user injected is done; a later barge-in now has nothing to
 	// interrupt, so the next SubmitVoiceTurn injects cleanly without an ESC.
 	b.inFlight.Store(false)
-	reply, _ := (*extP).OnOutput()
-	text := reply.Text
-	// Re-arm for the next turn regardless of whether this one had speakable text:
-	// a fresh Extractor baselines the just-finished reply so it is excluded next
-	// time, and the Detector forgets this turn's settle clock.
-	*extP = extract.New(b.screen)
-	det.Reset()
 
 	if isBlank(text) {
 		// A completed turn with no speakable text (e.g. a tool-only turn) still
@@ -362,20 +442,61 @@ func (b *Bridge) maybeSpeak(ctx context.Context, det *extract.Detector, extP **e
 		if b.events != nil {
 			b.events.TurnIdle()
 		}
-		return nil
+		return true, nil
 	}
-	// Emit the final text (transport sends reply.end) before synthesising, so the
-	// device screen shows the answer ahead of the audio; then speak; then idle.
+	// Emit the authoritative final text (transport sends reply.end) before any
+	// remaining audio, so the device screen shows the full answer.
 	if b.events != nil {
 		b.events.ReplyComplete(text)
 	}
-	if err := b.speak(ctx, text); err != nil {
-		return err
+	// Speak the part not already spoken. Under per-segment TTS this is just the
+	// trailing sentence; otherwise (the default) it is the whole reply (one-shot).
+	tail := text
+	if b.cfg.SegmentTTS {
+		if rest, ok := strings.CutPrefix(text, ts.spoken); ok {
+			tail = rest // speak only the unspoken remainder
+		}
+		// If the prefix broke (a rewrite), tail stays the full text — re-speak the
+		// reply rather than leave the device with a half-spoken answer.
+	}
+	if !isBlank(tail) {
+		if err := b.speak(ctx, tail); err != nil {
+			return true, err
+		}
 	}
 	if b.events != nil {
 		b.events.TurnIdle()
 	}
-	return nil
+	return true, nil
+}
+
+// sentenceEnders terminate a spoken segment for per-segment TTS — Latin and CJK
+// full stops, exclamation, question marks, plus the newline that separates a
+// finished line of reply.
+const sentenceEnders = ".!?。！？\n"
+
+// nextSentence returns the first complete sentence at the start of s (up to and
+// including its terminator) and the exact text consumed (so the caller can
+// advance its spoken prefix). It returns ("","") when s holds no terminator yet
+// — i.e. the sentence is still streaming in, so we wait rather than speak a
+// fragment. Trailing whitespace after the terminator is included in `consumed`
+// so the next sentence starts clean.
+func nextSentence(s string) (sentence, consumed string) {
+	idx := strings.IndexAny(s, sentenceEnders)
+	if idx < 0 {
+		return "", ""
+	}
+	end := idx + 1 // include the terminator rune's first byte position
+	// Advance past a multi-byte terminator rune (。！？ are 3 bytes in UTF-8).
+	for end < len(s) && s[end]&0xC0 == 0x80 {
+		end++
+	}
+	consumed = s[:end]
+	// Swallow following spaces/newlines into consumed so the next segment is clean.
+	for end < len(s) && (s[end] == ' ' || s[end] == '\n' || s[end] == '\t') {
+		end++
+	}
+	return strings.TrimSpace(consumed), s[:end]
 }
 
 // speak synthesises one reply and hands the audio to the device sink. A nil

--- a/adapter_v2/internal/deviceapi/streaming_test.go
+++ b/adapter_v2/internal/deviceapi/streaming_test.go
@@ -1,0 +1,132 @@
+package deviceapi
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestNextSentence(t *testing.T) {
+	cases := []struct {
+		in       string
+		sentence string
+		consumed string
+	}{
+		{"", "", ""},
+		{"no terminator yet", "", ""}, // still streaming → wait
+		{"Hello world.", "Hello world.", "Hello world."},
+		{"Hello. Next", "Hello.", "Hello. "}, // swallows the trailing space
+		{"你好。还有", "你好。", "你好。"},            // CJK full stop (3-byte rune)
+		{"Done!\nmore", "Done!", "Done!\n"},  // newline terminator + swallow
+		{"a? b? c", "a?", "a? "},             // first sentence only
+	}
+	for _, c := range cases {
+		gotS, gotC := nextSentence(c.in)
+		if gotS != c.sentence || gotC != c.consumed {
+			t.Errorf("nextSentence(%q) = (%q,%q), want (%q,%q)", c.in, gotS, gotC, c.sentence, c.consumed)
+		}
+	}
+}
+
+// recordingEvents captures the Events callbacks for assertions.
+type recordingEvents struct {
+	mu       sync.Mutex
+	deltas   []string
+	complete []string
+	idles    int
+}
+
+func (e *recordingEvents) ReplyDelta(text string)    { e.mu.Lock(); e.deltas = append(e.deltas, text); e.mu.Unlock() }
+func (e *recordingEvents) ReplyComplete(text string) { e.mu.Lock(); e.complete = append(e.complete, text); e.mu.Unlock() }
+func (e *recordingEvents) TurnIdle()                 { e.mu.Lock(); e.idles++; e.mu.Unlock() }
+
+// TestOnProgressStreamsDeltas: with StreamReplyDelta on, each new reply snapshot
+// fires one ReplyDelta; unchanged text does not; blank text is suppressed.
+func TestOnProgressStreamsDeltas(t *testing.T) {
+	ev := &recordingEvents{}
+	b := &Bridge{cfg: Config{StreamReplyDelta: true}, events: ev}
+	ts := &turnStream{}
+
+	_ = b.onProgress(context.Background(), "", ts)         // blank → no delta
+	_ = b.onProgress(context.Background(), "Hello", ts)    // new → delta
+	_ = b.onProgress(context.Background(), "Hello", ts)    // unchanged → no delta
+	_ = b.onProgress(context.Background(), "Hello world", ts) // grew → delta
+
+	if got := len(ev.deltas); got != 2 {
+		t.Fatalf("deltas = %v (len %d), want 2 [Hello, Hello world]", ev.deltas, got)
+	}
+	if ev.deltas[0] != "Hello" || ev.deltas[1] != "Hello world" {
+		t.Errorf("deltas = %v, want [Hello, Hello world]", ev.deltas)
+	}
+}
+
+// TestOnProgressDeltaOffIsSilent: default config emits no deltas.
+func TestOnProgressDeltaOff(t *testing.T) {
+	ev := &recordingEvents{}
+	b := &Bridge{cfg: Config{}, events: ev}
+	_ = b.onProgress(context.Background(), "Hello", &turnStream{})
+	if len(ev.deltas) != 0 {
+		t.Errorf("deltas = %v, want none when StreamReplyDelta is off", ev.deltas)
+	}
+}
+
+// TestOnProgressSuppressesSeed is the regression guard for the cross-turn leak:
+// claude's extractor surfaces the LAST "⏺" reply block, so at the start of a new
+// turn the PRIOR turn's reply is still extracted until this turn paints. onProgress
+// must NOT stream/speak that seed text (it would leak the previous answer, or on a
+// barge-in the just-interrupted one). Once distinct text appears, streaming flows.
+func TestOnProgressSuppressesSeed(t *testing.T) {
+	ev := &recordingEvents{}
+	tts := &countingTTS{format: "pcm16", out: []byte("AUD")}
+	sink := &recordingSink{}
+	b := &Bridge{cfg: Config{StreamReplyDelta: true, SegmentTTS: true}, events: ev, tts: tts, sink: sink}
+	// New turn opened with the prior turn's reply still on screen as the seed.
+	ts := &turnStream{seed: "ANSWER: alpha."}
+
+	// While the screen still shows the prior reply: no delta, no audio.
+	_ = b.onProgress(context.Background(), "ANSWER: alpha.", ts)
+	if len(ev.deltas) != 0 {
+		t.Errorf("leaked prior reply as a delta: %v", ev.deltas)
+	}
+	if got := tts.calls(); len(got) != 0 {
+		t.Errorf("re-spoke prior reply: %v", got)
+	}
+
+	// This turn paints its own distinct reply → streaming resumes.
+	_ = b.onProgress(context.Background(), "ANSWER: bravo.", ts)
+	if len(ev.deltas) != 1 || ev.deltas[0] != "ANSWER: bravo." {
+		t.Errorf("deltas = %v, want [ANSWER: bravo.] once seed cleared", ev.deltas)
+	}
+	if got := tts.calls(); len(got) != 1 || got[0] != "ANSWER: bravo." {
+		t.Errorf("tts calls = %v, want [ANSWER: bravo.]", got)
+	}
+}
+
+// TestOnProgressSegmentTTSSpeaksPerSentence: with SegmentTTS on, a completed
+// sentence is synthesised as soon as it appears; the trailing incomplete one waits.
+func TestOnProgressSegmentTTSSpeaksPerSentence(t *testing.T) {
+	tts := &countingTTS{format: "pcm16", out: []byte("AUD")}
+	sink := &recordingSink{}
+	b := &Bridge{cfg: Config{SegmentTTS: true}, tts: tts, sink: sink}
+	ts := &turnStream{}
+
+	// Reply streams in: first sentence complete, second still partial, then complete.
+	_ = b.onProgress(context.Background(), "Hello there.", ts)         // speak "Hello there."
+	_ = b.onProgress(context.Background(), "Hello there. How are", ts) // partial 2nd → wait
+	_ = b.onProgress(context.Background(), "Hello there. How are you?", ts) // speak "How are you?"
+
+	calls := tts.calls()
+	if len(calls) != 2 {
+		t.Fatalf("tts calls = %v (len %d), want 2 sentences", calls, len(calls))
+	}
+	if calls[0] != "Hello there." {
+		t.Errorf("first spoken = %q, want %q", calls[0], "Hello there.")
+	}
+	if calls[1] != "How are you?" {
+		t.Errorf("second spoken = %q, want %q", calls[1], "How are you?")
+	}
+	// The spoken prefix advanced past both sentences.
+	if ts.spoken != "Hello there. How are you?" {
+		t.Errorf("spoken prefix = %q, want full text", ts.spoken)
+	}
+}

--- a/adapter_v2/internal/devicews/e2e_test.go
+++ b/adapter_v2/internal/devicews/e2e_test.go
@@ -8,14 +8,16 @@
 //   - ASR is a StaticRecognizer (transcript = "hello") standing in for real ASR,
 //   - TTS is the SilentSynthesizer (zero-filled PCM16) standing in for real TTS,
 //   - the agent is cmd/mockcli, a real separately-compiled process under a PTY.
+//
 // Everything between — the protocol framing, session/Bridge wiring, inject, PTY
 // reply scrape, boundary, and the binary-audio downlink — is the production path.
 //
 // Asserts the round-trip the protocol promises:
-//   hello → hello.ok
-//   ptt.start + BINARY mic frames + ptt.stop
-//     → asr.final{"hello"} → reply.end (contains "ANSWER: hello")
-//     → ≥1 BINARY downlink frame (streamKind=tts, flags.final) → turn{idle}
+//
+//	hello → hello.ok
+//	ptt.start + BINARY mic frames + ptt.stop
+//	  → asr.final{"hello"} → reply.end (contains "ANSWER: hello")
+//	  → ≥1 BINARY downlink frame (streamKind=tts, flags.final) → turn{idle}
 //
 // Build-tagged `e2e` so plain `go test ./...` stays fast and dep-free; run via
 // `make -C adapter_v2 e2e`.
@@ -42,7 +44,9 @@ func TestE2EDeviceRoundTrip(t *testing.T) {
 	bin := buildMockCLI(t)
 
 	mgr := session.NewManager()
-	srv := New(mgr, deviceapi.StaticRecognizer{Text: "hello"}, deviceapi.SilentSynthesizer{}, []string{bin}, "", Options{})
+	// StreamReplyDelta on so the round-trip also exercises the Phase B live-subtitle
+	// path (reply.delta) ahead of the authoritative reply.end.
+	srv := New(mgr, deviceapi.StaticRecognizer{Text: "hello"}, deviceapi.SilentSynthesizer{}, []string{bin}, "", Options{StreamReplyDelta: true})
 	httpSrv := httptest.NewServer(srv.Handler())
 	defer httpSrv.Close()
 	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http") + "/v2/dev/ws"
@@ -77,6 +81,7 @@ func TestE2EDeviceRoundTrip(t *testing.T) {
 	// Collect downlink frames until turn{idle} or the context expires.
 	var (
 		sawASR, sawReplyEnd, sawIdle bool
+		sawReplyDelta                bool
 		replyText                    string
 		ttsFinalFrames               int
 	)
@@ -100,6 +105,10 @@ func TestE2EDeviceRoundTrip(t *testing.T) {
 			if m["text"] == "hello" {
 				sawASR = true
 			}
+		case "reply.delta":
+			if s, _ := m["text"].(string); strings.Contains(s, "ANSWER") {
+				sawReplyDelta = true
+			}
 		case "reply.end":
 			if s, _ := m["text"].(string); s != "" {
 				replyText = s
@@ -119,6 +128,9 @@ func TestE2EDeviceRoundTrip(t *testing.T) {
 	}
 	if !sawReplyEnd || !strings.Contains(replyText, "ANSWER: hello") {
 		t.Errorf("reply.end text = %q, want a substring \"ANSWER: hello\"", replyText)
+	}
+	if !sawReplyDelta {
+		t.Errorf("StreamReplyDelta on but no reply.delta frame carrying the reply arrived")
 	}
 	if ttsFinalFrames == 0 {
 		t.Errorf("never received a downlink TTS binary frame with flags.final")

--- a/adapter_v2/internal/devicews/frames.go
+++ b/adapter_v2/internal/devicews/frames.go
@@ -3,10 +3,10 @@
 // discriminator — TEXT frames carry JSON control objects, BINARY frames carry an
 // 8-byte header + raw codec audio (no base64). See adapter_v2/docs/device-protocol.md.
 //
-// Phase A scope: the required path only — hello handshake, PTT uplink → batch
-// ASR → inject into the PTY (deviceapi.Bridge), reply.end-only screen text
-// (no streaming reply.delta), and one-shot TTS streamed back as BINARY frames.
-// Streaming deltas, resume/ack, and the Cloud relay are later phases.
+// Phase A: the required path — hello handshake, PTT uplink → batch ASR → inject
+// into the PTY (deviceapi.Bridge), reply.end + one-shot TTS back as BINARY frames.
+// Phase B adds streaming reply.delta (live screen) and opt-in per-segment TTS.
+// Resume/ack and the Cloud relay are later phases.
 package devicews
 
 import "encoding/binary"
@@ -28,7 +28,14 @@ const (
 
 // flags — binary header bytes 6-7 (bitfield).
 const (
-	flagFinal    = 1 << 0 // last frame of this turn's stream
+	// flagFinal marks the last frame of a PLAYABLE AUDIO UNIT: the whole reply
+	// under one-shot TTS, or one sentence under per-segment streaming TTS (Phase
+	// B). The device plays the buffer it has accumulated and resets it on each
+	// final frame — so under segment TTS it plays each sentence as it arrives.
+	// The TURN END is the turn{idle} control frame, NOT this flag: a device must
+	// re-enable PTT on turn{idle}, never on flagFinal (else it would stop after
+	// the first sentence).
+	flagFinal    = 1 << 0
 	flagKeyframe = 1 << 1 // opus config / keyframe present
 )
 
@@ -135,6 +142,13 @@ type asrFinal struct {
 	Text   string `json:"text"`
 }
 
+type replyDelta struct {
+	T      string `json:"t"`
+	TurnID string `json:"turnId"`
+	Seq    uint16 `json:"seq"`
+	Text   string `json:"text"`
+}
+
 type replyEnd struct {
 	T      string `json:"t"`
 	TurnID string `json:"turnId"`
@@ -168,6 +182,6 @@ const (
 	codeASRTimeout = "ASR_TIMEOUT"
 	codeTTSFailed  = "TTS_FAILED"
 	codeBadProto   = "BAD_PROTO"
-	codeBusy       = "BUSY"       // a ptt.start arrived while a turn was still in flight
-	codeBadAudio   = "BAD_AUDIO"  // uplink codec unsupported / decode failed (not an ASR timeout)
+	codeBusy       = "BUSY"      // a ptt.start arrived while a turn was still in flight
+	codeBadAudio   = "BAD_AUDIO" // uplink codec unsupported / decode failed (not an ASR timeout)
 )

--- a/adapter_v2/internal/devicews/server.go
+++ b/adapter_v2/internal/devicews/server.go
@@ -41,15 +41,17 @@ type wsConn interface {
 // Server serves the bbwire/2 device protocol (Phase A) at one HTTP route. One
 // WebSocket connection = one device = one PTY session driven via a deviceapi.Bridge.
 type Server struct {
-	mgr    *session.Manager
-	asr    deviceapi.Recognizer // batch ASR over the buffered PTT utterance
-	tts    deviceapi.Synthesizer
-	argv   []string // default CLI to spawn under the PTY
-	cwd    string
-	auth   string // shared secret; "" disables auth (dev/LAN)
-	cols   int
-	rows   int
-	decode func(ctx context.Context, codec string, rate, ch int, payload []byte) ([]byte, error)
+	mgr         *session.Manager
+	asr         deviceapi.Recognizer // batch ASR over the buffered PTT utterance
+	tts         deviceapi.Synthesizer
+	argv        []string // default CLI to spawn under the PTY
+	cwd         string
+	auth        string // shared secret; "" disables auth (dev/LAN)
+	cols        int
+	rows        int
+	decode      func(ctx context.Context, codec string, rate, ch int, payload []byte) ([]byte, error)
+	streamDelta bool
+	segmentTTS  bool
 }
 
 // Options carries the optional knobs for New.
@@ -62,6 +64,13 @@ type Options struct {
 	// only — an opus device then gets an ASR_TIMEOUT error. Wired to
 	// voicekit.DecodeUplink (which shells to ffmpeg for opus).
 	Decode func(ctx context.Context, codec string, rate, ch int, payload []byte) ([]byte, error)
+
+	// StreamReplyDelta (Phase B) streams live reply.delta frames as the reply
+	// grows. Safe to default on (reply.end stays authoritative).
+	StreamReplyDelta bool
+	// SegmentTTS (Phase B) speaks the reply sentence-by-sentence instead of once at
+	// turn end. Opt-in (higher risk). Off → one-shot TTS (Phase A behaviour).
+	SegmentTTS bool
 }
 
 // New builds a device-WS server. asr/tts are the voice providers (a mock ASR and
@@ -73,7 +82,7 @@ func New(mgr *session.Manager, asr deviceapi.Recognizer, tts deviceapi.Synthesiz
 	if opt.Rows <= 0 {
 		opt.Rows = 24
 	}
-	return &Server{mgr: mgr, asr: asr, tts: tts, argv: argv, cwd: cwd, auth: opt.Auth, cols: opt.Cols, rows: opt.Rows, decode: opt.Decode}
+	return &Server{mgr: mgr, asr: asr, tts: tts, argv: argv, cwd: cwd, auth: opt.Auth, cols: opt.Cols, rows: opt.Rows, decode: opt.Decode, streamDelta: opt.StreamReplyDelta, segmentTTS: opt.SegmentTTS}
 }
 
 // Handler upgrades GET /v2/dev/ws and runs one device session on it.
@@ -116,7 +125,8 @@ type deviceConn struct {
 	fsm       int
 	curTurnID string
 	curU      uint16
-	dnSeq     uint16 // downlink frame counter, reset per turn
+	dnSeq     uint16 // downlink TTS frame counter, reset per turn
+	deltaSeq  uint16 // reply.delta sequence counter, reset per turn
 }
 
 // tryBeginCapture opens a new turn iff the connection is idle, recording its
@@ -128,7 +138,7 @@ func (c *deviceConn) tryBeginCapture(turnID string, u uint16) bool {
 		return false
 	}
 	c.fsm = connCapturing
-	c.curTurnID, c.curU, c.dnSeq = turnID, u, 0
+	c.curTurnID, c.curU, c.dnSeq, c.deltaSeq = turnID, u, 0, 0
 	return true
 }
 
@@ -183,9 +193,12 @@ func (c *deviceConn) writeBin(b []byte) error {
 	return c.conn.Write(c.ctx, websocket.MessageBinary, b)
 }
 
-// Play implements deviceapi.DeviceSink: send one reply's synthesized audio as a
-// BINARY downlink frame. Phase A is one-shot per reply, so this single frame is
-// marked final; per-segment streaming is Phase B.
+// Play implements deviceapi.DeviceSink: send one synthesized audio unit as a
+// BINARY downlink frame, marked final. "Final" means end-of-playable-unit, not
+// end-of-turn (see flagFinal): under one-shot TTS the unit is the whole reply;
+// under per-segment TTS (Phase B) the Bridge calls Play once per sentence, so each
+// sentence is its own final frame the device plays on arrival. Turn end is the
+// separate turn{idle} control frame.
 func (c *deviceConn) Play(_ context.Context, audio []byte, format string) error {
 	c.mu.Lock()
 	u, seq := c.curU, c.dnSeq
@@ -199,6 +212,17 @@ func (c *deviceConn) Play(_ context.Context, audio []byte, format string) error 
 		Flags:      flagFinal,
 	}
 	return c.writeBin(h.encode(audio))
+}
+
+// ReplyDelta implements deviceapi.Events: a live snapshot of the growing reply →
+// reply.delta. text is the full current reply (the device replaces its subtitle),
+// each tagged with an incrementing per-turn seq.
+func (c *deviceConn) ReplyDelta(text string) {
+	c.mu.Lock()
+	turnID, seq := c.curTurnID, c.deltaSeq
+	c.deltaSeq++
+	c.mu.Unlock()
+	_ = c.writeCtrl(replyDelta{T: "reply.delta", TurnID: turnID, Seq: seq, Text: text})
 }
 
 // ReplyComplete implements deviceapi.Events: the turn's final text → reply.end.
@@ -273,7 +297,12 @@ func (s *Server) serve(parent context.Context, conn wsConn) {
 	}
 	// asr is nil on the Bridge: the handler runs ASR itself (so it can emit
 	// asr.final between recognition and injection); the Bridge only needs tts+sink.
-	bridge := deviceapi.New(sess, nil, s.tts, dc, deviceapi.Config{Cols: s.cols, Rows: s.rows})
+	bridge := deviceapi.New(sess, nil, s.tts, dc, deviceapi.Config{
+		Cols:             s.cols,
+		Rows:             s.rows,
+		StreamReplyDelta: s.streamDelta,
+		SegmentTTS:       s.segmentTTS,
+	})
 	bridge.SetEvents(dc)
 	go bridge.Run(ctx)
 


### PR DESCRIPTION
## 概述

bbwire/2 **Phase B**:设备语音线的回复现在**边产生边流式下发**,不再只在 turn 末一次性给。

## 两个特性（都 flag 门控）

- **流式 `reply.delta`（默认开 `ADAPTER_V2_STREAM_DELTA`）**:每次抽取推进发一帧**当前完整回复的快照**(非 append 增量),设备实时替换 1.47" 字幕——稳健于 TUI 重绘/reflow。`reply.end` 仍权威。
- **逐句 TTS（opt-in `ADAPTER_V2_SEGMENT_TTS`）**:`nextSentence` 对增长中的回复 append-only 分句(支持中文 `。！？` 多字节),切句即合即播,第一句在播第二句还在抓;turn 末播尾巴。默认关 = Phase A 一次性 TTS（字节等价）。

`Bridge.Run` 重构:每 chunk 一次 `ext.OnOutput()` → `onProgress`(流式副作用) → `maybeSpeak`(边界,返回 spoke→重置)。rearm/打断逻辑保留。

## Review 驱动的修复（三视角对抗）

- **BLOCKING 跨轮泄漏**:claude 抽取器总取**最后一个 `⏺` 块**、无视 baseline,新一轮在自己绘制前会重新抽到**上一轮回复**——`onProgress` 无边界门会把上轮答案当增量发/重播(barge-in 时是被打断的那条)。**seed 抑制**修复:rebaseline 捕获屏上回复作 turn seed,`onProgress` 在 `text==seed` 时空操作;`maybeSpeak`(边界)不受影响,故相同重复回复仍会播。加了回归测试。
- **MAJOR `flagFinal` 语义歧义**:澄清为**"可播单元末帧"**(逐句 TTS 下=一句,一次性下=整段),设备每个 final 帧即播即清缓冲;turn 结束由 `turn{idle}` 定,不是 `flagFinal`。已在 frames.go/server.go/device-protocol.md 文档化(当前代码在此语义下正确,且比"攒到末帧才播"更适合流式)。

## 验证
`nextSentence` + `onProgress`(delta/关/seed抑制/分句)单测;e2e 签字门新增 `reply.delta` 到达断言。build/vet/test/-race + 设备 e2e 全绿。

仅 `adapter_v2/`,不动 v1。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)