### PR TITLE
fix(adapter_v2): 轮次未出新回复前不结束(修念旧回复)

### DIFF
--- a/adapter_v2/internal/deviceapi/deviceapi.go
+++ b/adapter_v2/internal/deviceapi/deviceapi.go
@@ -39,6 +39,8 @@ package deviceapi
 import (
 	"context"
 	"errors"
+	"log"
+	"os"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -47,6 +49,25 @@ import (
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/vtscreen"
 )
+
+// debugExtract, when ADAPTER_V2_DEBUG_EXTRACT is set, logs what the boundary
+// extracted plus the tail of the VT mirror at that moment — to diagnose why a
+// turn can extract a stale (previous-turn) reply.
+var debugExtract = os.Getenv("ADAPTER_V2_DEBUG_EXTRACT") != ""
+
+// tailLines returns the last n non-empty lines of s, for compact debug logging.
+func tailLines(s string, n int) string {
+	var kept []string
+	for _, l := range strings.Split(s, "\n") {
+		if strings.TrimSpace(l) != "" {
+			kept = append(kept, l)
+		}
+	}
+	if len(kept) > n {
+		kept = kept[len(kept)-n:]
+	}
+	return strings.Join(kept, "\n")
+}
 
 // ErrClosed is returned by SubmitVoiceTurn / Run when the underlying session's
 // PTY has already exited.
@@ -546,9 +567,28 @@ func (b *Bridge) maybeSpeak(ctx context.Context, det *extract.Detector, text str
 	if !det.TurnEnded(time.Now()) {
 		return false, nil
 	}
+	// Stale-guard (the "device replays the previous answer" bug): a multi-step /
+	// tool-using turn has QUIET GAPS between tool calls where the spinner clears, so
+	// the boundary can look "ended" BEFORE this turn's reply has rendered. At that
+	// moment the newest "⏺" block on screen is still the PREVIOUS turn's reply — the
+	// seed captured at rebaseline. Firing now would (re)speak that stale reply. So
+	// while the extraction is still exactly the seed, the turn is not really done:
+	// wait for the new reply to diverge from it. (A blank/tool-only turn falls
+	// through below to hand control back; an identical consecutive reply is the rare
+	// case that waits for the cloud's reply timeout.)
+	if !isBlank(text) && text == ts.seed {
+		if debugExtract {
+			log.Printf("deviceapi: boundary suppressed — extract still == seed (awaiting this turn's reply)")
+		}
+		return false, nil
+	}
 	// The turn the user injected is done; a later barge-in now has nothing to
 	// interrupt, so the next SubmitVoiceTurn injects cleanly without an ESC.
 	b.inFlight.Store(false)
+
+	if debugExtract {
+		log.Printf("deviceapi: boundary extract=%q\n--- mirror tail ---\n%s\n--- end ---", text, tailLines(b.screen.VisibleText(), 12))
+	}
 
 	if isBlank(text) {
 		// A completed turn with no speakable text (e.g. a tool-only turn) still


### PR DESCRIPTION
设备在后续轮次重播了上一轮的回复。根因(用 ADAPTER_V2_DEBUG_EXTRACT 抓真 claude 坐实):多步/带工具的轮次在工具调用之间有**安静间隙**,spinner 短暂消失。边界判据是「本轮出现过 spinner 且现已消失 + 输出静止」,**不要求 idle 提示**——所以在工具间隙、本轮回复还没渲染时就判轮次结束,抽到当时最新的 ⏺ 块=**上一轮的回复**。无工具的简单轮次没间隙,所以前几轮正常;带工具的(如查 Build Hub / SalesBrain)就重播上一轮。

**修**:`maybeSpeak` 里边界触发后,若抽取文本仍**恰好等于 seed**(rebaseline 时存的上一轮回复)且非空 → 本轮还没真完成,等新回复出现(文本与 seed 分叉)再说,而不是念旧的。空/纯工具轮仍交还控制;完全相同的连续回复是罕见情形,会等云端超时(可接受,胜过念错)。

保留 env 门控的抽取调试日志(ADAPTER_V2_DEBUG_EXTRACT,打印边界抽取文本 + VT 镜像末尾)供以后排查。deviceapi 单测+e2e+cloudrelay e2e 绿。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)