### PR TITLE
feat(adapter_v2): cloud relay — adapter_v2 注册成 SaaS HomeAdapter

### DIFF
--- a/adapter_v2/cmd/bbclaw-adapter-v2/main.go
+++ b/adapter_v2/cmd/bbclaw-adapter-v2/main.go
@@ -32,6 +32,7 @@ import (
 	"nhooyr.io/websocket"
 
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/buildinfo"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/cloudrelay"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/config"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/devicews"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/ptyhost"
@@ -60,6 +61,22 @@ func main() {
 		Handler: newRouter(mgr, cfg),
 	}
 
+	// Cloud relay (SaaS): when CLOUD_WS_URL is set, register with the BBClaw Cloud
+	// as a HomeAdapter so the device can pick adapter_v2 in its sites.list and have
+	// voice relayed here (cloud does ASR/TTS; we inject the transcript into a PTY
+	// and return the reply text). Runs alongside the LAN /v2/dev/ws device line.
+	// relayCtx is cancelled on shutdown so the relay stops dialing + closes its WS.
+	relayCtx, stopRelay := context.WithCancel(context.Background())
+	defer stopRelay()
+	if cloudrelay.Enabled() {
+		if rc, err := cloudrelay.LoadConfig(); err != nil {
+			log.Printf("bbclaw-adapter-v2: cloud relay disabled (config error): %v", err)
+		} else {
+			relay := cloudrelay.New(rc, cfg.Argv, cfg.Cwd, log.Printf)
+			go relay.Run(relayCtx)
+		}
+	}
+
 	// Run the listener in the background so main can block on signals and then
 	// drive a graceful shutdown. serveErr surfaces a startup failure (e.g. the
 	// port is already taken) so we don't hang waiting for a signal that the
@@ -82,6 +99,7 @@ func main() {
 	case s := <-sig:
 		log.Printf("bbclaw-adapter-v2: received %s, shutting down", s)
 	}
+	stopRelay() // stop the cloud relay's dial/reconnect loop and close its WS
 
 	// Graceful shutdown: stop accepting new connections and give in-flight
 	// handlers a bounded window to finish. Sessions themselves outlive the

--- a/adapter_v2/go.mod
+++ b/adapter_v2/go.mod
@@ -12,13 +12,11 @@ go 1.22
 require (
 	github.com/creack/pty v1.1.24
 	github.com/daboluocc/bbclaw/voice v0.0.0
+	github.com/google/uuid v1.6.0
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
 	nhooyr.io/websocket v1.8.17
 )
 
-require (
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
-)
+require github.com/gorilla/websocket v1.5.3 // indirect
 
 replace github.com/daboluocc/bbclaw/voice => ../voice

--- a/adapter_v2/internal/cloudrelay/cloudrelay.go
+++ b/adapter_v2/internal/cloudrelay/cloudrelay.go
@@ -1,0 +1,305 @@
+// Package cloudrelay makes adapter_v2 register with the BBClaw Cloud as a
+// HomeAdapter, so the device can select it in its SaaS site picker (sites.list)
+// and have voice relayed to it — exactly like v1, with ZERO cloud or firmware
+// changes (the cloud is adapter-type-agnostic; it keys peers only by role +
+// home_site_id and never checks a version or capability).
+//
+// In cloud_saas the cloud does ASR/TTS and relays only TEXT: it sends a
+// voice.transcript request, adapter_v2 injects the transcript into a per-device
+// PTY (deviceapi.Bridge — the same PTY inject + extract validated against real
+// claude), streams the reply back as voice.reply.delta events, and ends with a
+// voice.reply. No audio, no ASR/TTS on this path (that is the bbwire/2 LAN-direct
+// line's job).
+//
+// The wire protocol (Envelope, the welcome→info handshake, registration.code,
+// voice.transcript / voice.reply.delta / voice.reply / heartbeat) is ported from
+// v1's internal/homeadapter so it is byte-compatible with the deployed cloud.
+package cloudrelay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/buildinfo"
+	"github.com/google/uuid"
+)
+
+// appPingInterval is the application-level JSON ping cadence. WebSocket control
+// PINGs can be absorbed by an nginx front, so the cloud's ~35s read deadline is
+// kept alive with a JSON {"type":"ping"} (matches v1).
+const appPingInterval = 25 * time.Second
+
+// Envelope is the JSON frame exchanged with the cloud over the one home-adapter
+// WebSocket. Ported verbatim from v1 (internal/homeadapter CloudEnvelope) so the
+// cloud treats adapter_v2 as an identical peer.
+type Envelope struct {
+	Type       string         `json:"type"` // ping|welcome|ack|event|request|reply|info
+	MessageID  string         `json:"messageId,omitempty"`
+	DeviceID   string         `json:"deviceId,omitempty"`
+	HomeSiteID string         `json:"homeSiteId,omitempty"`
+	SessionID  string         `json:"sessionId,omitempty"`
+	Kind       string         `json:"kind,omitempty"`
+	Payload    map[string]any `json:"payload,omitempty"`
+	Error      string         `json:"error,omitempty"`
+}
+
+// Config is the cloud-relay configuration, read from the same env vars as v1.
+type Config struct {
+	CloudWSURL     string        // CLOUD_WS_URL (default wss://bbclaw.daboluo.cc/ws)
+	CloudAuthToken string        // CLOUD_AUTH_TOKEN (optional; anon home-adapter allowed)
+	HomeSiteID     string        // stable UUID identifying this adapter as a site
+	ReconnectDelay time.Duration // backoff between dial attempts
+	ReplyWait      time.Duration // max time to wait for a turn's reply
+}
+
+// Enabled reports whether the cloud relay should run: only when CLOUD_WS_URL is
+// explicitly set (so a bare `make run` stays LAN-only and never dials the cloud).
+func Enabled() bool {
+	return strings.TrimSpace(os.Getenv("CLOUD_WS_URL")) != ""
+}
+
+// LoadConfig builds the relay config from the environment, ensuring a stable
+// home_site_id (persisted, so the claimed binding survives restarts).
+func LoadConfig() (Config, error) {
+	siteID, err := ensureHomeSiteID()
+	if err != nil {
+		return Config{}, err
+	}
+	cfg := Config{
+		CloudWSURL:     getOrDefault("CLOUD_WS_URL", "wss://bbclaw.daboluo.cc/ws"),
+		CloudAuthToken: strings.TrimSpace(os.Getenv("CLOUD_AUTH_TOKEN")),
+		HomeSiteID:     siteID,
+		ReconnectDelay: 3 * time.Second,
+		ReplyWait:      90 * time.Second,
+	}
+	return cfg, nil
+}
+
+// dialURL builds wss://host/ws?role=home_adapter&home_site_id=…&token=… from the
+// base URL, normalising scheme and forcing the /ws path (ported from v1).
+func (c Config) dialURL() string {
+	base := strings.TrimSpace(c.CloudWSURL)
+	scheme := "wss://"
+	rest := base
+	switch {
+	case strings.HasPrefix(base, "https://"):
+		scheme, rest = "wss://", base[len("https://"):]
+	case strings.HasPrefix(base, "http://"):
+		scheme, rest = "ws://", base[len("http://"):]
+	case strings.HasPrefix(base, "wss://"):
+		scheme, rest = "wss://", base[len("wss://"):]
+	case strings.HasPrefix(base, "ws://"):
+		scheme, rest = "ws://", base[len("ws://"):]
+	}
+	host := rest
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		host = rest[:i] // drop any path; we force /ws
+	}
+	// Use the raw id (query-escaped) like v1 — NOT uuid.MustParse, which would
+	// panic the whole process if HOME_SITE_ID env were a non-UUID. A bad id at
+	// worst fails to match a cloud binding; it must never crash the adapter.
+	q := "role=home_adapter&home_site_id=" + url.QueryEscape(c.HomeSiteID)
+	if c.CloudAuthToken != "" {
+		q += "&token=" + url.QueryEscape(c.CloudAuthToken)
+	}
+	return fmt.Sprintf("%s%s/ws?%s", scheme, host, q)
+}
+
+// Relay is the running cloud-relay client. It owns the device→PTY bridges.
+type Relay struct {
+	cfg     Config
+	bridges *bridgeManager // per-device PTY session + Bridge
+	log     func(format string, args ...any)
+}
+
+// New builds a Relay. argv/cwd is the CLI each per-device PTY session drives
+// (same as the LAN device line). log is the line logger (e.g. log.Printf).
+func New(cfg Config, argv []string, cwd string, log func(string, ...any)) *Relay {
+	return &Relay{cfg: cfg, bridges: newBridgeManager(argv, cwd), log: log}
+}
+
+// Run connects to the cloud and serves relayed requests until ctx is cancelled,
+// reconnecting with a fixed backoff on any drop. It blocks; run it in a goroutine.
+func (r *Relay) Run(ctx context.Context) {
+	r.log("cloudrelay: home_site=%s dialing %s", r.cfg.HomeSiteID, r.cfg.CloudWSURL)
+	for ctx.Err() == nil {
+		if err := r.runOnce(ctx); err != nil && ctx.Err() == nil {
+			r.log("cloudrelay: connection ended: %v (reconnecting in %s)", err, r.cfg.ReconnectDelay)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(r.cfg.ReconnectDelay):
+		}
+	}
+}
+
+// runOnce dials once and serves frames until the connection drops or ctx ends.
+func (r *Relay) runOnce(ctx context.Context) error {
+	conn, _, err := websocket.Dial(ctx, r.cfg.dialURL(), nil)
+	if err != nil {
+		return fmt.Errorf("dial cloud: %w", err)
+	}
+	conn.SetReadLimit(1 << 20)
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Per-connection context: cancelled when this connection ends, so any in-flight
+	// turn handler unblocks (releasing its per-device turn lock) instead of holding
+	// it until ReplyWait after the cloud drops.
+	connCtx, connCancel := context.WithCancel(ctx)
+	defer connCancel()
+
+	// All writes go through one mutex (a WS conn is not safe for concurrent writes).
+	var writeMu sync.Mutex
+	write := func(env Envelope) error {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		wctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		return wsjson.Write(wctx, conn, env)
+	}
+
+	// App-level JSON ping keepalive.
+	pingCtx, stopPing := context.WithCancel(ctx)
+	defer stopPing()
+	go func() {
+		t := time.NewTicker(appPingInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-pingCtx.Done():
+				return
+			case <-t.C:
+				if write(Envelope{Type: "ping"}) != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	r.log("cloudrelay: connected home_site=%s", r.cfg.HomeSiteID)
+	for {
+		var env Envelope
+		if err := wsjson.Read(ctx, conn, &env); err != nil {
+			return fmt.Errorf("read cloud frame: %w", err)
+		}
+		switch strings.ToLower(strings.TrimSpace(env.Type)) {
+		case "welcome":
+			r.onWelcome(env, write)
+		case "ack":
+			// nothing to do
+		case "event":
+			if strings.EqualFold(strings.TrimSpace(env.Kind), "registration.code") {
+				r.announceCode(env)
+			}
+		case "request":
+			go r.handleRequest(connCtx, write, env)
+		}
+	}
+}
+
+// onWelcome logs the registration state and reports adapter info (display-only on
+// the cloud, but v1 always sends it after welcome).
+func (r *Relay) onWelcome(env Envelope, write func(Envelope) error) {
+	if reg, _ := env.Payload["homeAdapterRegistration"].(string); strings.TrimSpace(reg) != "" {
+		r.log("cloudrelay: welcome home_site=%s registration=%s", r.cfg.HomeSiteID, reg)
+	}
+	_ = write(Envelope{
+		Type:       "info",
+		HomeSiteID: r.cfg.HomeSiteID,
+		Payload: map[string]any{
+			"adapterVersion": buildinfo.Tag,
+			"buildTime":      buildinfo.BuildTime,
+			"platform":       "adapter_v2",
+		},
+	})
+}
+
+// announceCode prints the claim code the user redeems in the portal to bind this
+// adapter to their account (so it appears in their device's sites.list).
+func (r *Relay) announceCode(env Envelope) {
+	code, _ := env.Payload["code"].(string)
+	if strings.TrimSpace(code) == "" {
+		return
+	}
+	expires, _ := env.Payload["expiresAt"].(string)
+	r.log("cloudrelay: ┌──────────────────────────────────────────────┐")
+	r.log("cloudrelay: │ PAIRING REQUIRED — claim this adapter_v2     │")
+	r.log("cloudrelay: │   code: %-36s │", code)
+	r.log("cloudrelay: │   expires: %-33s │", expires)
+	r.log("cloudrelay: │ Redeem in the BBClaw portal:                 │")
+	r.log("cloudrelay: │   POST /v1/registrations/claim {\"code\":...}  │")
+	r.log("cloudrelay: └──────────────────────────────────────────────┘")
+}
+
+// handleRequest dispatches a cloud request. Only voice.transcript is served (the
+// voice path); other kinds (agent-bus proxy features) are silently ignored, which
+// the cloud tolerates (v1's handleRequest default is a no-op too).
+func (r *Relay) handleRequest(ctx context.Context, write func(Envelope) error, env Envelope) {
+	switch strings.ToLower(strings.TrimSpace(env.Kind)) {
+	case "voice.transcript":
+		if err := r.handleTranscript(ctx, write, env); err != nil {
+			r.log("cloudrelay: transcript device=%s error: %v", env.DeviceID, err)
+			_ = write(Envelope{
+				Type: "reply", MessageID: env.MessageID, DeviceID: env.DeviceID,
+				HomeSiteID: r.cfg.HomeSiteID, Kind: "voice.reply",
+				Payload: map[string]any{"ok": false, "error": err.Error()},
+			})
+		}
+	default:
+		// Unsupported kind — ignore (cloud tolerates a silent no-op).
+	}
+}
+
+// ── small helpers ───────────────────────────────────────────────────────────
+
+func getOrDefault(name, def string) string {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		return v
+	}
+	return def
+}
+
+type identityFile struct {
+	HomeSiteID string `json:"homeSiteId"`
+}
+
+// ensureHomeSiteID returns HOME_SITE_ID if set, else loads/creates a persisted
+// UUID at ~/.bbclaw-adapter-v2/identity.json so the claimed binding survives
+// restarts. Uses a v2-specific dir so it does not collide with v1's site id
+// (adapter_v2 is a SEPARATE site in the picker).
+func ensureHomeSiteID() (string, error) {
+	if id := strings.TrimSpace(os.Getenv("HOME_SITE_ID")); id != "" {
+		return id, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home: %w", err)
+	}
+	path := filepath.Join(home, ".bbclaw-adapter-v2", "identity.json")
+	if raw, err := os.ReadFile(path); err == nil {
+		var f identityFile
+		if json.Unmarshal(raw, &f) == nil && strings.TrimSpace(f.HomeSiteID) != "" {
+			return strings.TrimSpace(f.HomeSiteID), nil
+		}
+	}
+	id := uuid.New().String()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return "", fmt.Errorf("create identity dir: %w", err)
+	}
+	data, _ := json.Marshal(identityFile{HomeSiteID: id})
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", fmt.Errorf("write identity: %w", err)
+	}
+	return id, nil
+}

