### PR TITLE
fix(adapter_v2): 设备会话跳过 claude 权限弹框(bypass)

### DIFF
--- a/adapter_v2/cmd/bbclaw-adapter-v2/main.go
+++ b/adapter_v2/cmd/bbclaw-adapter-v2/main.go
@@ -67,7 +67,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("bbclaw-adapter-v2: butler workspace: %v", err)
 	}
-	defaultArgv := butler.AppendDevicePersona(cfg.Argv, defaultCwd)
+	defaultArgv := butler.DeviceClaudeArgs(cfg.Argv, defaultCwd)
 	log.Printf("bbclaw-adapter-v2: butler workspace %s", defaultCwd)
 
 	srv := &http.Server{

--- a/adapter_v2/internal/butler/butler_test.go
+++ b/adapter_v2/internal/butler/butler_test.go
@@ -7,26 +7,41 @@ import (
 	"testing"
 )
 
-func TestAppendDevicePersona(t *testing.T) {
-	// claude CLI → device persona appended via --append-system-prompt.
-	got := AppendDevicePersona([]string{"/usr/local/bin/claude"}, "/ws")
-	if len(got) != 3 || got[1] != "--append-system-prompt" || !strings.Contains(got[2], "对讲机") {
-		t.Errorf("claude argv not augmented: %v", got)
+func TestDeviceClaudeArgs(t *testing.T) {
+	// claude CLI → bypass-permissions flag + device persona appended.
+	got := DeviceClaudeArgs([]string{"/usr/local/bin/claude"}, "/ws")
+	if !containsArg(got, "--dangerously-skip-permissions") {
+		t.Errorf("missing permission bypass (voice device can't answer prompts): %v", got)
+	}
+	if i := argIndex(got, "--append-system-prompt"); i < 0 || i+1 >= len(got) || !strings.Contains(got[i+1], "对讲机") {
+		t.Errorf("device persona not appended: %v", got)
 	}
 	// Non-claude CLI (e.g. the e2e mockcli) → untouched.
-	if base := AppendDevicePersona([]string{"/tmp/mockcli"}, "/ws"); len(base) != 1 {
+	if base := DeviceClaudeArgs([]string{"/tmp/mockcli"}, "/ws"); len(base) != 1 {
 		t.Errorf("non-claude argv should be untouched, got %v", base)
 	}
-	// Explicit empty env disables the prompt.
-	t.Setenv("ADAPTER_V2_VOICE_SYSTEM_PROMPT", "")
-	if off := AppendDevicePersona([]string{"claude"}, ""); len(off) != 1 {
-		t.Errorf("empty env should disable the persona, got %v", off)
+	// Permission bypass can be turned off for safety.
+	t.Setenv("ADAPTER_V2_SKIP_PERMISSIONS", "0")
+	if off := DeviceClaudeArgs([]string{"claude"}, ""); containsArg(off, "--dangerously-skip-permissions") {
+		t.Errorf("ADAPTER_V2_SKIP_PERMISSIONS=0 should drop the bypass flag: %v", off)
 	}
-	// Custom env overrides the default whole prompt.
+	t.Setenv("ADAPTER_V2_SKIP_PERMISSIONS", "1")
+	// Custom persona env overrides the default whole prompt.
 	t.Setenv("ADAPTER_V2_VOICE_SYSTEM_PROMPT", "be terse")
-	if cust := AppendDevicePersona([]string{"claude"}, ""); len(cust) != 3 || cust[2] != "be terse" {
-		t.Errorf("custom env not applied, got %v", cust)
+	got = DeviceClaudeArgs([]string{"claude"}, "")
+	if i := argIndex(got, "--append-system-prompt"); i < 0 || got[i+1] != "be terse" {
+		t.Errorf("custom persona env not applied: %v", got)
 	}
+}
+
+func containsArg(args []string, want string) bool { return argIndex(args, want) >= 0 }
+func argIndex(args []string, want string) int {
+	for i, a := range args {
+		if a == want {
+			return i
+		}
+	}
+	return -1
 }
 
 func TestEnsureWorkspaceScaffoldsAndIsIdempotent(t *testing.T) {

--- a/adapter_v2/internal/butler/workspace.go
+++ b/adapter_v2/internal/butler/workspace.go
@@ -60,20 +60,43 @@ func EnsureWorkspace(dir string) (string, error) {
 	return dir, nil
 }
 
-// AppendDevicePersona appends claude's --append-system-prompt <DeviceSystemPrompt>
-// to argv, scoped to a claude CLI (the flag is claude-specific; other CLIs are
-// left untouched). The persona text can be overridden whole via
-// ADAPTER_V2_VOICE_SYSTEM_PROMPT, or disabled by setting it empty.
-func AppendDevicePersona(argv []string, cwd string) []string {
+// DeviceClaudeArgs builds the claude argv for the device/voice session. It does
+// two device-specific things (scoped to a claude CLI; other CLIs pass through):
+//
+//  1. Bypasses permission prompts (--dangerously-skip-permissions). A voice device
+//     has NO way to answer claude's "Do you want to proceed? 1.Yes 2.No" tool
+//     dialogs, so a Bash/edit tool call would hang the turn forever. The butler
+//     runs in its own controlled workspace, and the user opted into an autonomous
+//     voice assistant, so bypassing is the right tradeoff. Disable with
+//     ADAPTER_V2_SKIP_PERMISSIONS=0 (then tool turns will hang on the prompt).
+//  2. Appends the walkie-talkie device persona via --append-system-prompt. Override
+//     the whole prompt with ADAPTER_V2_VOICE_SYSTEM_PROMPT, or set it empty to skip.
+func DeviceClaudeArgs(argv []string, cwd string) []string {
 	if len(argv) == 0 || !strings.Contains(strings.ToLower(filepath.Base(argv[0])), "claude") {
 		return argv
+	}
+	out := append([]string{}, argv...)
+	if envBool("ADAPTER_V2_SKIP_PERMISSIONS", true) {
+		out = append(out, "--dangerously-skip-permissions")
 	}
 	prompt := DeviceSystemPrompt(cwd, "")
 	if v, ok := os.LookupEnv("ADAPTER_V2_VOICE_SYSTEM_PROMPT"); ok {
 		prompt = v
 	}
-	if strings.TrimSpace(prompt) == "" {
-		return argv
+	if strings.TrimSpace(prompt) != "" {
+		out = append(out, "--append-system-prompt", prompt)
 	}
-	return append(append([]string{}, argv...), "--append-system-prompt", prompt)
+	return out
+}
+
+// envBool reads a boolean env var (1/true/yes/on vs 0/false/no/off), returning def
+// when unset or unrecognised.
+func envBool(name string, def bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	}
+	return def
 }


### PR DESCRIPTION
语音设备没法回答 claude 的「Do you want to proceed? 1.Yes 2.No」工具弹框——所以第一次 Bash/编辑工具调用(如管家跑 curl 查 IP)就**卡在权限框**,无路可走。(auto / acceptEdits 不够:只自动接受编辑,Bash 仍弹框。)

**修**:设备/语音会话的 claude 用 `--dangerously-skip-permissions` 启动,工具直接跑不弹框。管家跑在自己受控的 workspace 里,用户也选择了自主语音助手,对这种形态 bypass 是对的权衡。**真 claude 实测**:「用 bash 运行 echo…」直接执行并回复输出,无弹框无卡顿。`ADAPTER_V2_SKIP_PERMISSIONS=0` 可关。

AppendDevicePersona → DeviceClaudeArgs(现在做 bypass+人设);其它 CLI 原样透传。build/vet/test 绿。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)