### PR TITLE
feat: 默认续上次对话(P1)+ 设置页 PTT 退出

### DIFF
--- a/adapter_v2/internal/butler/butler_test.go
+++ b/adapter_v2/internal/butler/butler_test.go
@@ -13,9 +13,18 @@ func TestDeviceClaudeArgs(t *testing.T) {
 	if !containsArg(got, "--dangerously-skip-permissions") {
 		t.Errorf("missing permission bypass (voice device can't answer prompts): %v", got)
 	}
+	if !containsArg(got, "--continue") {
+		t.Errorf("missing --continue (default resume of the previous conversation): %v", got)
+	}
 	if i := argIndex(got, "--append-system-prompt"); i < 0 || i+1 >= len(got) || !strings.Contains(got[i+1], "对讲机") {
 		t.Errorf("device persona not appended: %v", got)
 	}
+	// Resume is default-on but disableable.
+	t.Setenv("ADAPTER_V2_RESUME", "0")
+	if containsArg(DeviceClaudeArgs([]string{"claude"}, ""), "--continue") {
+		t.Errorf("ADAPTER_V2_RESUME=0 should drop --continue")
+	}
+	t.Setenv("ADAPTER_V2_RESUME", "1")
 	// Non-claude CLI (e.g. the e2e mockcli) → untouched.
 	if base := DeviceClaudeArgs([]string{"/tmp/mockcli"}, "/ws"); len(base) != 1 {
 		t.Errorf("non-claude argv should be untouched, got %v", base)

--- a/adapter_v2/internal/butler/workspace.go
+++ b/adapter_v2/internal/butler/workspace.go
@@ -75,6 +75,10 @@ func EnsureWorkspace(dir string) (string, error) {
 //     ADAPTER_V2_SKIP_PERMISSIONS=0 (then tool turns will hang on the prompt).
 //  2. Appends the walkie-talkie device persona via --append-system-prompt. Override
 //     the whole prompt with ADAPTER_V2_VOICE_SYSTEM_PROMPT, or set it empty to skip.
+//  3. Resumes the most recent conversation (--continue) so the assistant picks up
+//     where it left off across adapter restarts, instead of starting fresh every
+//     boot. Disable with ADAPTER_V2_RESUME=0. (A future "new conversation" /
+//     history-pick feature will spawn without --continue, or with --resume <id>.)
 func DeviceClaudeArgs(argv []string, cwd string) []string {
 	if len(argv) == 0 || !strings.Contains(strings.ToLower(filepath.Base(argv[0])), "claude") {
 		return argv
@@ -82,6 +86,9 @@ func DeviceClaudeArgs(argv []string, cwd string) []string {
 	out := append([]string{}, argv...)
 	if envBool("ADAPTER_V2_SKIP_PERMISSIONS", true) {
 		out = append(out, "--dangerously-skip-permissions")
+	}
+	if envBool("ADAPTER_V2_RESUME", true) {
+		out = append(out, "--continue")
 	}
 	prompt := DeviceSystemPrompt(cwd, "")
 	if v, ok := os.LookupEnv("ADAPTER_V2_VOICE_SYSTEM_PROMPT"); ok {

--- a/firmware/src/bb_radio_app.c
+++ b/firmware/src/bb_radio_app.c
@@ -560,6 +560,7 @@ static int agent_chat_voice_capture_active(void) {
  * only thing on screen.
  * ───────────────────────────────────────────────────────────────────── */
 static volatile int s_settings_active;
+static volatile int s_settings_ptt_exit_req; /* PTT pressed while in settings → exit to chat */
 static lv_obj_t* s_settings_root;
 
 /* settings_overlay_enter: entry point for the SETTINGS overlay.
@@ -877,9 +878,15 @@ static void on_ptt_changed(int pressed) {
   bb_state_dispatch_simple(new_pressed ? BB_EVT_PTT_DOWN : BB_EVT_PTT_UP);
 
   if (s_settings_active) {
-    /* SSoT 那边已经记了 reason=page_settings；这里再补一条贴近 PTT 子系统的
-     * INFO 方便老日志格式 grep。 */
-    ESP_LOGI(TAG, "ptt: dropped (settings overlay active) pressed=%d", new_pressed);
+    /* PTT while the settings overlay is up = quick exit back to chat (a big,
+     * always-reachable "get me out" button). Request it on the DOWN edge and
+     * wake the main loop (bump the version); the actual teardown runs there, on
+     * the same task as the nav-driven exit, so LVGL/state work is serialised. */
+    if (new_pressed) {
+      s_settings_ptt_exit_req = 1;
+      s_ptt_change_version++;
+    }
+    ESP_LOGI(TAG, "ptt: settings overlay active -> request exit pressed=%d", new_pressed);
     return;
   }
   s_ptt_pressed = new_pressed;
@@ -2187,6 +2194,23 @@ static void stream_task(void* arg) {
         vTaskDelay(pdMS_TO_TICKS(20));
         continue;
       }
+    }
+
+    /* PTT pressed while the settings overlay is up → exit settings back to chat.
+     * Runs on this (stream) task, same as the nav-driven exit, so the LVGL +
+     * state-transition work is serialised. Handled before the normal PTT consume
+     * so the edge becomes an "exit", not a chat record. */
+    if (s_settings_ptt_exit_req) {
+      s_settings_ptt_exit_req = 0;
+      ptt_handled_version = s_ptt_change_version; /* consume the edge */
+      if (s_settings_active) {
+        settings_overlay_exit();
+        set_radio_app_state(BBCLAW_STATE_CHAT);
+        if (!radio_app_is_locked()) agent_chat_enter();
+        ESP_LOGI(TAG, "SETTINGS: PTT -> CHAT");
+      }
+      vTaskDelay(pdMS_TO_TICKS(20));
+      continue;
     }
 
     unsigned ptt_version = s_ptt_change_version;


### PR DESCRIPTION
会话管理 P1 + 设置页交互。

**adapter_v2(P1 默认 resume)**:设备会话的 claude 启动加 `--continue`,重启续上次对话,不再每次开机开新对话(你测试时一堆一次性 .jsonl 就是这么来的)。`ADAPTER_V2_RESUME=0` 可关。(后续:新对话/历史选择会不带 --continue 或带 --resume <id>,并持久化 active session id。)

**firmware(PTT 退出设置页)**:设置页打开时按 PTT → 退回 chat(一个随手可达的"退出"大键),不再被静默丢弃。DOWN 边沿置请求标志 + 唤醒主循环,在与 nav 退出同一 task 上拆除 overlay(LVGL+状态转换串行化)。

两边都本地编译通过(go build;idf.py build → bbclaw_firmware.bin)。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)