--- a/adapter_v2/internal/cloudrelay/e2e_test.go
+++ b/adapter_v2/internal/cloudrelay/e2e_test.go
@@ -1,0 +1,148 @@
+//go:build e2e
+
+// Cloud-relay acceptance gate: a mock BBClaw Cloud sends a voice.transcript, and
+// adapter_v2 — registered as a HomeAdapter — must inject it into a real PTY
+// (cmd/mockcli), stream voice.reply.delta, and finish with voice.reply carrying
+// the scraped answer. Proves the SaaS path end to end with no real cloud and no
+// device, using the same wire frames the deployed cloud uses.
+//
+// Run via `make -C adapter_v2 e2e` (build tag e2e).
+package cloudrelay
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
+)
+
+func TestE2ECloudRelayVoiceTurn(t *testing.T) {
+	bin := buildMockCLI(t)
+
+	// Channels for the mock cloud to report what adapter_v2 sent back.
+	type result struct {
+		sawInfo  bool
+		deltas   int
+		replyOK  bool
+		replyTxt string
+	}
+	resCh := make(chan result, 1)
+
+	// Mock cloud: accept the home-adapter WS, send welcome + voice.transcript,
+	// then collect the adapter's frames until voice.reply.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("role") != "home_adapter" || r.URL.Query().Get("home_site_id") == "" {
+			http.Error(w, "bad role/site", http.StatusBadRequest)
+			return
+		}
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close(websocket.StatusNormalClosure, "")
+		ctx, cancel := context.WithTimeout(r.Context(), 25*time.Second)
+		defer cancel()
+
+		_ = wsjson.Write(ctx, c, Envelope{Type: "welcome", Payload: map[string]any{"homeAdapterRegistration": "claimed"}})
+		_ = wsjson.Write(ctx, c, Envelope{
+			Type: "request", MessageID: "m1", DeviceID: "dev-1", Kind: "voice.transcript",
+			Payload: map[string]any{"text": "hello", "sessionKey": "s1", "streamId": "st1"},
+		})
+
+		var res result
+		for {
+			var env Envelope
+			if err := wsjson.Read(ctx, c, &env); err != nil {
+				break
+			}
+			switch {
+			case env.Type == "info":
+				res.sawInfo = true
+			case env.Type == "event" && env.Kind == "voice.reply.delta":
+				res.deltas++
+			case env.Type == "reply" && env.Kind == "voice.reply":
+				res.replyOK, _ = env.Payload["ok"].(bool)
+				res.replyTxt, _ = env.Payload["text"].(string)
+				resCh <- res
+				return
+			}
+		}
+		resCh <- res
+	}))
+	defer srv.Close()
+
+	relay := New(Config{
+		CloudWSURL:     "ws" + strings.TrimPrefix(srv.URL, "http"),
+		HomeSiteID:     "11111111-1111-1111-1111-111111111111",
+		ReconnectDelay: time.Second,
+		ReplyWait:      20 * time.Second,
+	}, []string{bin}, "", func(string, ...any) {})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go relay.Run(ctx)
+
+	select {
+	case res := <-resCh:
+		if !res.sawInfo {
+			t.Error("adapter never sent the info frame after welcome")
+		}
+		if !res.replyOK {
+			t.Errorf("voice.reply ok=false")
+		}
+		if !strings.Contains(res.replyTxt, "ANSWER: hello") {
+			t.Errorf("voice.reply text = %q, want a substring \"ANSWER: hello\"", res.replyTxt)
+		}
+		if res.deltas == 0 {
+			t.Errorf("no voice.reply.delta streamed (StreamReplyDelta on)")
+		}
+	case <-time.After(25 * time.Second):
+		t.Fatal("timed out waiting for voice.reply")
+	}
+}
+
+// buildMockCLI compiles cmd/mockcli into a temp dir and returns the path.
+func buildMockCLI(t *testing.T) string {
+	t.Helper()
+	goBin := goToolPath()
+	bin := filepath.Join(t.TempDir(), "mockcli")
+	cmd := exec.Command(goBin, "build", "-o", bin, "./cmd/mockcli")
+	cmd.Dir = moduleRoot(t, goBin)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build mockcli: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func moduleRoot(t *testing.T, goBin string) string {
+	t.Helper()
+	out, err := exec.Command(goBin, "env", "GOMOD").Output()
+	if err != nil {
+		t.Fatalf("go env GOMOD: %v", err)
+	}
+	gomod := strings.TrimSpace(string(out))
+	if gomod == "" || gomod == os.DevNull {
+		t.Fatalf("no go.mod from %s", goBin)
+	}
+	return filepath.Dir(gomod)
+}
+
+func goToolPath() string {
+	if p, err := exec.LookPath("go"); err == nil {
+		return p
+	}
+	for _, c := range []string{"/opt/homebrew/bin/go", "/usr/local/go/bin/go", "/usr/local/bin/go"} {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	return "go"
+}

--- a/adapter_v2/internal/cloudrelay/transcript.go
+++ b/adapter_v2/internal/cloudrelay/transcript.go
@@ -1,0 +1,231 @@
+package cloudrelay
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/deviceapi"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/ptyhost"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
+)
+
+// handleTranscript runs one relayed voice turn: inject the cloud's transcript into
+// the device's PTY, stream the assistant reply back as voice.reply.delta events,
+// and finish with the authoritative voice.reply. The cloud already did ASR and
+// will do TTS — this path is text in, text out.
+func (r *Relay) handleTranscript(ctx context.Context, write func(Envelope) error, env Envelope) error {
+	text, _ := env.Payload["text"].(string)
+	text = strings.TrimSpace(text)
+	deviceID := strings.TrimSpace(env.DeviceID)
+	if deviceID == "" {
+		deviceID = "cloud-anon"
+	}
+	if text == "" {
+		// Nothing to say — return a clean empty reply rather than poke the CLI.
+		return write(Envelope{
+			Type: "reply", MessageID: env.MessageID, DeviceID: env.DeviceID,
+			HomeSiteID: r.cfg.HomeSiteID, Kind: "voice.reply",
+			Payload: map[string]any{"ok": true, "text": ""},
+		})
+	}
+
+	cb, err := r.bridges.get(deviceID)
+	if err != nil {
+		return err
+	}
+
+	// One turn at a time per device: serialise, then arm the events observer with
+	// this request's write/env, inject, and wait for the turn to complete.
+	cb.turnMu.Lock()
+	defer cb.turnMu.Unlock()
+	done := cb.ev.begin(write, env, r.cfg.HomeSiteID)
+	defer cb.ev.end()
+
+	if err := cb.bridge.SubmitVoiceTurn(text); err != nil {
+		return err
+	}
+
+	// Keepalive: a silent turn (long thinking / a long-running tool call) must
+	// reset the cloud's per-request reply-idle timer (ReplyIdleWait, default 120s)
+	// or the cloud drops the turn. Only a MessageID-bearing event resets it (the
+	// 25s connection ping does not), so emit voice.reply.heartbeat every 15s until
+	// the turn ends — mirroring v1's startHeartbeat.
+	stopHB := make(chan struct{})
+	go r.heartbeat(write, env, stopHB)
+	defer close(stopHB)
+
+	timedOut := false
+	select {
+	case <-done:
+	case <-time.After(r.cfg.ReplyWait):
+		timedOut = true
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	return write(Envelope{
+		Type: "reply", MessageID: env.MessageID, DeviceID: env.DeviceID,
+		HomeSiteID: r.cfg.HomeSiteID, Kind: "voice.reply",
+		Payload: map[string]any{"ok": true, "text": cb.ev.reply(), "replyWaitTimedOut": timedOut},
+	})
+}
+
+// heartbeatInterval is well under the cloud's ReplyIdleWait (default 120s) so a
+// silent turn never trips HOME_ADAPTER_TIMEOUT.
+const heartbeatInterval = 15 * time.Second
+
+// heartbeat emits voice.reply.heartbeat for env.MessageID every heartbeatInterval
+// until stop is closed, keeping the cloud's per-request reply-idle timer alive
+// during a silent agent turn.
+func (r *Relay) heartbeat(write func(Envelope) error, env Envelope, stop <-chan struct{}) {
+	t := time.NewTicker(heartbeatInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-t.C:
+			if write(Envelope{
+				Type: "event", MessageID: env.MessageID, DeviceID: env.DeviceID,
+				HomeSiteID: r.cfg.HomeSiteID, Kind: "voice.reply.heartbeat",
+				Payload: map[string]any{"phase": "thinking"},
+			}) != nil {
+				return
+			}
+		}
+	}
+}
+
+// ── per-device bridge ───────────────────────────────────────────────────────
+
+// cloudBridge is one device's PTY session + Bridge + the events observer that
+// turns the Bridge's reply stream into cloud frames.
+type cloudBridge struct {
+	sess   *session.Session
+	bridge *deviceapi.Bridge
+	ev     *cloudEvents
+	// turnMu serialises turns for this device. The cloud already waits for each
+	// voice.reply before relaying the next transcript, so same-device turns don't
+	// overlap in practice — this guards against a future pipelining cloud and
+	// keeps the single-turn cloudEvents observer correct.
+	turnMu sync.Mutex
+}
+
+// bridgeManager lazily creates one cloudBridge per device id and keeps its
+// Bridge.Run goroutine alive for the process lifetime.
+type bridgeManager struct {
+	mgr  *session.Manager
+	argv []string
+	cwd  string
+
+	mu      sync.Mutex
+	bridges map[string]*cloudBridge
+}
+
+func newBridgeManager(argv []string, cwd string) *bridgeManager {
+	return &bridgeManager{mgr: session.NewManager(), argv: argv, cwd: cwd, bridges: map[string]*cloudBridge{}}
+}
+
+func (m *bridgeManager) get(deviceID string) (*cloudBridge, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if cb, ok := m.bridges[deviceID]; ok {
+		return cb, nil
+	}
+	sess, err := m.mgr.GetOrCreate(deviceID, ptyhost.Config{Argv: m.argv, Cwd: m.cwd})
+	if err != nil {
+		return nil, err
+	}
+	ev := &cloudEvents{}
+	// asr/tts/sink are nil: this path is text-only (cloud does ASR/TTS). The
+	// Bridge injects the transcript and extracts the reply; the events observer
+	// streams that reply text to the cloud. StreamReplyDelta on → live deltas.
+	bridge := deviceapi.New(sess, nil, nil, nil, deviceapi.Config{StreamReplyDelta: true})
+	bridge.SetEvents(ev)
+	go bridge.Run(context.Background())
+	cb := &cloudBridge{sess: sess, bridge: bridge, ev: ev}
+	m.bridges[deviceID] = cb
+	return cb, nil
+}
+
+// cloudEvents implements deviceapi.Events, routing one turn's reply stream to the
+// cloud frames of the request currently being served. Exactly one turn is active
+// at a time per device (the cloud relays transcripts sequentially per device).
+type cloudEvents struct {
+	mu        sync.Mutex
+	active    bool
+	write     func(Envelope) error
+	env       Envelope
+	homeSite  string
+	replyText string
+	done      chan struct{}
+}
+
+// begin arms the observer for a new turn and returns its completion channel.
+func (e *cloudEvents) begin(write func(Envelope) error, env Envelope, homeSite string) <-chan struct{} {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.active = true
+	e.write = write
+	e.env = env
+	e.homeSite = homeSite
+	e.replyText = ""
+	e.done = make(chan struct{})
+	return e.done
+}
+
+// end disarms the observer after the turn (so a late event is dropped). It nils
+// done too, so a stale TurnIdle from an abandoned (timed-out) turn — which fires
+// from the Bridge goroutine after handleTranscript already returned — finds
+// done==nil and no-ops instead of closing the NEXT turn's done channel.
+func (e *cloudEvents) end() {
+	e.mu.Lock()
+	e.active = false
+	e.write = nil
+	e.done = nil
+	e.mu.Unlock()
+}
+
+// reply returns the final reply text captured for the turn.
+func (e *cloudEvents) reply() string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.replyText
+}
+
+// ReplyDelta streams a live snapshot of the growing reply as a voice.reply.delta
+// event (the cloud feeds it to TTS and re-emits to the device).
+func (e *cloudEvents) ReplyDelta(text string) {
+	e.mu.Lock()
+	active, w, env, home := e.active, e.write, e.env, e.homeSite
+	e.mu.Unlock()
+	if !active || w == nil {
+		return
+	}
+	_ = w(Envelope{
+		Type: "event", MessageID: env.MessageID, DeviceID: env.DeviceID,
+		HomeSiteID: home, Kind: "voice.reply.delta", Payload: map[string]any{"text": text},
+	})
+}
+
+// ReplyComplete records the authoritative final reply text (sent in voice.reply).
+func (e *cloudEvents) ReplyComplete(text string) {
+	e.mu.Lock()
+	if e.active {
+		e.replyText = text
+	}
+	e.mu.Unlock()
+}
+
+// TurnIdle signals the turn is done so handleTranscript can send voice.reply.
+func (e *cloudEvents) TurnIdle() {
+	e.mu.Lock()
+	if e.active && e.done != nil {
+		close(e.done)
+		e.done = nil
+		e.active = false
+	}
+	e.mu.Unlock()
+}


