### PR TITLE
fix(adapter_v2): 复用 v1 的 workspace(保留用户记忆)

### DIFF
--- a/adapter_v2/cmd/bbclaw-adapter-v2/main.go
+++ b/adapter_v2/cmd/bbclaw-adapter-v2/main.go
@@ -62,7 +62,7 @@ func main() {
 	// device persona appended. The device (LAN + cloud relay) and the web terminal
 	// all spawn session.DefaultID with THIS exact argv + cwd, attaching to one
 	// identical PTY. ADAPTER_V2_CWD overrides the workspace dir; otherwise the
-	// dedicated ~/.bbclaw-adapter-v2/workspace is created + scaffolded.
+	// shared ~/.bbclaw-adapter/workspace (v1's) is used, keeping the user's memory.
 	defaultCwd, err := butler.EnsureWorkspace(cfg.Cwd)
 	if err != nil {
 		log.Fatalf("bbclaw-adapter-v2: butler workspace: %v", err)

--- a/adapter_v2/internal/butler/workspace.go
+++ b/adapter_v2/internal/butler/workspace.go
@@ -18,13 +18,17 @@ var memoryFiles = map[string]string{
 	"decisions.md":   "# 关键决策\n\n（敲定的重要决策 + 原因，一条一句）\n",
 }
 
-// DefaultWorkspaceDir returns ~/.bbclaw-adapter-v2/workspace — the butler's home.
+// DefaultWorkspaceDir returns ~/.bbclaw-adapter/workspace — SHARED with v1's
+// butler. v2 deliberately reuses v1's workspace so the assistant keeps the user's
+// accumulated memory (name, preferences, projects) across the v1→v2 move; on a
+// machine that already ran v1, EnsureWorkspace finds CLAUDE.md + MEMORY/ present
+// and leaves them untouched, so v1's curated persona and memory carry over as-is.
 func DefaultWorkspaceDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("user home: %w", err)
 	}
-	return filepath.Join(home, ".bbclaw-adapter-v2", "workspace"), nil
+	return filepath.Join(home, ".bbclaw-adapter", "workspace"), nil
 }
 
 // EnsureWorkspace creates the butler workspace at dir (if empty, the default) and


### PR DESCRIPTION
v2 之前用独立的 `~/.bbclaw-adapter-v2/workspace`,记忆是空的——管家不认识用户了(v1 在 `~/.bbclaw-adapter/workspace/MEMORY/profile.md` 记了「怎么称呼:周老板」)。改默认 workspace 指向 v1 的 `~/.bbclaw-adapter/workspace`,v2 直接复用 v1 的 CLAUDE.md + MEMORY/。EnsureWorkspace 只写缺失文件,所以跑过 v1 的机器上不会覆盖任何东西——人设和记忆原样沿用。(ADAPTER_V2_CWD 仍可覆盖。)

Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)