### PR TITLE
fix(adapter_v2): 云中继只发终帧干净回复(修 TTS 念错内容)

### DIFF
--- a/adapter_v2/internal/cloudrelay/transcript.go
+++ b/adapter_v2/internal/cloudrelay/transcript.go
@@ -162,10 +162,19 @@ func (m *bridgeManager) get(deviceID string) (*cloudBridge, error) {
 		return nil, err
 	}
 	ev := &cloudEvents{}
-	// asr/tts/sink are nil: this path is text-only (cloud does ASR/TTS). The
-	// Bridge injects the transcript and extracts the reply; the events observer
-	// streams that reply text to the cloud. StreamReplyDelta on → live deltas.
-	bridge := deviceapi.New(sess, nil, nil, nil, deviceapi.Config{StreamReplyDelta: true, Warmup: true})
+	// asr/tts/sink are nil: this path is text-only (cloud does ASR/TTS). The Bridge
+	// injects the transcript and extracts the reply; the events observer forwards
+	// that reply text to the cloud, which TTSs it.
+	//
+	// StreamReplyDelta is OFF: the cloud TTSs the voice.reply.delta stream, but our
+	// deltas are NormalizeReply'd snapshots of a still-growing reply, and
+	// normalization (wrap-rejoin / space-collapse) is non-monotonic as text grows —
+	// so streamed snapshots desync the cloud's append-only diff and it speaks the
+	// wrong text. Instead we forward ONE delta with the final, clean reply at turn
+	// end (cloudEvents.ReplyComplete → forwardDelta), so the cloud TTSs exactly the
+	// text the device extracted. (Streaming sentence-level TTS can return later with
+	// a normalization-aware, monotonic delta stream.)
+	bridge := deviceapi.New(sess, nil, nil, nil, deviceapi.Config{Warmup: true})
 	bridge.SetEvents(ev)
 	go bridge.Run(context.Background())
 	cb := &cloudBridge{sess: sess, bridge: bridge, ev: ev}


### PR DESCRIPTION
设备上**抽取正确但 TTS 念的是完全不同的内容**。云端 TTS 念的是 `voice.reply.delta` **流**(不是终帧),而 #227 之后我们的 delta 是 NormalizeReply 后的**流式快照**。规范化(折行重接/空格折叠)随文本增长**非单调**,流式快照让云端的追加式 diff 错位 → 合成出错文本。

**修**:云中继 bridge 关掉 StreamReplyDelta。deviceapi 不再发中间 delta;`cloudEvents.ReplyComplete` 在轮末把**最终规范化回复作为一个 delta** 发出(已确认顺序:ReplyComplete 先于 TurnIdle,observer 仍 armed)→ 云端念的就是设备抽取的那段。代价:失去逐句流式 TTS 延迟优势(设备在轮末才听到完整回复)——对管家短回复可接受;以后可用"规范化感知的单调 delta 流"恢复流式。

cloudrelay 单测 + e2e 绿(e2e 仍见一个终帧 delta=回复)。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)