### PR DESCRIPTION
## 概述

让 **adapter_v2 注册成 SaaS HomeAdapter**,设备在 sites.list 里就能选它、语音中继过来——和 v1 完全一样,**云端零改、固件零改**(侦察证实云端对 adapter 类型无关,只按 role+home_site_id 路由)。

**关键架构**:cloud_saas 是**云端做 ASR/TTS、只中继文本**。云端发 `voice.transcript{text}`,adapter_v2 注入 PTY(复用已验证的 deviceapi.Bridge inject+extract)→ 流式 `voice.reply.delta` → 终帧 `voice.reply`。纯文本,无音频/ASR/TTS(那是 bbwire/2 LAN 直连那条线的事)。

## 内容
- `internal/cloudrelay/cloudrelay.go` — 出站云 WS 客户端(从 v1 port:`?role=home_adapter&home_site_id=…`、重连、25s app-ping、welcome→info、注册码 claim)+ home_site_id 持久化(`~/.bbclaw-adapter-v2/`,**独立的新 site**)。帧与部署云端字节兼容。
- `internal/cloudrelay/transcript.go` — `voice.transcript` handler:每设备 session+Bridge(nil ASR/TTS=纯文本,StreamReplyDelta 开)→ 注入 → 流 delta → 终帧。每设备 turn 串行 + **voice.reply.heartbeat 心跳**(防云端 reply-idle 超时)。
- `main.go` — 配 `CLOUD_WS_URL` 即起(与 LAN 设备线并存),shutdown ctx 管控。

## Review
三视角对抗(协议 vs 真云端/并发/集成):协议逐字段对齐。**已修**:BLOCKING 缺心跳(长静默轮被云端丢)、MAJOR `uuid.MustParse` panic(非UUID HOME_SITE_ID 崩进程→改 raw+QueryEscape,实测不崩)、MAJOR stale-TurnIdle 关错 done(end 置 nil)、per-conn ctx。

## 验证
build/vet/test/race 绿;**云中继签字门 e2e 通过**(mock 云发 voice.transcript → 注入 mockcli → 流 delta → voice.reply 含 "ANSWER: hello");非UUID 冒烟不崩。Epic #192。

## 你异地验证 SaaS
```
CLOUD_WS_URL=wss://bbclaw.daboluo.cc/ws make -C adapter_v2 run
# 日志打印 PAIRING 注册码 → 在 portal 认领 → 设备 sites.list 出现第3个站点 → 选它 → 说话
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)