### PR TITLE
fix(adapter_v2): 云中继语音重复播报 + 设置页超时 + 回复简洁

### DIFF
--- a/adapter_v2/internal/cloudrelay/cloudrelay.go
+++ b/adapter_v2/internal/cloudrelay/cloudrelay.go
@@ -125,7 +125,32 @@ type Relay struct {
 // New builds a Relay. argv/cwd is the CLI each per-device PTY session drives
 // (same as the LAN device line). log is the line logger (e.g. log.Printf).
 func New(cfg Config, argv []string, cwd string, log func(string, ...any)) *Relay {
-	return &Relay{cfg: cfg, bridges: newBridgeManager(argv, cwd), log: log}
+	return &Relay{cfg: cfg, bridges: newBridgeManager(withVoicePrompt(argv), cwd), log: log}
+}
+
+// defaultVoicePrompt keeps cloud-relayed replies short and speakable. Raw claude
+// answers in full CLI prose (lists, code blocks, multi-paragraph), which the cloud
+// then reads aloud in full — far too much for a voice device. Override with
+// ADAPTER_V2_VOICE_SYSTEM_PROMPT; set it empty to disable.
+const defaultVoicePrompt = "你是通过语音设备对话的助手。回答必须简短、口语化，控制在1-2句话以内；不要使用列表、代码块、标题或长篇解释，直接说重点。"
+
+// withVoicePrompt appends the voice persona via claude's --append-system-prompt,
+// scoped to the cloud-relay PTYs only (the web terminal keeps full claude). Only
+// applied to a claude CLI — the flag is claude-specific — so other CLIs are left
+// untouched. An empty prompt (env set to "") disables it.
+func withVoicePrompt(argv []string) []string {
+	if len(argv) == 0 || !strings.Contains(strings.ToLower(filepath.Base(argv[0])), "claude") {
+		return argv
+	}
+	prompt := defaultVoicePrompt
+	if v, ok := os.LookupEnv("ADAPTER_V2_VOICE_SYSTEM_PROMPT"); ok {
+		prompt = v
+	}
+	if strings.TrimSpace(prompt) == "" {
+		return argv
+	}
+	out := append([]string{}, argv...)
+	return append(out, "--append-system-prompt", prompt)
 }
 
 // Run connects to the cloud and serves relayed requests until ctx is cancelled,
@@ -242,12 +267,12 @@ func (r *Relay) announceCode(env Envelope) {
 	r.log("cloudrelay: └──────────────────────────────────────────────┘")
 }
 
-// handleRequest dispatches a cloud request. Only voice.transcript is served (the
-// voice path); other kinds (agent-bus proxy features) are silently ignored, which
-// the cloud tolerates (v1's handleRequest default is a no-op too).
+// handleRequest dispatches a cloud request. voice.transcript is the voice path;
+// the agent.* / chat.* / menu kinds are the device settings-page proxy requests,
+// answered with minimal static replies so the settings UI doesn't hang. Anything
+// else is silently ignored (the cloud tolerates a no-op, like v1's default).
 func (r *Relay) handleRequest(ctx context.Context, write func(Envelope) error, env Envelope) {
-	switch strings.ToLower(strings.TrimSpace(env.Kind)) {
-	case "voice.transcript":
+	if strings.EqualFold(strings.TrimSpace(env.Kind), "voice.transcript") {
 		if err := r.handleTranscript(ctx, write, env); err != nil {
 			r.log("cloudrelay: transcript device=%s error: %v", env.DeviceID, err)
 			_ = write(Envelope{
@@ -256,9 +281,11 @@ func (r *Relay) handleRequest(ctx context.Context, write func(Envelope) error, e
 				Payload: map[string]any{"ok": false, "error": err.Error()},
 			})
 		}
-	default:
-		// Unsupported kind — ignore (cloud tolerates a silent no-op).
+		return
 	}
+	// Settings/UI proxy kinds (agent.drivers, agent.messages, agent.menu, …) get a
+	// minimal static reply; unknown kinds fall through to a silent no-op.
+	r.handleAgentProxy(write, env)
 }
 
 // ── small helpers ───────────────────────────────────────────────────────────

--- a/adapter_v2/internal/cloudrelay/delta_test.go
+++ b/adapter_v2/internal/cloudrelay/delta_test.go
@@ -1,0 +1,121 @@
+package cloudrelay
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// reconstructLikeCloud mimics the cloud's deviceTTSChunkStreamer.handleReplyDelta
+// append-only diff (server.go:1187-1196): increment = text[len(prev):] when text
+// extends prev, else the whole text; the spoken audio is the concatenation of all
+// increments. We assert that, given our forwarded deltas, the cloud speaks the
+// reply EXACTLY once (no repeats) — the bug that caused "一直在重复播报".
+func reconstructLikeCloud(deltas []string) string {
+	prev, spoken := "", ""
+	for _, text := range deltas {
+		inc := text
+		if len(text) > len(prev) && strings.HasPrefix(text, prev) {
+			inc = text[len(prev):]
+		}
+		prev = text
+		spoken += inc
+	}
+	return spoken
+}
+
+// driveTurn feeds a sequence of reply snapshots (as deviceapi would, ending with
+// the final via ReplyComplete) and returns the deltas the relay forwarded.
+func driveTurn(snapshots []string, final string) []string {
+	var forwarded []string
+	ev := &cloudEvents{}
+	ev.begin(func(env Envelope) error {
+		if env.Kind == "voice.reply.delta" {
+			forwarded = append(forwarded, env.Payload["text"].(string))
+		}
+		return nil
+	}, Envelope{MessageID: "m"}, "site")
+	for _, s := range snapshots {
+		ev.ReplyDelta(s)
+	}
+	ev.ReplyComplete(final)
+	return forwarded
+}
+
+// TestDeltaConcurrentTurns mirrors production: reply events (ReplyDelta/
+// ReplyComplete/TurnIdle) fire from the Bridge.Run goroutine while begin/end/
+// reply() run on the handleTranscript goroutine. Run under -race to catch any
+// real data race on cloudEvents' fields (the single-goroutine table test above
+// exercises none). Also asserts a late ReplyDelta after end() is dropped.
+func TestDeltaConcurrentTurns(t *testing.T) {
+	ev := &cloudEvents{}
+	write := func(Envelope) error { return nil }
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		done := ev.begin(write, Envelope{MessageID: "m"}, "site")
+		wg.Add(1)
+		go func() { // the Bridge.Run side
+			defer wg.Done()
+			ev.ReplyDelta("你")
+			ev.ReplyDelta("你好")
+			ev.ReplyComplete("你好,我在")
+			ev.TurnIdle()
+		}()
+		<-done // the handleTranscript side waits for the turn, then reads + disarms
+		_ = ev.reply()
+		ev.end()
+		wg.Wait()
+		ev.ReplyDelta("late") // after end(): must be dropped (active==false), no panic
+	}
+}
+
+func TestDeltaMonotonicNoRepeat(t *testing.T) {
+	cases := []struct {
+		name      string
+		snapshots []string
+		final     string
+		want      string // what the cloud should speak — the reply, once
+	}{
+		{
+			name:      "clean append-only growth",
+			snapshots: []string{"你", "你好", "你好,", "你好,我在"},
+			final:     "你好,我在",
+			want:      "你好,我在",
+		},
+		{
+			name: "TUI redraw jitter (non-monotonic snapshots dropped)",
+			// "你好" then a redraw that drops a char, then resumes growth past it.
+			snapshots: []string{"你好", "你", "你好,我", "你好,我在这"},
+			final:     "你好,我在这",
+			want:      "你好,我在这",
+		},
+		{
+			name:      "all snapshots jittery, final flushes whole reply once",
+			snapshots: []string{"abc", "ab", "axc", "ab"},
+			final:     "abcdef",
+			want:      "abcdef",
+		},
+		{
+			name:      "no intermediate deltas, final only",
+			snapshots: nil,
+			final:     "just the final",
+			want:      "just the final",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deltas := driveTurn(tc.snapshots, tc.final)
+
+			// 1) every forwarded delta strictly extends the previous (monotonic).
+			for i := 1; i < len(deltas); i++ {
+				if !strings.HasPrefix(deltas[i], deltas[i-1]) || len(deltas[i]) <= len(deltas[i-1]) {
+					t.Errorf("delta %d %q does not strictly extend %q", i, deltas[i], deltas[i-1])
+				}
+			}
+			// 2) the cloud's append-only diff speaks the reply exactly once.
+			if got := reconstructLikeCloud(deltas); got != tc.want {
+				t.Errorf("cloud would speak %q, want %q (deltas=%v)", got, tc.want, deltas)
+			}
+		})
+	}
+}

--- a/adapter_v2/internal/cloudrelay/proxy.go
+++ b/adapter_v2/internal/cloudrelay/proxy.go
@@ -1,0 +1,120 @@
+package cloudrelay
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// proxyDriver is the single logical driver adapter_v2 advertises to the device's
+// settings UI. adapter_v2 has no driver matrix — it runs one claude PTY — so it
+// reports exactly one driver, always active. (The device is moving to a read-only
+// driver display anyway; this keeps the current firmware's settings page working
+// in cloud_saas instead of timing out.)
+const proxyDriver = "claude-code"
+
+// handleAgentProxy answers the cloud-relayed agent.* settings/UI requests the
+// device fires from its settings page (driver list, history, sessions, menu).
+// Without these, adapter_v2's old silent no-op left the device's HTTP calls to
+// hang until ESP_ERR_HTTP_EAGAIN. The cloud matches replies by MessageID and
+// reshapes our flat payload into the device's {ok,data} body, so we only need the
+// exact field names — values are minimal/static. Returns false if the kind is not
+// one we proxy (caller then ignores it).
+func (r *Relay) handleAgentProxy(write func(Envelope) error, env Envelope) bool {
+	reply := func(kind string, payload map[string]any) bool {
+		_ = write(Envelope{
+			Type: "reply", MessageID: env.MessageID, DeviceID: env.DeviceID,
+			HomeSiteID: r.cfg.HomeSiteID, Kind: kind, Payload: payload,
+		})
+		return true
+	}
+
+	switch strings.ToLower(strings.TrimSpace(env.Kind)) {
+	case "agent.drivers":
+		return reply("agent.drivers.reply", map[string]any{
+			"drivers":        []map[string]any{driverEntry()},
+			"active_driver":  proxyDriver,
+			"butler_driver":  proxyDriver,
+			"butler_capable": true,
+		})
+	case "chat.drivers":
+		return reply("chat.drivers.reply", map[string]any{
+			"drivers": []map[string]any{{"name": proxyDriver, "capabilities": driverCaps()}},
+		})
+	case "agent.messages":
+		// Empty history — the PTY is the source of truth, not a message store.
+		return reply("agent.messages.reply", map[string]any{
+			"messages": []any{}, "total": 0, "hasMore": false,
+		})
+	case "agent.sessions", "agent.sessions.list.logical":
+		return reply("agent.sessions.reply", map[string]any{"sessions": []any{}})
+	case "agent.sessions.create":
+		return reply("agent.sessions.create.reply", map[string]any{"session": map[string]any{
+			"id": "ls-default", "driver": proxyDriver, "cwd": "", "title": "",
+			"createdAt": "1970-01-01T00:00:00Z", "lastUsedAt": "1970-01-01T00:00:00Z",
+		}})
+	case "agent.cwd_pool":
+		return reply("agent.cwd_pool.reply", map[string]any{"pool": []any{}})
+	case "agent.active_driver.set":
+		return reply("agent.active_driver.set.reply", map[string]any{
+			"ok": true, "active_driver": proxyDriver,
+		})
+	case "agent.active_model.set":
+		return reply("agent.active_model.set.reply", map[string]any{
+			"ok": true, "driver": proxyDriver, "active_model": "",
+		})
+	case "agent.menu":
+		return reply("agent.menu.reply", menuPayload(env))
+	case "agent.menu.action":
+		return reply("agent.menu.action.reply", map[string]any{"result": "closed"})
+	default:
+		return false
+	}
+}
+
+func driverCaps() map[string]any {
+	return map[string]any{
+		"toolApproval": false, "resume": true, "streaming": true,
+		"maxInputBytes": 0, "butler": true,
+	}
+}
+
+func driverEntry() map[string]any {
+	return map[string]any{
+		"name":           proxyDriver,
+		"capabilities":   driverCaps(),
+		"butler_capable": true,
+		"installed":      true,
+	}
+}
+
+// menuPayload returns a minimal server-driven menu (ADR-019). Only the driver and
+// cwd menus get a real row; everything else is an empty menu — enough for the
+// device to render without hanging while driver/model selection is being retired.
+func menuPayload(env Envelope) map[string]any {
+	var p struct {
+		ID string `json:"id"`
+	}
+	raw, _ := json.Marshal(env.Payload)
+	_ = json.Unmarshal(raw, &p)
+
+	base := func(id, title string, rows []map[string]any, empty string) map[string]any {
+		return map[string]any{
+			"id": id, "menuVersion": 1, "title": title, "selectedIndex": 0,
+			"rows": rows, "emptyText": empty,
+		}
+	}
+	switch strings.TrimSpace(p.ID) {
+	case "drivers":
+		return base("drivers", "驱动", []map[string]any{{
+			"id": proxyDriver, "label": proxyDriver, "marker": "active",
+			"action": map[string]any{"type": "set_driver", "driver": proxyDriver},
+		}}, "无可用驱动")
+	case "cwd":
+		return base("cwd", "选择项目", []map[string]any{{
+			"id": "__default__", "label": "默认工作区",
+			"action": map[string]any{"type": "create_session", "cwd": ""},
+		}}, "无可用项目")
+	default:
+		return base(strings.TrimSpace(p.ID), "", []map[string]any{}, "暂无内容")
+	}
+}

--- a/adapter_v2/internal/cloudrelay/proxy_test.go
+++ b/adapter_v2/internal/cloudrelay/proxy_test.go
@@ -1,0 +1,79 @@
+package cloudrelay
+
+import (
+	"strings"
+	"testing"
+)
+
+// The device settings page fires these kinds; each must get a reply (so the
+// device's HTTP call resolves instead of timing out to ESP_ERR_HTTP_EAGAIN) with
+// the field names the cloud extracts.
+func TestProxyAnswersSettingsKinds(t *testing.T) {
+	r := &Relay{cfg: Config{HomeSiteID: "site"}}
+
+	cases := []struct {
+		kind      string
+		wantField string // a field the cloud/firmware reads from the reply
+	}{
+		{"agent.drivers", "drivers"},
+		{"agent.messages", "messages"},
+		{"agent.sessions", "sessions"},
+		{"agent.sessions.list.logical", "sessions"}, // the kind the firmware actually fires
+		{"agent.cwd_pool", "pool"},
+		{"agent.active_driver.set", "active_driver"},
+		{"agent.menu", "rows"},
+		{"agent.menu.action", "result"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			var got Envelope
+			n := 0
+			ok := r.handleAgentProxy(func(e Envelope) error { got = e; n++; return nil },
+				Envelope{Kind: tc.kind, MessageID: "m1", DeviceID: "d1", Payload: map[string]any{"id": "drivers"}})
+			if !ok {
+				t.Fatalf("%s not handled (would hang the device)", tc.kind)
+			}
+			if n != 1 || got.Type != "reply" || got.MessageID != "m1" {
+				t.Fatalf("want one reply echoing messageId, got type=%q n=%d id=%q", got.Type, n, got.MessageID)
+			}
+			if _, has := got.Payload[tc.wantField]; !has {
+				t.Errorf("reply payload missing %q field: %v", tc.wantField, got.Payload)
+			}
+		})
+	}
+
+	// agent.drivers must advertise the single claude driver as active.
+	var drv Envelope
+	r.handleAgentProxy(func(e Envelope) error { drv = e; return nil },
+		Envelope{Kind: "agent.drivers", MessageID: "m"})
+	if drv.Payload["active_driver"] != proxyDriver {
+		t.Errorf("active_driver = %v, want %q", drv.Payload["active_driver"], proxyDriver)
+	}
+
+	// An unknown kind is not our concern → false (caller no-ops).
+	if r.handleAgentProxy(func(Envelope) error { return nil }, Envelope{Kind: "something.else"}) {
+		t.Error("unknown kind should return false")
+	}
+}
+
+func TestVoicePromptScopedToClaude(t *testing.T) {
+	// claude CLI → voice persona appended.
+	got := withVoicePrompt([]string{"/usr/local/bin/claude"})
+	if len(got) != 3 || got[1] != "--append-system-prompt" || !strings.Contains(got[2], "简短") {
+		t.Errorf("claude argv not augmented: %v", got)
+	}
+	// Non-claude CLI (e.g. the e2e mockcli) → untouched, so other CLIs/tests are safe.
+	if base := withVoicePrompt([]string{"/tmp/mockcli"}); len(base) != 1 {
+		t.Errorf("non-claude argv should be untouched, got %v", base)
+	}
+	// Explicit empty env disables it.
+	t.Setenv("ADAPTER_V2_VOICE_SYSTEM_PROMPT", "")
+	if off := withVoicePrompt([]string{"claude"}); len(off) != 1 {
+		t.Errorf("empty env should disable the prompt, got %v", off)
+	}
+	// Custom env overrides the default.
+	t.Setenv("ADAPTER_V2_VOICE_SYSTEM_PROMPT", "be terse")
+	if cust := withVoicePrompt([]string{"claude"}); len(cust) != 3 || cust[2] != "be terse" {
+		t.Errorf("custom env not applied, got %v", cust)
+	}
+}

