### PR TITLE
feat(adapter_v2): 云中继打印对话输入输出日志(便于排错)

### DIFF
--- a/adapter_v2/internal/cloudrelay/cloudrelay.go
+++ b/adapter_v2/internal/cloudrelay/cloudrelay.go
@@ -284,8 +284,13 @@ func (r *Relay) handleRequest(ctx context.Context, write func(Envelope) error, e
 		return
 	}
 	// Settings/UI proxy kinds (agent.drivers, agent.messages, agent.menu, …) get a
-	// minimal static reply; unknown kinds fall through to a silent no-op.
-	r.handleAgentProxy(write, env)
+	// minimal static reply; unknown kinds fall through to a silent no-op. Log either
+	// way so the device's settings-page traffic is visible while debugging.
+	if r.handleAgentProxy(write, env) {
+		r.log("cloudrelay: proxy device=%s kind=%s", env.DeviceID, env.Kind)
+	} else {
+		r.log("cloudrelay: ignored device=%s kind=%s (no handler)", env.DeviceID, env.Kind)
+	}
 }
 
 // ── small helpers ───────────────────────────────────────────────────────────

--- a/adapter_v2/internal/cloudrelay/transcript.go
+++ b/adapter_v2/internal/cloudrelay/transcript.go
@@ -22,8 +22,13 @@ func (r *Relay) handleTranscript(ctx context.Context, write func(Envelope) error
 	if deviceID == "" {
 		deviceID = "cloud-anon"
 	}
+	// Log the conversation IN (the cloud's ASR transcript). The cloud does ASR/TTS,
+	// so this transcript + the reply below are the full I/O visible to adapter_v2 —
+	// the primary signal for debugging a relayed voice turn.
+	r.log("cloudrelay: ◀ asr device=%s text=%q", deviceID, text)
+	started := time.Now()
 	if text == "" {
-		// Nothing to say — return a clean empty reply rather than poke the CLI.
+		r.log("cloudrelay: ▶ reply device=%s (empty transcript — skipped, no CLI turn)", deviceID)
 		return write(Envelope{
 			Type: "reply", MessageID: env.MessageID, DeviceID: env.DeviceID,
 			HomeSiteID: r.cfg.HomeSiteID, Kind: "voice.reply",
@@ -62,13 +67,19 @@ func (r *Relay) handleTranscript(ctx context.Context, write func(Envelope) error
 	case <-time.After(r.cfg.ReplyWait):
 		timedOut = true
 	case <-ctx.Done():
+		r.log("cloudrelay: ✗ turn device=%s cancelled after %s (connection dropped?)", deviceID, time.Since(started).Round(time.Millisecond))
 		return ctx.Err()
 	}
 
+	reply := cb.ev.reply()
+	// Log the conversation OUT (the reply text the cloud will TTS). A blank reply
+	// here is the signal that extraction returned nothing for this turn.
+	r.log("cloudrelay: ▶ reply device=%s elapsed=%s timedOut=%v text=%q",
+		deviceID, time.Since(started).Round(time.Millisecond), timedOut, reply)
 	return write(Envelope{
 		Type: "reply", MessageID: env.MessageID, DeviceID: env.DeviceID,
 		HomeSiteID: r.cfg.HomeSiteID, Kind: "voice.reply",
-		Payload: map[string]any{"ok": true, "text": cb.ev.reply(), "replyWaitTimedOut": timedOut},
+		Payload: map[string]any{"ok": true, "text": reply, "replyWaitTimedOut": timedOut},
 	})
 }
 


### PR DESCRIPTION
云中继之前**静默处理**语音轮次——你说话时 adapter_v2 日志里啥都没有,所以看着像"没执行"。

cloud_saas 下云端做 ASR/TTS,所以 adapter_v2 收到的**转写**和返回的**回复**就是这里能看到的完整对话(回复正是云端拿去 TTS 的文本)。两者都打出来。

每轮语音:
```
cloudrelay: ◀ asr device=<id> text="<转写输入>"
cloudrelay: ▶ reply device=<id> elapsed=<耗时> timedOut=<bool> text="<回复输出>"
```
- `▶ reply ... text=""` 空 → 抽取没拿到东西(就是之前念欢迎页那类问题)
- **没有 `◀ asr` 行** → 转写根本没到 adapter(云端路由问题,不是 adapter)
- `✗ turn ... cancelled` → 中途掉线
- 设置页流量也打:`cloudrelay: proxy device=<id> kind=agent.drivers` / `ignored ... (no handler)`

纯日志,无行为改动。build/vet/test + e2e 绿。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)