### PR TITLE
feat(adapter_v2): NormalizeReply — vt 网格文本规范化(TTS 渲染组件)

### DIFF
--- a/adapter_v2/internal/extract/extract.go
+++ b/adapter_v2/internal/extract/extract.go
@@ -93,7 +93,17 @@ const replyMarker = "⏺"
 // anchor on claude's "⏺" reply marker and take that block (#claude). Fallback for
 // CLIs without the marker: diff the visible content against the per-turn baseline
 // so only the newest lines survive.
+// extract returns the newest reply as clean, speakable text: it isolates the
+// reply block from the vt grid (extractRaw) and runs it through NormalizeReply
+// (the swappable "TTS rendering" step) to undo grid artifacts — wrapping, padding
+// spaces, continuation indent — that read badly aloud.
 func (e *Extractor) extract() string {
+	return NormalizeReply(e.extractRaw())
+}
+
+// extractRaw isolates the newest-reply text from the current screen, still
+// carrying vt-grid layout (NormalizeReply cleans it).
+func (e *Extractor) extractRaw() string {
 	visible := e.screen.VisibleText()
 	if reply, ok := extractMarkerBlock(visible); ok {
 		return reply

--- a/adapter_v2/internal/extract/normalize.go
+++ b/adapter_v2/internal/extract/normalize.go
@@ -1,0 +1,108 @@
+package extract
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// NormalizeReply turns the raw text scraped from claude's vt grid into clean,
+// speakable prose for the device/voice line. It is a SEPARATE, swappable step
+// (the "TTS rendering" component): when we only have the rendered 80-column
+// window — not claude's original token stream — the extracted text carries grid
+// artifacts that read badly aloud. Replace/skip this layer if a future transport
+// yields the raw text directly.
+//
+// It fixes the artifacts observed on real devices:
+//   - hard wraps that split a word/sentence across grid rows
+//     ("工作目\n录现在是…" → "工作目录现在是…")
+//   - runs of spaces from wide-char / alignment padding
+//     ("我是   Claude Code … 命令行       AI" → "我是 Claude Code … 命令行 AI")
+//   - the 2-space continuation indent claude aligns under "⏺ "
+//
+// A blank line is a real paragraph break and is preserved (as a single newline);
+// every other newline inside a paragraph is treated as a wrap and rejoined. CJK
+// boundaries rejoin with no space (Chinese has no inter-word spaces); an
+// ASCII-word boundary rejoins with one space (the wrap ate the original space).
+func NormalizeReply(raw string) string {
+	var paragraphs []string
+	var cur string
+	flush := func() {
+		if s := collapseSpaces(strings.TrimSpace(cur)); s != "" {
+			paragraphs = append(paragraphs, s)
+		}
+		cur = ""
+	}
+	for _, line := range strings.Split(raw, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" {
+			flush() // blank line → paragraph break
+			continue
+		}
+		cur = rejoinWrap(cur, t)
+	}
+	flush()
+	return strings.Join(paragraphs, "\n")
+}
+
+// rejoinWrap appends next to cur across a wrap boundary. Script-based: if either
+// side of the boundary is CJK, rejoin with NO space (Chinese/Japanese have no
+// inter-word spaces, and a long line wrapped between two CJK runes); otherwise
+// the text is Latin and the wrap dropped a real inter-word space, so rejoin with
+// one space ("…is Paris." + "It has…" → "…is Paris. It has…").
+func rejoinWrap(cur, next string) string {
+	if cur == "" {
+		return next
+	}
+	if next == "" {
+		return cur
+	}
+	a, _ := utf8.DecodeLastRuneInString(cur)
+	b, _ := utf8.DecodeRuneInString(next)
+	if isCJK(a) || isCJK(b) {
+		return cur + next
+	}
+	return cur + " " + next
+}
+
+// collapseSpaces reduces every run of 2+ spaces to a single space (the wide-char
+// / alignment padding artifact). Newlines are not present here (paragraphs are
+// joined before this runs), so only spaces are touched.
+func collapseSpaces(s string) string {
+	if !strings.Contains(s, "  ") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := false
+	for _, r := range s {
+		if r == ' ' {
+			if prevSpace {
+				continue
+			}
+			prevSpace = true
+		} else {
+			prevSpace = false
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// isCJK reports whether r is an East Asian character or CJK/fullwidth
+// punctuation — the cases where text has no inter-word spaces, so a wrap between
+// such runes must rejoin with none.
+func isCJK(r rune) bool {
+	switch {
+	case unicode.Is(unicode.Han, r),
+		unicode.Is(unicode.Hiragana, r),
+		unicode.Is(unicode.Katakana, r),
+		unicode.Is(unicode.Hangul, r):
+		return true
+	case r >= 0x3000 && r <= 0x303F: // CJK symbols & punctuation (，。、！？「」…)
+		return true
+	case r >= 0xFF00 && r <= 0xFFEF: // halfwidth & fullwidth forms
+		return true
+	}
+	return false
+}

--- a/adapter_v2/internal/extract/normalize_test.go
+++ b/adapter_v2/internal/extract/normalize_test.go
@@ -1,0 +1,57 @@
+package extract
+
+import "testing"
+
+func TestNormalizeReply(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{
+			name: "plain CJK reply unchanged",
+			in:   "你好你好,我在呢!",
+			want: "你好你好,我在呢!",
+		},
+		{
+			name: "CJK word split by a hard wrap is rejoined with no space",
+			in:   "工作目\n录现在是 bbclaw 的 adapter_v2。",
+			want: "工作目录现在是 bbclaw 的 adapter_v2。",
+		},
+		{
+			name: "Latin sentence wrapped across rows rejoins with a space",
+			in:   "The capital of France is Paris.\nIt has been the country's capital\nand is its largest city.",
+			want: "The capital of France is Paris. It has been the country's capital and is its largest city.",
+		},
+		{
+			name: "runs of padding spaces collapse to one",
+			in:   "我是   Claude Code,Anthropic 推出的命令行       AI",
+			want: "我是 Claude Code,Anthropic 推出的命令行 AI",
+		},
+		{
+			name: "2-space continuation indent is stripped",
+			in:   "你好!\n  我是助手。",
+			want: "你好!我是助手。",
+		},
+		{
+			name: "blank line is a real paragraph break (kept as one newline)",
+			in:   "你好你好,我在呢!\n\n对了,咱们还没正式认识——我该怎么称呼你?",
+			want: "你好你好,我在呢!\n对了,咱们还没正式认识——我该怎么称呼你?",
+		},
+		{
+			name: "CJK-then-Latin wrap rejoins with no space",
+			in:   "推出的命令行 AI\n编程助手,很高兴帮你。",
+			want: "推出的命令行 AI编程助手,很高兴帮你。",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeReply(tc.in); got != tc.want {
+				t.Errorf("NormalizeReply(%q)\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/adapter_v2/internal/extract/testdata/claude_reply.expected.txt
+++ b/adapter_v2/internal/extract/testdata/claude_reply.expected.txt
@@ -1,3 +1,1 @@
-The capital of France is Paris.
-  It has been the country's capital since the 12th century
-  and is its largest city.
+The capital of France is Paris. It has been the country's capital since the 12th century and is its largest city.


### PR DESCRIPTION
独立可替换的「TTS 渲染」组件:把从 claude 80 列 vt 网格抓到的文本还原成可朗读散文。TUI 只能拿到渲染窗口(拿不到原始 token 流),抽出的文本带网格残留,朗读很糟,这层负责清洗。(以后有别的取数方案就换掉这层。)

**extract.NormalizeReply 修复真机所见残留**:
- 硬折行切断的词/句重接(`工作目\n录现在是…`→`工作目录现在是…`;按脚本:Latin 补回被吃的词间空格,CJK 不加)
- 宽字符/对齐填充的连续空格折叠为单个(`我是···Claude Code…命令行·······AI`→`我是 Claude Code…命令行 AI`)
- 续行对齐缩进剥除
- 空行=真段落分隔(保留单换行);段内其它换行视为折行重接

接入 extract()(extractRaw→NormalizeReply),设备线(LAN+云中继)每条回复都规范化;web 终端不受影响(走 termchan 原始字节)。单测覆盖每类残留;**对真 claude 验证**:多段回复抽成连续、可朗读、无中途断句的干净文本。

Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)