### PR TITLE
fix(adapter_v2): 抽取多段回复(不在顶格行截断)

### DIFF
--- a/adapter_v2/internal/extract/extract.go
+++ b/adapter_v2/internal/extract/extract.go
@@ -149,9 +149,12 @@ func extractMarkerBlock(visible string) (string, bool) {
 			block = append(block, "") // keep interior blanks (paragraph breaks)
 			continue
 		}
-		// A continuation line is indented; anything flush-left, or any noise line,
-		// ends the reply block (the "✻ … for Ns" summary, box rules, prompt, footer).
-		if isNoiseLine(l) || !strings.HasPrefix(raw[k], "  ") {
+		// The reply runs until the first NOISE line — claude's "✻ … for Ns"
+		// completion summary, the idle prompt, box rules, or the status footer. We do
+		// NOT stop at a flush-left line: claude v2 lays out later reply paragraphs at
+		// column 0 (not only as 2-space-indented continuations), so requiring
+		// indentation truncated multi-paragraph replies to just the first paragraph.
+		if isNoiseLine(l) {
 			break
 		}
 		block = append(block, l)

--- a/adapter_v2/internal/extract/extract_test.go
+++ b/adapter_v2/internal/extract/extract_test.go
@@ -265,3 +265,26 @@ func TestExtractFallbackStillWorksForMarkerlessCLI(t *testing.T) {
 		t.Errorf("marker-less diff fallback regressed: %q", r.Text)
 	}
 }
+
+// Regression: claude v2 lays out a multi-paragraph reply's later paragraphs at
+// column 0 (flush-left), not as 2-space-indented continuations. The extractor
+// must capture the WHOLE reply up to the "✻ … for Ns" completion summary, not
+// truncate at the first flush-left paragraph (the on-device bug where only
+// "你好你好,我在呢!" was spoken and the follow-up paragraph was dropped).
+func TestExtractMarkerBlockFlushLeftParagraphs(t *testing.T) {
+	s := vtscreen.New(80, 24)
+	ext := New(s)
+	s.Feed([]byte("\x1b[1;1H" +
+		"⏺ 你好你好,我在呢!\r\n" +
+		"\r\n" +
+		"对了,咱们还没正式认识——我该怎么称呼你?\r\n" + // flush-left 2nd paragraph
+		"✻ Worked for 2s\r\n" + // completion summary → reply ends here
+		"❯ \r\n"))
+	r, _ := ext.OnOutput()
+	if !strings.Contains(r.Text, "你好你好,我在呢!") || !strings.Contains(r.Text, "对了,咱们还没正式认识") {
+		t.Errorf("flush-left 2nd paragraph dropped: %q", r.Text)
+	}
+	if strings.Contains(r.Text, "Worked for") || strings.Contains(r.Text, "❯") {
+		t.Errorf("reply leaked the completion summary / prompt: %q", r.Text)
+	}
+}


### PR DESCRIPTION
设备上管家回复被截成第一段:只念了「你好你好，我在呢！」，丢了后续「对了，咱们还没正式认识——我该怎么称呼你？…」。adapter 日志证实抽取只返回了第一行。

**原因**:extractMarkerBlock 取 ⏺ 行 + 仅 **2 空格缩进**的续行，遇顶格行就停。但 claude v2 多段回复的后续段落是**顶格(col 0)**(抓真 claude TUI 确认)，所以顶格的第二段被提前截断。

**修复**:回复从 ⏺ 行一直取到第一个**噪声行**(✻ 完成摘要 / ❯ 提示 / 框线 / 状态栏，均已被 isNoiseLine 识别)，不再因顶格而停。顶格段落被纳入，缩进续行仍正常。对真 claude 验证(多段回复完整抽出)+ 回归测试钉死。

Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)