--- a/adapter_v2/internal/cloudrelay/transcript.go
+++ b/adapter_v2/internal/cloudrelay/transcript.go
@@ -160,7 +160,23 @@ type cloudEvents struct {
 	env       Envelope
 	homeSite  string
 	replyText string
-	done      chan struct{}
+	// sent is the last reply snapshot forwarded to the cloud this turn. deviceapi
+	// emits ReplyDelta as a FULL snapshot (robust to TUI redraw, for the device's
+	// re-render). The cloud's TTS streamer, however, treats each voice.reply.delta
+	// as APPEND-only: it speaks text[len(prevDelta):] when the snapshot extends the
+	// previous one, else it speaks the WHOLE text again. claude's TUI redraws make
+	// snapshots non-monotonic, so forwarding every snapshot makes the cloud re-speak
+	// the growing reply over and over. We therefore forward a snapshot ONLY when it
+	// strictly extends `sent` (a prefix-monotonic stream), so the cloud's diff sums
+	// to exactly the reply with no repeats. Non-monotonic snapshots are skipped.
+	// Tradeoff: if the FINAL reply diverges mid-string from the last forwarded
+	// snapshot (a TUI reflow at the final paint — rare for the short replies the
+	// voice persona enforces), the final is skipped too, so the cloud speaks the last
+	// forwarded prefix (slightly stale) rather than re-speaking; the authoritative
+	// full text still goes out in voice.reply. We prefer "never repeat" over "always
+	// fully voiced".
+	sent string
+	done chan struct{}
 }
 
 // begin arms the observer for a new turn and returns its completion channel.
