### PR TITLE
fix(adapter_v2): 设备别念 claude 欢迎页——抽取要求 ⏺ 标记

### DIFF
--- a/adapter_v2/internal/extract/extract.go
+++ b/adapter_v2/internal/extract/extract.go
@@ -99,6 +99,16 @@ func (e *Extractor) extract() string {
 		return reply
 	}
 
+	// No "⏺" assistant block on screen. If this IS claude (its "❯" prompt or the
+	// working spinner is visible), the assistant simply hasn't emitted its reply
+	// yet — return nothing rather than leaking the welcome banner / status chrome
+	// as a "reply" (which the device would otherwise speak, e.g. the whole startup
+	// screen on the first turn of a fresh session). The baseline-diff fallback
+	// below exists ONLY for genuinely marker-less CLIs that never render a "⏺".
+	if isClaudeScreen(visible) {
+		return ""
+	}
+
 	lines := contentLines(visible)
 	// Keep only lines not already present in the baseline. A reply line that
 	// happens to duplicate baseline text verbatim is rare and harmless to drop;
@@ -150,6 +160,36 @@ func extractMarkerBlock(visible string) (string, bool) {
 		block = block[:len(block)-1]
 	}
 	return strings.Join(block, "\n"), true
+}
+
+// isClaudeScreen reports whether the visible grid carries claude's signature
+// chrome — its "❯" input-prompt glyph or the working spinner — meaning this is a
+// claude session whose reply (a "⏺" block) is simply not on screen yet. Used to
+// suppress the diff fallback for claude so the welcome banner / status bar never
+// leak into the reply. Keyed on "❯" specifically (not a generic ">") so a real
+// marker-less CLI still gets the diff fallback.
+func isClaudeScreen(visible string) bool {
+	for _, line := range strings.Split(visible, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" {
+			continue
+		}
+		if isSpinnerLine(t) {
+			return true
+		}
+		// A line opening with a box-drawing border glyph is claude's TUI chrome
+		// (welcome banner, input box, status bar are all boxed); the assistant
+		// reply block is never boxed. With no "⏺" present, a boxed line is chrome.
+		if r := []rune(t); len(r) > 0 && isBoxDrawingRune(r[0]) {
+			return true
+		}
+		// claude's prompt glyph "❯" at the start of the (border-stripped) line,
+		// whether idle ("❯") or echoing the user's text ("❯ …" / "❯ …").
+		if s := strings.TrimSpace(strings.TrimLeft(t, "│|")); strings.HasPrefix(s, "❯") {
+			return true
+		}
+	}
+	return false
 }
 
 // stripReplyMarker removes claude's assistant-turn bullet ("⏺ ", U+23FA) from the

--- a/adapter_v2/internal/extract/extract_test.go
+++ b/adapter_v2/internal/extract/extract_test.go
@@ -230,3 +230,38 @@ func itoa(n int) string {
 	}
 	return string(buf[i:])
 }
+
+// Regression for the SaaS voice bug: on the first turn of a fresh claude session
+// the screen is the boxed welcome banner (no "⏺" reply yet). The diff fallback
+// used to return that whole banner as the "reply", so the device spoke the
+// startup screen. isClaudeScreen must suppress it — empty until "⏺" appears —
+// while a genuinely marker-less CLI still gets the diff fallback.
+func TestExtractSuppressesClaudeChromeUntilMarker(t *testing.T) {
+	s := vtscreen.New(80, 24)
+	ext := New(s)
+
+	// claude welcome/idle chrome: boxed banner + "❯" prompt, no "⏺" reply.
+	s.Feed([]byte("\x1b[1;1H╭─── Claude Code v2.1.185 ──────────────────╮\r\n" +
+		"│            Welcome back mikas!             │\r\n" +
+		"╰────────────────────────────────────────────╯\r\n" +
+		"❯ Try \"edit main.go\"\r\n"))
+	if r, _ := ext.OnOutput(); strings.TrimSpace(r.Text) != "" {
+		t.Errorf("welcome chrome leaked as reply: %q", r.Text)
+	}
+
+	// claude emits its reply — now the "⏺" block is the reply.
+	s.Feed([]byte("\x1b[6;1H⏺ The answer is 42.\r\n"))
+	if r, _ := ext.OnOutput(); !strings.Contains(r.Text, "The answer is 42.") {
+		t.Errorf("reply not extracted once marker present: %q", r.Text)
+	}
+}
+
+func TestExtractFallbackStillWorksForMarkerlessCLI(t *testing.T) {
+	s := vtscreen.New(80, 24)
+	ext := New(s)
+	// A plain marker-less CLI: no box-drawing, no "❯", no "⏺" — diff fallback applies.
+	s.Feed([]byte("\x1b[1;1Hplain assistant reply line\r\n"))
+	if r, _ := ext.OnOutput(); !strings.Contains(r.Text, "plain assistant reply line") {
+		t.Errorf("marker-less diff fallback regressed: %q", r.Text)
+	}
+}


### PR DESCRIPTION
## 问题

设备播报的是 claude **整个启动页**(`Claude Code v2.x` banner、`Try "..."` 占位、`auto mode on` 页脚),而不是发送后返回的回复。

## 根因(对真 claude v2.1.185 复现确认)

新 session 第一轮,在 claude 渲染出 `⏺` 回复块**之前**,屏幕是盒装欢迎 banner。抽取器找不到 `⏺` → **退化到 baseline-diff → 返回所有非基线行 = 整屏 banner**。这些帧被当 `voice.reply.delta` 流出去念了(配合云端 TTS 还叠加了之前的重复)。

## 修复

无 `⏺` 回复块时,若屏是 **claude chrome**(box-drawing 边框 / `❯` 提示 / 思考 spinner)→ 返回**空**。回复块 `⏺` 从不带盒,所以"有盒但无标记"的屏就是 chrome 不是回复。baseline-diff 退化路径**只留给真正无标记的 CLI**(无盒、无 `❯`、无 `⏺`),回归测试钉死。

## 验证(端到端对真 claude)

一次性 PTY harness 完全按云中继方式驱动 `session + deviceapi.Bridge`:
- **修前**:一轮流出 **11 个 banner chrome delta**,`ReplyComplete=" "`(空)
- **修后**:流出**1 个 delta `"HELLO-THERE-123"`**,`ReplyComplete="HELLO-THERE-123"` ✅

顺带确认生产 80×24 尺寸一致(PTY 和 Bridge 私有 VT 镜像都默认 80×24;我最初看到的乱码是 harness 里 120-vs-80 不匹配的假象,非生产问题)。

LAN bbwire/2 和 SaaS 云中继**共用抽取器,两条路都受益**。已知限制:回复长到 `⏺` 滚出 80×24 屏会被抑制——语音人设保证回复 1-2 句,可接受。extract/deviceapi/cloudrelay 测试 + e2e 门全绿。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)