### PR TITLE
feat(firmware): 持久化选中 adapter 到 NVS + 设置页隐藏 driver/模型

### DIFF
--- a/firmware/include/bb_session_store.h
+++ b/firmware/include/bb_session_store.h
@@ -87,3 +87,28 @@ esp_err_t bb_session_store_load_active_driver(char* out_name, size_t sz);
  * @return ESP_OK if task spawned (NVS write happens asynchronously).
  */
 esp_err_t bb_session_store_save_active_driver(const char* driver_name);
+
+/**
+ * Read the cached active adapter home_site_id (the SaaS adapter the user last
+ * selected in Settings). Populated by preload_nvs at boot and refreshed by
+ * save_active_site. Pure memory read — safe from any task.
+ *
+ * Lets the Settings page show the last-chosen adapter immediately, before (or
+ * even without) a fresh sites.list round-trip — which can fail/time out right
+ * after boot if the cloud WS isn't ready yet. Routing is server-side, so this is
+ * for the device's own default/display.
+ *
+ * @param out_id  Output buffer; empty string when no cache entry.
+ * @param sz      Buffer size; recommend 40 (UUID + NUL).
+ * @return ESP_OK on cache hit, ESP_ERR_NVS_NOT_FOUND when empty.
+ */
+esp_err_t bb_session_store_load_active_site(char* out_id, size_t sz);
+
+/**
+ * Persist the active adapter home_site_id to NVS (deferred write, same pattern
+ * as save_active_driver). "" erases the entry.
+ *
+ * @param site_id  home_site_id (UUID); "" clears it.
+ * @return ESP_OK if the persist task spawned (write happens asynchronously).
+ */
+esp_err_t bb_session_store_save_active_site(const char* site_id);

--- a/firmware/src/bb_session_store.c
+++ b/firmware/src/bb_session_store.c
@@ -18,6 +18,13 @@ static const char* TAG = "bb_session_store";
  * namespace; max 23 chars + NUL covers every current driver id. */
 #define BB_SESSION_NVS_KEY_ACTIVE_DRIVER "drv/active"
 