@@ -172,6 +188,7 @@ func (e *cloudEvents) begin(write func(Envelope) error, env Envelope, homeSite s
 	e.env = env
 	e.homeSite = homeSite
 	e.replyText = ""
+	e.sent = ""
 	e.done = make(chan struct{})
 	return e.done
 }
@@ -195,23 +212,35 @@ func (e *cloudEvents) reply() string {
 	return e.replyText
 }
 
-// ReplyDelta streams a live snapshot of the growing reply as a voice.reply.delta
-// event (the cloud feeds it to TTS and re-emits to the device).
-func (e *cloudEvents) ReplyDelta(text string) {
+// forwardDelta forwards a reply snapshot to the cloud ONLY if it strictly extends
+// what we've already sent this turn (prefix-monotonic), keeping the cloud's
+// append-only TTS diff correct (no repeats). Non-monotonic snapshots — caused by
+// claude's TUI redrawing the reply block — are dropped.
+func (e *cloudEvents) forwardDelta(text string) {
 	e.mu.Lock()
-	active, w, env, home := e.active, e.write, e.env, e.homeSite
-	e.mu.Unlock()
-	if !active || w == nil {
+	if !e.active || e.write == nil || len(text) <= len(e.sent) || !strings.HasPrefix(text, e.sent) {
+		e.mu.Unlock()
 		return
 	}
+	w, env, home := e.write, e.env, e.homeSite
+	e.sent = text
+	e.mu.Unlock()
 	_ = w(Envelope{
 		Type: "event", MessageID: env.MessageID, DeviceID: env.DeviceID,
 		HomeSiteID: home, Kind: "voice.reply.delta", Payload: map[string]any{"text": text},
 	})
 }
 
-// ReplyComplete records the authoritative final reply text (sent in voice.reply).
+// ReplyDelta streams the growing reply as a monotonic voice.reply.delta.
+func (e *cloudEvents) ReplyDelta(text string) { e.forwardDelta(text) }
+
+// ReplyComplete records the authoritative final reply text and forwards the final
+// tail when it extends the last snapshot (covering the whole reply in the common
+// append-only case; see the `sent` field doc for the mid-string-divergence
+// tradeoff). It relies on forwardDelta's e.active/e.write guard to drop a late
+// final after end() — that guard must not be removed.
 func (e *cloudEvents) ReplyComplete(text string) {
+	e.forwardDelta(text)
 	e.mu.Lock()
 	if e.active {
 		e.replyText = text


### PR DESCRIPTION
## 背景

异地 flash 真机验证 SaaS 路径(PR #221)——配对、`sites.list` 选 adapter_v2、语音中继**都通了**。但抓到三个真问题,本 PR 全修(**云端/固件零改**,全在 adapter_v2)。

## 三修

**① 重复/叠加播报(主因)**
deviceapi 的 `ReplyDelta` 发**全量快照**(为设备重渲染设计,稳健于 TUI 重绘);但云端 TTS streamer 把每个 `voice.reply.delta` 当**追加**(`text[len(prevDelta):]`,不匹配前缀就整段重念),且**只有 delta 驱动 TTS**。claude 的 TUI 重绘让快照非单调 → 云端把增长中的回复一遍遍重念。
**修**:`cloudEvents` 只在快照**严格扩展已发送内容**(前缀单调)时才转发 → 云端 diff 恰好累加成完整回复一次,**绝不重复**。非单调丢弃,终帧补尾。(已文档化权衡:极少见的终帧中段重排会念最后转发的前缀而非重念;权威全文仍走 `voice.reply`。)

**② 新设备设置页卡死**(`list_drivers`/`load_messages` → `ESP_ERR_HTTP_EAGAIN`)
云端把设备设置调用代理成 `agent.drivers`/`agent.messages`/`agent.sessions`/`agent.menu`… 转给 home adapter;relay 只处理 `voice.transcript`,其余静默 no-op → 设备 HTTP 超时。
**修**:`proxy.go` 对每个 kind 回**设备可解析的最小静态响应**(单 `claude-code` 驱动且 active、空历史/会话、最小菜单),字段名对齐云端提取 + 固件解析。adapter_v2 本就一个 claude PTY,单驱动是诚实答案(也契合"驱动只读显示"规划)。

**③ 回复太长**(语音设备念长篇 CLI 散文)
**修**:经 claude 的 `--append-system-prompt` 注入简洁语音人设(≤1-2 句、禁列表/代码),**仅作用于云中继 PTY**(web 终端保持完整 claude)。`ADAPTER_V2_VOICE_SYSTEM_PROMPT` 可覆盖,置空可关。

## Review

三视角对抗(delta 语义 vs 真云端 / proxy 形状 vs 云端+固件 / 作用域):**零 blocking、零 major**——delta 修复可证明绝不重复、proxy 字段名匹配。已处理 minor:诚实文档化中段重排权衡、**加真跨 goroutine `-race` 测试**、补 `agent.sessions.list.logical` 用例(固件实际调的 kind)。

## 验证
build/vet/test/race 绿;cloud-relay e2e 签字门过;全模块无回归。

## 你异地复验
`CLOUD_WS_URL=wss://bbclaw.daboluo.cc/ws make run`(home_site_id 已持久化 → 直接 `claimed`,不用再认领):预期回复**简短不重复**、新设备设置页**不再卡**。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)