+/* Active adapter home_site_id (the SaaS adapter the user last selected). A
+ * UUID (36 chars) + NUL. Persisted so Settings can show the last adapter
+ * immediately without waiting on a sites.list fetch that may fail right after
+ * boot; routing itself is server-side. */
+#define BB_SESSION_NVS_KEY_ACTIVE_SITE "site/active"
+#define BB_ACTIVE_SITE_CACHE_SZ 40
+
 /* Driver name → NVS key short prefix mapping (ADR-014: ls/ prefix) */
 typedef struct {
   const char* driver_name;
@@ -180,10 +187,13 @@ static void persist_task(void* arg) {
 static char s_active_driver_cache[BB_ACTIVE_DRIVER_CACHE_SZ] = {0};
 static int  s_active_driver_loaded = 0;
 
+static char s_active_site_cache[BB_ACTIVE_SITE_CACHE_SZ] = {0};
+
 void bb_session_store_preload_nvs(void) {
   if (s_active_driver_loaded) return;
   s_active_driver_loaded = 1;
   s_active_driver_cache[0] = '\0';
+  s_active_site_cache[0] = '\0';
   nvs_handle_t h;
   esp_err_t err = nvs_open(BB_SESSION_NVS_NS, NVS_READONLY, &h);
   if (err != ESP_OK) {
@@ -193,7 +203,6 @@ void bb_session_store_preload_nvs(void) {
   }
   size_t sz = sizeof(s_active_driver_cache);
   err = nvs_get_str(h, BB_SESSION_NVS_KEY_ACTIVE_DRIVER, s_active_driver_cache, &sz);
-  nvs_close(h);
   if (err == ESP_OK) {
     ESP_LOGI(TAG, "preload_nvs: active_driver='%s'", s_active_driver_cache);
   } else if (err == ESP_ERR_NVS_NOT_FOUND) {
@@ -202,6 +211,85 @@ void bb_session_store_preload_nvs(void) {
     ESP_LOGW(TAG, "preload_nvs: active_driver read failed (%s)", esp_err_to_name(err));
     s_active_driver_cache[0] = '\0';
   }
+  size_t ssz = sizeof(s_active_site_cache);
+  err = nvs_get_str(h, BB_SESSION_NVS_KEY_ACTIVE_SITE, s_active_site_cache, &ssz);
+  if (err == ESP_OK) {
+    ESP_LOGI(TAG, "preload_nvs: active_site='%s'", s_active_site_cache);
+  } else if (err != ESP_ERR_NVS_NOT_FOUND) {
+    s_active_site_cache[0] = '\0';
+  }
+  nvs_close(h);
+}
+
+esp_err_t bb_session_store_load_active_site(char* out_id, size_t sz) {
+  if (out_id == NULL || sz == 0) return ESP_ERR_INVALID_ARG;
+  out_id[0] = '\0';
+  if (!s_active_driver_loaded) {
+    bb_session_store_preload_nvs();
+  }
+  if (s_active_site_cache[0] == '\0') {
+    return ESP_ERR_NVS_NOT_FOUND;
+  }
+  strncpy(out_id, s_active_site_cache, sz - 1);
+  out_id[sz - 1] = '\0';
+  return ESP_OK;
+}
+
+typedef struct {
+  char site_id[BB_ACTIVE_SITE_CACHE_SZ];
+} active_site_payload_t;
+
+static void active_site_persist_task(void* arg) {
+  active_site_payload_t* p = (active_site_payload_t*)arg;
+  if (p == NULL) {
+    vTaskDelete(NULL);
+    return;
+  }
+  nvs_handle_t h;
+  esp_err_t err = nvs_open(BB_SESSION_NVS_NS, NVS_READWRITE, &h);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "active_site persist: nvs_open failed (%s)", esp_err_to_name(err));
+    free(p);
+    vTaskDelete(NULL);
+    return;
+  }
+  if (p->site_id[0] == '\0') {
+    err = nvs_erase_key(h, BB_SESSION_NVS_KEY_ACTIVE_SITE);
+    if (err == ESP_OK || err == ESP_ERR_NVS_NOT_FOUND) err = nvs_commit(h);
+  } else {
+    err = nvs_set_str(h, BB_SESSION_NVS_KEY_ACTIVE_SITE, p->site_id);
+    if (err == ESP_OK) {
+      err = nvs_commit(h);
+      ESP_LOGI(TAG, "active_site persist: '%s'", p->site_id);
+    }
+  }
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "active_site persist: write failed (%s)", esp_err_to_name(err));
+  }
+  nvs_close(h);
+  free(p);
+  vTaskDelete(NULL);
+}
+
+esp_err_t bb_session_store_save_active_site(const char* site_id) {
+  if (site_id == NULL) return ESP_ERR_INVALID_ARG;
+  s_active_driver_loaded = 1;  /* cache is now authoritative */
+  strncpy(s_active_site_cache, site_id, sizeof(s_active_site_cache) - 1);
+  s_active_site_cache[sizeof(s_active_site_cache) - 1] = '\0';
+
+  active_site_payload_t* p = (active_site_payload_t*)calloc(1, sizeof(*p));
+  if (p == NULL) return ESP_ERR_NO_MEM;
+  strncpy(p->site_id, site_id, sizeof(p->site_id) - 1);
+  TaskHandle_t t = NULL;
+  BaseType_t ok = xTaskCreate(active_site_persist_task, "site_persist",
+                              BB_SESSION_PERSIST_TASK_STACK, p,
+                              BB_SESSION_PERSIST_TASK_PRIO, &t);
+  if (ok != pdPASS) {
+    ESP_LOGE(TAG, "save_active_site: xTaskCreate failed");
+    free(p);
+    return ESP_FAIL;
+  }
+  return ESP_OK;
 }
 
 esp_err_t bb_session_store_load_active_driver(char* out_name, size_t sz) {

--- a/firmware/src/bb_ui_settings.c
+++ b/firmware/src/bb_ui_settings.c
@@ -308,8 +308,10 @@ static const char* current_model_label(const bb_agent_driver_info_t* d) {
 
 static int main_visible_rows(main_row_t* out) {
   int n = 0;
-  out[n++] = MAIN_ROW_DRIVER;
-  out[n++] = MAIN_ROW_MODEL;
+  /* Driver/Model are intentionally NOT shown: the agent backend (driver + model)
+   * is configured on the adapter side now, not per-device. The picker/fetch code
+   * is left in place (harmless, and the driver fetch still drives the post-switch
+   * chat re-sync) but is simply unreachable from the menu. */
   if (bb_transport_is_cloud_saas()) {
     out[n++] = MAIN_ROW_ADAPTER;
   }
@@ -752,13 +754,21 @@ static void on_site_fetch_done(void* user_data) {
     int total = r->count > BB_SETTINGS_SITE_CACHE_MAX ? BB_SETTINGS_SITE_CACHE_MAX : r->count;
     memcpy(s_st.site_cache, r->sites, sizeof(r->sites[0]) * (size_t)total);
     s_st.site_cache_count = total;
-    /* Seed active_site_id from the reply's active flag if we don't have one. */
+    /* Seed active_site_id from the reply's active flag (cloud truth). */
+    char prev_active[sizeof(s_st.active_site_id)];
+    strncpy(prev_active, s_st.active_site_id, sizeof(prev_active) - 1);
+    prev_active[sizeof(prev_active) - 1] = '\0';
     for (int i = 0; i < total; ++i) {
       if (r->sites[i].active) {
         strncpy(s_st.active_site_id, r->sites[i].home_site_id, sizeof(s_st.active_site_id) - 1);
         s_st.active_site_id[sizeof(s_st.active_site_id) - 1] = '\0';
         break;
       }
+    }
+    /* Persist when the cloud's active differs from what we had (covers a binding
+     * set from another device/web), so the NVS default stays in sync. */
+    if (s_st.active_site_id[0] != '\0' && strcmp(s_st.active_site_id, prev_active) != 0) {
+      bb_session_store_save_active_site(s_st.active_site_id);
     }
     ESP_LOGI(TAG, "site fetch ok: %d sites active='%s'", total, s_st.active_site_id);
   }
@@ -939,6 +949,12 @@ static void commit_task(void* arg) {
     err = bb_adapter_sites_activate(p->site_id, active_id, sizeof(active_id), err_code, sizeof(err_code));
     ESP_LOGI(TAG, "commit adapter site='%s' -> %s (active='%s' code='%s')",
              p->site_id, esp_err_to_name(err), active_id, err_code);
+    if (err == ESP_OK) {
+      /* Remember the chosen adapter so next boot's Settings shows it as default
+       * even before/without a fresh sites.list (save_active_site spawns its own
+       * internal-stack writer, safe to call from this PSRAM commit task). */
+      bb_session_store_save_active_site(active_id[0] != '\0' ? active_id : p->site_id);
+    }
     if (lvgl_port_lock(200)) {
       lv_async_call(err == ESP_OK ? on_adapter_activated : on_adapter_activate_failed, NULL);
       lvgl_port_unlock();
@@ -1123,9 +1139,14 @@ void bb_ui_settings_show(lv_obj_t* parent) {
     return;
   }
 
-  /* Initialise level + cursor before any LVGL work. */
+  /* Initialise level + cursor before any LVGL work. Driver/Model are hidden now,
+   * so start the cursor on the first VISIBLE row rather than MAIN_ROW_DRIVER. */
   s_st.level = LEVEL_MAIN;
-  s_st.sel = MAIN_ROW_DRIVER;
+  {
+    main_row_t vrows[MAIN_ROW_ID_COUNT];
+    int vn = main_visible_rows(vrows);
+    s_st.sel = vn > 0 ? vrows[0] : MAIN_ROW_VOLUME;
+  }
   /* Load current volume from persisted config. */
   s_st.volume_pct = bb_device_config_get()->volume_pct;
   s_st.volume_dirty = 0;
@@ -1135,6 +1156,13 @@ void bb_ui_settings_show(lv_obj_t* parent) {
    * shows something sensible even before the async fetch lands. */
   if (s_st.active_driver[0] == '\0') {
     bb_session_store_load_active_driver(s_st.active_driver, sizeof(s_st.active_driver));
+  }
+  /* Seed the active adapter from NVS too, so the "Adapter:" row shows the last
+   * selected machine immediately — even if the sites.list fetch is slow or fails
+   * right after boot (routing is server-side; this is for display/default). The
+   * fetch refreshes it (incl. live on/offline) when it lands. */
+  if (s_st.active_site_id[0] == '\0') {
+    bb_session_store_load_active_site(s_st.active_site_id, sizeof(s_st.active_site_id));
   }
 
   s_st.root = lv_obj_create(parent);


### PR DESCRIPTION
两处设备设置改动(配合 adapter_v2 / SaaS)。

**① 选中的 adapter(home_site_id)存 NVS,设置页从它 seed。** 之前 active adapter 只在 RAM(每次 sites.list 回包重建),所以刚开机/云 WS 没就绪/fetch 超时(8s)时,设置页「Adapter:」显示「(loading)/(none)」。路由本就是云端的(云记 device→site 绑定),所以这纯是设备自己的默认/显示:现在立刻显示上次选的 adapter,fetch 回来再刷新(含 on/offline)。新 `bb_session_store` 的 `site/active` 键照 `drv/active` 模板(boot 内部栈 preload;延迟写在 spawn 的内部栈任务——NVS 写冻结 flash cache)。用户激活时存;fetch 发现云端绑定变了(如 web/别的设备设的)也同步存。

**② 设置菜单隐藏 Driver + Model。** 驱动/模型现在在 adapter 侧配,不再 per-device → 两行从 `main_visible_rows()` 去掉。picker/fetch 代码留着(无害,驱动 fetch 还驱动切换 adapter 后的聊天 resync),只是菜单不可达。主光标起始改到第一个可见行。

本地 idf.py build 通过(bbclaw_firmware.bin,8% free)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)