### PR TITLE
feat(adapter_v2): P2 会话生命周期(adapter 侧)——续接/新建/列表/切换

### DIFF
--- a/adapter_v2/cmd/bbclaw-adapter-v2/main.go
+++ b/adapter_v2/cmd/bbclaw-adapter-v2/main.go
@@ -67,12 +67,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("bbclaw-adapter-v2: butler workspace: %v", err)
 	}
-	defaultArgv := butler.DeviceClaudeArgs(cfg.Argv, defaultCwd)
-	log.Printf("bbclaw-adapter-v2: butler workspace %s", defaultCwd)
+	baseArgv := butler.DeviceClaudeArgs(cfg.Argv, defaultCwd)
+	// DeviceSession owns the default conversation's lifecycle (ADR-032): it appends
+	// the resume flag (--resume <active>/--continue/--session-id) to baseArgv, so
+	// every entry point spawns session.DefaultID identically and resume / new /
+	// switch stay coherent. Loads the persisted active conversation on boot.
+	devSess := butler.NewDeviceSession(mgr, baseArgv, defaultCwd)
+	log.Printf("bbclaw-adapter-v2: butler workspace %s (active session %q)", defaultCwd, devSess.ActiveID())
 
 	srv := &http.Server{
 		Addr:    cfg.Addr,
-		Handler: newRouter(mgr, cfg, defaultArgv, defaultCwd),
+		Handler: newRouter(mgr, cfg, devSess),
 	}
 
 	// Cloud relay (SaaS): when CLOUD_WS_URL is set, register with the BBClaw Cloud
@@ -86,7 +91,7 @@ func main() {
 		if rc, err := cloudrelay.LoadConfig(); err != nil {
 			log.Printf("bbclaw-adapter-v2: cloud relay disabled (config error): %v", err)
 		} else {
-			relay := cloudrelay.New(mgr, rc, defaultArgv, defaultCwd, log.Printf)
+			relay := cloudrelay.New(mgr, devSess, rc, log.Printf)
 			go relay.Run(relayCtx)
 		}
 	}
@@ -128,9 +133,9 @@ func main() {
 // newRouter builds the Phase 1 HTTP mux: the terminal WebSocket endpoint and a
 // health probe. It is a separate constructor so tests can exercise routing
 // without binding a real listener.
-func newRouter(mgr *session.Manager, cfg config.Config, defaultArgv []string, defaultCwd string) http.Handler {
+func newRouter(mgr *session.Manager, cfg config.Config, devSess *butler.DeviceSession) http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/ws", wsHandler(mgr, cfg, defaultArgv, defaultCwd))
+	mux.HandleFunc("/ws", wsHandler(mgr, cfg, devSess))
 	mux.HandleFunc("/healthz", healthzHandler)
 
 	// bbwire/2 device protocol, Phase A (adapter_v2/docs/device-protocol.md).
@@ -145,7 +150,7 @@ func newRouter(mgr *session.Manager, cfg config.Config, defaultArgv []string, de
 	streamDelta := envBool("ADAPTER_V2_STREAM_DELTA", true)
 	segmentTTS := envBool("ADAPTER_V2_SEGMENT_TTS", false)
 	log.Printf("bbclaw-adapter-v2: device line ASR=%s TTS=%s streamDelta=%v segmentTTS=%v", asrMode, ttsMode, streamDelta, segmentTTS)
-	devSrv := devicews.New(mgr, rec, syn, defaultArgv, defaultCwd, devicews.Options{
+	devSrv := devicews.New(mgr, rec, syn, devSess, devicews.Options{
 		Decode:           voicekit.DecodeUplink,
 		StreamReplyDelta: streamDelta,
 		SegmentTTS:       segmentTTS,
@@ -183,19 +188,20 @@ func healthzHandler(w http.ResponseWriter, _ *http.Request) {
 // the configured default CLI argv — so the first client to ask for an id starts
 // the CLI and every later client (or a reconnecting one) joins the same live
 // session and replays its screen.
-func wsHandler(mgr *session.Manager, cfg config.Config, defaultArgv []string, defaultCwd string) http.HandlerFunc {
+func wsHandler(mgr *session.Manager, cfg config.Config, devSess *butler.DeviceSession) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// No ?session= → the shared default session (the one the device drives), so
 		// opening the web UI joins the device's live conversation. An explicit
 		// ?session=<id> selects another session (the future web session-browser);
-		// only the default session carries the butler persona + workspace cwd.
+		// only the default session carries the butler persona + workspace cwd +
+		// the active-conversation resume flag (from DeviceSession).
 		id := r.URL.Query().Get("session")
-		argv, cwd := cfg.Argv, cfg.Cwd
-		if id == "" {
+		var cfgPty ptyhost.Config
+		if id == "" || id == session.DefaultID {
 			id = session.DefaultID
-		}
-		if id == session.DefaultID {
-			argv, cwd = defaultArgv, defaultCwd
+			cfgPty = devSess.Config()
+		} else {
+			cfgPty = ptyhost.Config{Argv: cfg.Argv, Cwd: cfg.Cwd}
 		}
 
 		// Accept the WebSocket upgrade FIRST, before touching the session, so a
@@ -215,10 +221,7 @@ func wsHandler(mgr *session.Manager, cfg config.Config, defaultArgv []string, de
 		// GetOrCreate serializes the race so two simultaneous first connections
 		// cannot each spawn a PTY and leak the loser. A spawn failure now closes
 		// the just-accepted WebSocket (we are past the HTTP response).
-		sess, err := mgr.GetOrCreate(id, ptyhost.Config{
-			Argv: argv,
-			Cwd:  cwd,
-		})
+		sess, err := mgr.GetOrCreate(id, cfgPty)
 		if err != nil {
 			log.Printf("bbclaw-adapter-v2: create session %q: %v", id, err)
 			conn.Close(websocket.StatusInternalError, "failed to start session")

--- a/adapter_v2/cmd/bbclaw-adapter-v2/main_test.go
+++ b/adapter_v2/cmd/bbclaw-adapter-v2/main_test.go
@@ -12,6 +12,7 @@ import (
 
 	"nhooyr.io/websocket"
 
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/butler"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/config"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
 )
@@ -63,7 +64,7 @@ func readReconnected(t *testing.T, conn *websocket.Conn) {
 // TestHealthz verifies the liveness probe returns 200 "ok".
 func TestHealthz(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), testConfig().Argv, testConfig().Cwd))
+	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/healthz")
@@ -87,7 +88,7 @@ func TestHealthz(t *testing.T) {
 // share one PTY.
 func TestWSNoSessionJoinsDefault(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), testConfig().Argv, testConfig().Cwd))
+	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
 	t.Cleanup(srv.Close)
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
 
@@ -115,7 +116,7 @@ func TestWSNoSessionJoinsDefault(t *testing.T) {
 // longer an error: it resolves to the shared default session.)
 func TestWSNonWebSocketRejected(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), testConfig().Argv, testConfig().Cwd))
+	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/ws")
@@ -137,7 +138,7 @@ func TestWSNonWebSocketRejected(t *testing.T) {
 // the existing session rather than spawning a second process.
 func TestWSCreatesSessionOnce(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), testConfig().Argv, testConfig().Cwd))
+	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
 	t.Cleanup(srv.Close)
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
 
@@ -176,7 +177,7 @@ func TestWSCreatesSessionOnce(t *testing.T) {
 // not swallow stray requests as the index page.
 func TestRouterUnknownPath(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), testConfig().Argv, testConfig().Cwd))
+	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/nope")
@@ -196,7 +197,7 @@ func TestRouterUnknownPath(t *testing.T) {
 // index.html can't silently drop the contract the server depends on.
 func TestWebClientServed(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), testConfig().Argv, testConfig().Cwd))
+	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/")
@@ -245,7 +246,7 @@ func TestWebClientServed(t *testing.T) {
 // must dispatch those to their own handlers, not to the static index page.
 func TestSpecificRoutesWinOverWebRoot(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), testConfig().Argv, testConfig().Cwd))
+	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
 	t.Cleanup(srv.Close)
 
 	tests := []struct {

--- a/adapter_v2/internal/butler/butler_test.go
+++ b/adapter_v2/internal/butler/butler_test.go
@@ -13,18 +13,13 @@ func TestDeviceClaudeArgs(t *testing.T) {
 	if !containsArg(got, "--dangerously-skip-permissions") {
 		t.Errorf("missing permission bypass (voice device can't answer prompts): %v", got)
 	}
-	if !containsArg(got, "--continue") {
-		t.Errorf("missing --continue (default resume of the previous conversation): %v", got)
-	}
 	if i := argIndex(got, "--append-system-prompt"); i < 0 || i+1 >= len(got) || !strings.Contains(got[i+1], "对讲机") {
 		t.Errorf("device persona not appended: %v", got)
 	}
-	// Resume is default-on but disableable.
-	t.Setenv("ADAPTER_V2_RESUME", "0")
-	if containsArg(DeviceClaudeArgs([]string{"claude"}, ""), "--continue") {
-		t.Errorf("ADAPTER_V2_RESUME=0 should drop --continue")
+	// The resume flag is NOT part of the base argv — DeviceSession owns it.
+	if containsArg(got, "--continue") || containsArg(got, "--resume") {
+		t.Errorf("base argv must not carry a resume flag (DeviceSession adds it): %v", got)
 	}
-	t.Setenv("ADAPTER_V2_RESUME", "1")
 	// Non-claude CLI (e.g. the e2e mockcli) → untouched.
 	if base := DeviceClaudeArgs([]string{"/tmp/mockcli"}, "/ws"); len(base) != 1 {
 		t.Errorf("non-claude argv should be untouched, got %v", base)

--- a/adapter_v2/internal/butler/session.go
+++ b/adapter_v2/internal/butler/session.go
@@ -1,0 +1,306 @@
+package butler
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/ptyhost"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
+	"github.com/google/uuid"
+)
+
+// DeviceSession owns the lifecycle of the shared default conversation (ADR-032).
+// One conversation = one claude session (a <uuid>.jsonl in the workspace). It is
+// the single source of truth for the ACTIVE conversation id, so every entry point
+// that (re)creates session.DefaultID spawns claude with the SAME resume flag, and
+// the device can list / start / switch conversations coherently.
+//
+// Switching = respawn: New/Resume update the active id (persisted) and kill the
+// live default session via the Manager, so the next spawn uses the new resume
+// flag. The cloud-relay bridge auto-rebuilds (its dead-session eviction) and a web
+// terminal reconnects.
+type DeviceSession struct {
+	mgr      *session.Manager
+	baseArgv []string // persona + permissions, WITHOUT the resume flag
+	cwd      string   // the butler workspace
+
+	mu       sync.Mutex
+	activeID string // claude session uuid; "" => --continue (resume latest)
+	fresh    bool   // true: activeID is a brand-new conversation (--session-id), not --resume
+}
+
+// NewDeviceSession builds the holder, loading the persisted active id (or, absent
+// that, the most recent conversation in the workspace) so a restart resumes the
+// same conversation the user was last in.
+func NewDeviceSession(mgr *session.Manager, baseArgv []string, cwd string) *DeviceSession {
+	d := &DeviceSession{mgr: mgr, baseArgv: baseArgv, cwd: cwd}
+	sessions, _ := listConversations(cwd)
+	exists := func(id string) bool {
+		for _, s := range sessions {
+			if s.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+	// Prefer the persisted active conversation, but only if it still exists on disk
+	// (a deleted/invalid id would make claude --resume fail/hang). Else the most
+	// recent conversation. Else — a fresh workspace with no history — mint a NEW
+	// one. We never use a bare --continue: it hangs when there's nothing to resume
+	// (verified against real claude), and an explicit id is what the active-id
+	// reporting / isolation needs.
+	id := loadActiveSession()
+	switch {
+	case id != "" && exists(id):
+		d.activeID, d.fresh = id, false // resume persisted
+	case len(sessions) > 0:
+		d.activeID, d.fresh = sessions[0].ID, false // resume most recent
+	default:
+		d.activeID, d.fresh = uuid.New().String(), true // fresh workspace → new conversation
+	}
+	return d
+}
+
+// Config is the ptyhost.Config for spawning session.DefaultID. All entry points
+// use this so the default PTY always runs the active conversation.
+func (d *DeviceSession) Config() ptyhost.Config {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := append([]string{}, d.baseArgv...)
+	// The resume flags (--continue / --resume / --session-id) are claude-specific;
+	// don't append them to another CLI (e.g. a test's `cat`, which would treat
+	// "--continue" as a filename and exit).
+	if len(out) > 0 && strings.Contains(strings.ToLower(filepath.Base(out[0])), "claude") {
+		switch {
+		case d.activeID == "":
+			out = append(out, "--continue") // no known id yet → resume the latest
+		case d.fresh:
+			out = append(out, "--session-id", d.activeID) // brand-new conversation
+		default:
+			out = append(out, "--resume", d.activeID) // resume a specific conversation
+		}
+	}
+	return ptyhost.Config{Argv: out, Cwd: d.cwd}
+}
+
+// ActiveID returns the active conversation id (may be "" before the first spawn
+// when resuming the latest via --continue).
+func (d *DeviceSession) ActiveID() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.activeID
+}
+
+// New starts a fresh conversation: mint a new id, persist it, and respawn the
+// default session with --session-id. Returns the new id.
+func (d *DeviceSession) New() string {
+	id := uuid.New().String()
+	d.mu.Lock()
+	d.activeID = id
+	d.fresh = true
+	d.mu.Unlock()
+	saveActiveSession(id)
+	d.respawn()
+	return id
+}
+
+// Resume switches to an existing conversation: set it active, persist, and respawn
+// with --resume <id>.
+func (d *DeviceSession) Resume(id string) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return
+	}
+	d.mu.Lock()
+	d.activeID = id
+	d.fresh = false
+	d.mu.Unlock()
+	saveActiveSession(id)
+	d.respawn()
+}
+
+// respawn kills the live default session so the next spawn picks up the new
+// resume flag. Lazy: the cloud relay rebuilds on the next turn; a web terminal
+// reconnects.
+func (d *DeviceSession) respawn() {
+	d.mgr.Remove(session.DefaultID)
+}
+
+// List returns the workspace's conversations, most-recent first.
+func (d *DeviceSession) List() ([]ConversationInfo, error) {
+	return listConversations(d.cwd)
+}
+
+// ConversationInfo is one claude conversation for the device's history picker.
+type ConversationInfo struct {
+	ID         string // claude session uuid
+	Title      string // first user message (truncated), or the id
+	ModUnixSec int64  // .jsonl mtime, for ordering / lastUsed display
+}
+
+// ── claude conversation storage ─────────────────────────────────────────────
+
+// claudeProjectDir maps a cwd to claude's per-project conversation directory
+// (~/.claude/projects/<cwd with '/' and '.' replaced by '-'>). This encoding is
+// claude-internal; if it ever changes, listing degrades to empty (callers treat
+// that as "no history", which is safe).
+func claudeProjectDir(cwd string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	enc := strings.ReplaceAll(cwd, "/", "-")
+	enc = strings.ReplaceAll(enc, ".", "-")
+	return filepath.Join(home, ".claude", "projects", enc)
+}
+
+func listConversations(cwd string) ([]ConversationInfo, error) {
+	dir := claudeProjectDir(cwd)
+	if dir == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil // no project dir yet => no history
+	}
+	var out []ConversationInfo
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".jsonl") {
+			continue
+		}
+		id := strings.TrimSuffix(name, ".jsonl")
+		info, err := e.Info()
+		var mod int64
+		if err == nil {
+			mod = info.ModTime().Unix()
+		}
+		out = append(out, ConversationInfo{
+			ID:         id,
+			Title:      conversationTitle(filepath.Join(dir, name), id),
+			ModUnixSec: mod,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ModUnixSec > out[j].ModUnixSec })
+	return out, nil
+}
+
+// conversationTitle reads the first user message from a conversation .jsonl as a
+// human label, falling back to the id. claude writes one JSON object per line;
+// a user turn is {"type":"user","message":{"role":"user","content":...}} where
+// content is a string or an array of {type:"text",text:...} blocks.
+func conversationTitle(path, id string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return shortID(id)
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		var rec struct {
+			Type    string `json:"type"`
+			Message struct {
+				Role    string          `json:"role"`
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if json.Unmarshal(sc.Bytes(), &rec) != nil {
+			continue
+		}
+		if rec.Type != "user" && rec.Message.Role != "user" {
+			continue
+		}
+		if t := firstText(rec.Message.Content); t != "" {
+			return truncateTitle(t)
+		}
+	}
+	return shortID(id)
+}
+
+// firstText extracts text from a claude content field (string, or []{type,text}).
+func firstText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return strings.TrimSpace(s)
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) == nil {
+		for _, b := range blocks {
+			if strings.TrimSpace(b.Text) != "" {
+				return strings.TrimSpace(b.Text)
+			}
+		}
+	}
+	return ""
+}
+
+func truncateTitle(s string) string {
+	s = strings.Join(strings.Fields(s), " ") // collapse whitespace/newlines
+	r := []rune(s)
+	if len(r) > 24 {
+		return string(r[:24]) + "…"
+	}
+	return s
+}
+
+func shortID(id string) string {
+	if len(id) >= 8 {
+		return "对话-" + id[:8]
+	}
+	return "对话-" + id
+}
+
+// ── active-session persistence (~/.bbclaw-adapter-v2/active-session.json) ─────
+
+type activeSessionFile struct {
+	ActiveSessionID string `json:"activeSessionId"`
+}
+
+func activeSessionPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".bbclaw-adapter-v2", "active-session.json")
+}
+
+func loadActiveSession() string {
+	if id := strings.TrimSpace(os.Getenv("ADAPTER_V2_ACTIVE_SESSION")); id != "" {
+		return id
+	}
+	p := activeSessionPath()
+	if p == "" {
+		return ""
+	}
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		return ""
+	}
+	var f activeSessionFile
+	if json.Unmarshal(raw, &f) != nil {
+		return ""
+	}
+	return strings.TrimSpace(f.ActiveSessionID)
+}
+
+func saveActiveSession(id string) {
+	p := activeSessionPath()
+	if p == "" {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(p), 0o700)
+	data, _ := json.Marshal(activeSessionFile{ActiveSessionID: id})
+	_ = os.WriteFile(p, data, 0o600)
+}

--- a/adapter_v2/internal/butler/session_test.go
+++ b/adapter_v2/internal/butler/session_test.go
@@ -1,0 +1,94 @@
+package butler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
+)
+
+func TestDeviceSessionConfigResumeModes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // isolate active-session + claude dirs
+	mgr := session.NewManager()
+
+	// A fresh workspace (no history) → start a NEW conversation (--session-id),
+	// never a bare --continue (which hangs with nothing to resume).
+	d := NewDeviceSession(mgr, []string{"/usr/local/bin/claude"}, "/ws")
+	if a := d.Config().Argv; !containsArg(a, "--session-id") || containsArg(a, "--continue") {
+		t.Errorf("fresh workspace should start a new conversation via --session-id: %v", a)
+	}
+
+	// New() → a brand-new conversation spawns with --session-id <id>.
+	id := d.New()
+	if id == "" {
+		t.Fatal("New() returned empty id")
+	}
+	a := d.Config().Argv
+	if i := argIndex(a, "--session-id"); i < 0 || a[i+1] != id {
+		t.Errorf("New() should spawn --session-id %s: %v", id, a)
+	}
+	if d.ActiveID() != id {
+		t.Errorf("ActiveID=%q, want %q", d.ActiveID(), id)
+	}
+
+	// A real conversation on disk so resume/reload of it is honoured (the holder
+	// discards a persisted id whose .jsonl is gone).
+	pdir := claudeProjectDir("/ws")
+	_ = os.MkdirAll(pdir, 0o755)
+	_ = os.WriteFile(filepath.Join(pdir, "abc-123.jsonl"), []byte(`{"type":"user","message":{"role":"user","content":"hi"}}`+"\n"), 0o644)
+
+	// Resume(other) → --resume <other>.
+	d.Resume("abc-123")
+	a = d.Config().Argv
+	if i := argIndex(a, "--resume"); i < 0 || a[i+1] != "abc-123" {
+		t.Errorf("Resume should spawn --resume abc-123: %v", a)
+	}
+
+	// Persistence: a fresh holder (same HOME) loads the persisted active id
+	// (its .jsonl exists, so it is honoured).
+	d2 := NewDeviceSession(mgr, []string{"claude"}, "/ws")
+	if d2.ActiveID() != "abc-123" {
+		t.Errorf("persisted active id not reloaded: got %q", d2.ActiveID())
+	}
+
+	// Non-claude CLI → no claude-specific resume flag (would break e.g. `cat`).
+	dc := NewDeviceSession(mgr, []string{"cat"}, "")
+	if a := dc.Config().Argv; containsArg(a, "--continue") || containsArg(a, "--resume") || containsArg(a, "--session-id") {
+		t.Errorf("non-claude argv must not get a resume flag: %v", a)
+	}
+}
+
+func TestDeviceSessionList(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := "/Users/x/.bbclaw-adapter/workspace"
+	// Materialise claude's project dir for cwd with two conversation files.
+	dir := claudeProjectDir(cwd)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeJSONL := func(name, firstUser string) {
+		body := `{"type":"user","message":{"role":"user","content":"` + firstUser + `"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeJSONL("11111111-aaaa.jsonl", "第一段对话")
+	writeJSONL("22222222-bbbb.jsonl", "second chat")
+
+	d := NewDeviceSession(session.NewManager(), []string{"claude"}, cwd)
+	list, err := d.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("want 2 conversations, got %d: %+v", len(list), list)
+	}
+	// Title comes from the first user message.
+	titles := list[0].Title + "|" + list[1].Title
+	if !strings.Contains(titles, "第一段对话") || !strings.Contains(titles, "second chat") {
+		t.Errorf("titles not parsed from first user message: %q", titles)
+	}
+}

--- a/adapter_v2/internal/butler/workspace.go
+++ b/adapter_v2/internal/butler/workspace.go
@@ -75,10 +75,10 @@ func EnsureWorkspace(dir string) (string, error) {
 //     ADAPTER_V2_SKIP_PERMISSIONS=0 (then tool turns will hang on the prompt).
 //  2. Appends the walkie-talkie device persona via --append-system-prompt. Override
 //     the whole prompt with ADAPTER_V2_VOICE_SYSTEM_PROMPT, or set it empty to skip.
-//  3. Resumes the most recent conversation (--continue) so the assistant picks up
-//     where it left off across adapter restarts, instead of starting fresh every
-//     boot. Disable with ADAPTER_V2_RESUME=0. (A future "new conversation" /
-//     history-pick feature will spawn without --continue, or with --resume <id>.)
+//
+// It builds the BASE argv only — persona + permissions, NO resume flag. The resume
+// flag (--continue / --resume <id> / --session-id <id>) is owned by DeviceSession
+// (ADR-032), which appends it per the active conversation.
 func DeviceClaudeArgs(argv []string, cwd string) []string {
 	if len(argv) == 0 || !strings.Contains(strings.ToLower(filepath.Base(argv[0])), "claude") {
 		return argv
@@ -86,9 +86,6 @@ func DeviceClaudeArgs(argv []string, cwd string) []string {
 	out := append([]string{}, argv...)
 	if envBool("ADAPTER_V2_SKIP_PERMISSIONS", true) {
 		out = append(out, "--dangerously-skip-permissions")
-	}
-	if envBool("ADAPTER_V2_RESUME", true) {
-		out = append(out, "--continue")
 	}
 	prompt := DeviceSystemPrompt(cwd, "")
 	if v, ok := os.LookupEnv("ADAPTER_V2_VOICE_SYSTEM_PROMPT"); ok {

--- a/adapter_v2/internal/cloudrelay/cloudrelay.go
+++ b/adapter_v2/internal/cloudrelay/cloudrelay.go
@@ -31,6 +31,7 @@ import (
 	"nhooyr.io/websocket/wsjson"
 
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/buildinfo"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/butler"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
 	"github.com/google/uuid"
 )
@@ -119,17 +120,18 @@ func (c Config) dialURL() string {
 // Relay is the running cloud-relay client. It owns the device→PTY bridges.
 type Relay struct {
 	cfg     Config
-	bridges *bridgeManager // per-device PTY session + Bridge
+	dev     *butler.DeviceSession // active-conversation lifecycle (ADR-032)
+	bridges *bridgeManager        // PTY session + Bridge onto session.DefaultID
 	log     func(format string, args ...any)
 }
 
 // New builds a Relay sharing the given session.Manager (so the device's voice
-// turns drive the SAME default session the web terminal joins). argv/cwd is the
-// CLI the default session runs — caller passes it already persona-wrapped via
-// WithVoicePrompt so every entry point spawns the default session identically.
-// log is the line logger (e.g. log.Printf).
-func New(mgr *session.Manager, cfg Config, argv []string, cwd string, log func(string, ...any)) *Relay {
-	return &Relay{cfg: cfg, bridges: newBridgeManager(mgr, argv, cwd), log: log}
+// turns drive the SAME default session the web terminal joins). dev owns the
+// default conversation's spawn config (persona + permissions + the active
+// conversation's resume flag) and the new/list/resume operations. log is the line
+// logger (e.g. log.Printf).
+func New(mgr *session.Manager, dev *butler.DeviceSession, cfg Config, log func(string, ...any)) *Relay {
+	return &Relay{cfg: cfg, dev: dev, bridges: newBridgeManager(mgr, dev), log: log}
 }
 
 // Run connects to the cloud and serves relayed requests until ctx is cancelled,

--- a/adapter_v2/internal/cloudrelay/e2e_test.go
+++ b/adapter_v2/internal/cloudrelay/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/butler"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
 
 	"nhooyr.io/websocket"
@@ -81,12 +82,13 @@ func TestE2ECloudRelayVoiceTurn(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	relay := New(session.NewManager(), Config{
+	mgr := session.NewManager()
+	relay := New(mgr, butler.NewDeviceSession(mgr, []string{bin}, ""), Config{
 		CloudWSURL:     "ws" + strings.TrimPrefix(srv.URL, "http"),
 		HomeSiteID:     "11111111-1111-1111-1111-111111111111",
 		ReconnectDelay: time.Second,
 		ReplyWait:      20 * time.Second,
-	}, []string{bin}, "", func(string, ...any) {})
+	}, func(string, ...any) {})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/adapter_v2/internal/cloudrelay/proxy.go
+++ b/adapter_v2/internal/cloudrelay/proxy.go
@@ -3,6 +3,8 @@ package cloudrelay
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/butler"
 )
 
 // proxyDriver is the single logical driver adapter_v2 advertises to the device's
@@ -46,12 +48,44 @@ func (r *Relay) handleAgentProxy(write func(Envelope) error, env Envelope) bool 
 			"messages": []any{}, "total": 0, "hasMore": false,
 		})
 	case "agent.sessions", "agent.sessions.list.logical":
-		return reply("agent.sessions.reply", map[string]any{"sessions": []any{}})
+		// Real conversation history (ADR-032): the workspace's claude .jsonl files,
+		// most-recent first, with the active one flagged.
+		active := r.devActiveID()
+		sessions := []map[string]any{}
+		for _, s := range r.devList() {
+			sessions = append(sessions, map[string]any{
+				"id": s.ID, "title": s.Title, "lastUsedAt": s.ModUnixSec,
+				"active": s.ID == active,
+			})
+		}
+		return reply("agent.sessions.reply", map[string]any{"sessions": sessions, "active": active})
 	case "agent.sessions.create":
+		// Start a fresh conversation: respawn the default session with a new id.
+		id := ""
+		if r.dev != nil {
+			id = r.dev.New()
+		}
+		r.log("cloudrelay: session.new device=%s id=%s", env.DeviceID, id)
 		return reply("agent.sessions.create.reply", map[string]any{"session": map[string]any{
-			"id": "ls-default", "driver": proxyDriver, "cwd": "", "title": "",
-			"createdAt": "1970-01-01T00:00:00Z", "lastUsedAt": "1970-01-01T00:00:00Z",
+			"id": id, "driver": proxyDriver, "title": "新对话", "active": true,
 		}})
+	case "agent.sessions.activate", "agent.sessions.select":
+		// Resume an existing conversation: respawn with --resume <id>.
+		var p struct {
+			SessionID string `json:"sessionId"`
+			ID        string `json:"id"`
+		}
+		raw, _ := json.Marshal(env.Payload)
+		_ = json.Unmarshal(raw, &p)
+		id := strings.TrimSpace(p.SessionID)
+		if id == "" {
+			id = strings.TrimSpace(p.ID)
+		}
+		if id != "" && r.dev != nil {
+			r.dev.Resume(id)
+			r.log("cloudrelay: session.resume device=%s id=%s", env.DeviceID, id)
+		}
+		return reply("agent.sessions.activate.reply", map[string]any{"ok": id != "", "active": r.devActiveID()})
 	case "agent.cwd_pool":
 		return reply("agent.cwd_pool.reply", map[string]any{"pool": []any{}})
 	case "agent.active_driver.set":
@@ -69,6 +103,22 @@ func (r *Relay) handleAgentProxy(write func(Envelope) error, env Envelope) bool 
 	default:
 		return false
 	}
+}
+
+// devList returns the device session's conversation list (empty on nil/error).
+func (r *Relay) devList() []butler.ConversationInfo {
+	if r.dev == nil {
+		return nil
+	}
+	list, _ := r.dev.List()
+	return list
+}
+
+func (r *Relay) devActiveID() string {
+	if r.dev == nil {
+		return ""
+	}
+	return r.dev.ActiveID()
 }
 
 func driverCaps() map[string]any {

--- a/adapter_v2/internal/cloudrelay/transcript.go
+++ b/adapter_v2/internal/cloudrelay/transcript.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/butler"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/deviceapi"
-	"github.com/daboluocc/bbclaw/adapter_v2/internal/ptyhost"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
 )
 
@@ -127,16 +127,15 @@ type cloudBridge struct {
 // bridgeManager lazily creates one cloudBridge per device id and keeps its
 // Bridge.Run goroutine alive for the process lifetime.
 type bridgeManager struct {
-	mgr  *session.Manager
-	argv []string
-	cwd  string
+	mgr *session.Manager
+	dev *butler.DeviceSession // supplies the default session's spawn config
 
 	mu      sync.Mutex
 	bridges map[string]*cloudBridge
 }
 
-func newBridgeManager(mgr *session.Manager, argv []string, cwd string) *bridgeManager {
-	return &bridgeManager{mgr: mgr, argv: argv, cwd: cwd, bridges: map[string]*cloudBridge{}}
+func newBridgeManager(mgr *session.Manager, dev *butler.DeviceSession) *bridgeManager {
+	return &bridgeManager{mgr: mgr, dev: dev, bridges: map[string]*cloudBridge{}}
 }
 
 // get returns the cloud relay's bridge onto the shared DEFAULT session. The
@@ -157,7 +156,7 @@ func (m *bridgeManager) get(deviceID string) (*cloudBridge, error) {
 		}
 		delete(m.bridges, session.DefaultID)
 	}
-	sess, err := m.mgr.GetOrCreate(session.DefaultID, ptyhost.Config{Argv: m.argv, Cwd: m.cwd})
+	sess, err := m.mgr.GetOrCreate(session.DefaultID, m.dev.Config())
 	if err != nil {
 		return nil, err
 	}

--- a/adapter_v2/internal/devicews/server.go
+++ b/adapter_v2/internal/devicews/server.go
@@ -11,6 +11,7 @@ import (
 
 	"nhooyr.io/websocket"
 
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/butler"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/deviceapi"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/ptyhost"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
@@ -44,9 +45,8 @@ type Server struct {
 	mgr         *session.Manager
 	asr         deviceapi.Recognizer // batch ASR over the buffered PTT utterance
 	tts         deviceapi.Synthesizer
-	argv        []string // default CLI to spawn under the PTY
-	cwd         string
-	auth        string // shared secret; "" disables auth (dev/LAN)
+	dev         *butler.DeviceSession // default conversation's spawn config (ADR-032)
+	auth        string                // shared secret; "" disables auth (dev/LAN)
 	cols        int
 	rows        int
 	decode      func(ctx context.Context, codec string, rate, ch int, payload []byte) ([]byte, error)
@@ -74,15 +74,16 @@ type Options struct {
 }
 
 // New builds a device-WS server. asr/tts are the voice providers (a mock ASR and
-// local TTS suffice for Phase A); argv/cwd is the CLI each device session drives.
-func New(mgr *session.Manager, asr deviceapi.Recognizer, tts deviceapi.Synthesizer, argv []string, cwd string, opt Options) *Server {
+// local TTS suffice for Phase A); dev supplies the default conversation's spawn
+// config (the LAN device line drives the same default session as the cloud relay).
+func New(mgr *session.Manager, asr deviceapi.Recognizer, tts deviceapi.Synthesizer, dev *butler.DeviceSession, opt Options) *Server {
 	if opt.Cols <= 0 {
 		opt.Cols = 80
 	}
 	if opt.Rows <= 0 {
 		opt.Rows = 24
 	}
-	return &Server{mgr: mgr, asr: asr, tts: tts, argv: argv, cwd: cwd, auth: opt.Auth, cols: opt.Cols, rows: opt.Rows, decode: opt.Decode, streamDelta: opt.StreamReplyDelta, segmentTTS: opt.SegmentTTS}
+	return &Server{mgr: mgr, asr: asr, tts: tts, dev: dev, auth: opt.Auth, cols: opt.Cols, rows: opt.Rows, decode: opt.Decode, streamDelta: opt.StreamReplyDelta, segmentTTS: opt.SegmentTTS}
 }
 
 // Handler upgrades GET /v2/dev/ws and runs one device session on it.
@@ -289,11 +290,9 @@ func (s *Server) serve(parent context.Context, conn wsConn) {
 	// the cloud relay also targets), not a per-device session — so device and web
 	// share one PTY. deviceID is kept for logging/echo only. (P1: single default
 	// session; per-device sessions are a later phase.)
-	sess, err := s.mgr.GetOrCreate(session.DefaultID, ptyhost.Config{
-		Argv:        s.argv,
-		Cwd:         s.cwd,
-		InitialSize: ptyhost.Size{Cols: uint16(s.cols), Rows: uint16(s.rows)},
-	})
+	pcfg := s.dev.Config()
+	pcfg.InitialSize = ptyhost.Size{Cols: uint16(s.cols), Rows: uint16(s.rows)}
+	sess, err := s.mgr.GetOrCreate(session.DefaultID, pcfg)
 	if err != nil {
 		_ = dc.writeCtrl(errFrame{T: "error", Code: codeBadProto, Detail: "session create failed"})
 		conn.Close(websocket.StatusInternalError, "session")

--- a/adapter_v2/internal/devicews/server_test.go
+++ b/adapter_v2/internal/devicews/server_test.go
@@ -10,6 +10,7 @@ import (
 
 	"nhooyr.io/websocket"
 
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/butler"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/deviceapi"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
 )
@@ -99,7 +100,7 @@ func TestTurnFSM(t *testing.T) {
 }
 
 func TestServeRejectsBadFirstFrame(t *testing.T) {
-	srv := New(session.NewManager(), deviceapi.StaticRecognizer{Text: "x"}, deviceapi.SilentSynthesizer{}, []string{"cat"}, "", Options{})
+	srv := New(session.NewManager(), deviceapi.StaticRecognizer{Text: "x"}, deviceapi.SilentSynthesizer{}, butler.NewDeviceSession(session.NewManager(), []string{"cat"}, ""), Options{})
 	f := newFakeConn(inFrame{typ: websocket.MessageBinary, data: []byte{0x01, 0x02, 0x03}})
 
 	runServe(srv, f)
@@ -110,7 +111,7 @@ func TestServeRejectsBadFirstFrame(t *testing.T) {
 }
 
 func TestServeRejectsBadAuth(t *testing.T) {
-	srv := New(session.NewManager(), deviceapi.StaticRecognizer{Text: "x"}, deviceapi.SilentSynthesizer{}, []string{"cat"}, "", Options{Auth: "s3cret"})
+	srv := New(session.NewManager(), deviceapi.StaticRecognizer{Text: "x"}, deviceapi.SilentSynthesizer{}, butler.NewDeviceSession(session.NewManager(), []string{"cat"}, ""), Options{Auth: "s3cret"})
 	hello, _ := json.Marshal(map[string]any{"t": "hello", "proto": Proto, "auth": "wrong"})
 	f := newFakeConn(inFrame{typ: websocket.MessageText, data: hello})
 
@@ -123,7 +124,7 @@ func TestServeRejectsBadAuth(t *testing.T) {
 }
 
 func TestServeHelloOK(t *testing.T) {
-	srv := New(session.NewManager(), deviceapi.StaticRecognizer{Text: "x"}, deviceapi.SilentSynthesizer{}, []string{"cat"}, "", Options{})
+	srv := New(session.NewManager(), deviceapi.StaticRecognizer{Text: "x"}, deviceapi.SilentSynthesizer{}, butler.NewDeviceSession(session.NewManager(), []string{"cat"}, ""), Options{})
 	hello, _ := json.Marshal(map[string]any{"t": "hello", "proto": Proto, "dev": "unit"})
 	f := newFakeConn(inFrame{typ: websocket.MessageText, data: hello})
 

--- a/adapter_v2/internal/session/session.go
+++ b/adapter_v2/internal/session/session.go
@@ -318,6 +318,24 @@ func (m *Manager) Get(id string) *Session {
 	return m.sessions[id]
 }
 
+// Remove kills the session for id (terminating its CLI child) and drops it from
+// the map, so the next GetOrCreate spawns a fresh one. Used to respawn the shared
+// default session when switching conversations (new / resume a different id):
+// killing it closes the client channels, so an attached Bridge's Run returns
+// ErrClosed and a web terminal sees a clean disconnect + reconnect. No-op if the
+// id isn't live.
+func (m *Manager) Remove(id string) {
+	m.mu.Lock()
+	s := m.sessions[id]
+	if s != nil {
+		delete(m.sessions, id)
+	}
+	m.mu.Unlock()
+	if s != nil {
+		s.kill()
+	}
+}
+
 // GetOrCreate returns the live session for id, spawning one with cfg if absent.
 // It is the atomic create-if-absent the /ws handler needs: two near-simultaneous
 // first connections to the same id (a phone and a web page opening the same


### PR DESCRIPTION
ADR-032 P2 的 adapter 半边。引入 butler.DeviceSession 作为 active 对话的唯一真相,续接/新建/切换在设备线、云中继、web 终端间一致(都用 DeviceSession.Config() 启动 session.DefaultID)。

- **DeviceSession**:持有默认对话的启动配置(人设+权限 base argv + active 对话的 resume flag)+ active 对话 id(持久化 ~/.bbclaw-adapter-v2/active-session.json)。boot 续持久化对话(--resume <id>,若 .jsonl 还在),否则最近的,否则铸新(--session-id)。**永不用裸 --continue**(真 claude 验过:无历史时 --continue 会挂)。切换=重启:New()/Resume() 改 active id + 杀 session.DefaultID(新增 Manager.Remove)→ 下次启动用新 flag,云中继 bridge 自动重建(死会话驱逐),web 重连。List() 枚举 workspace 的 claude .jsonl(id+首条用户消息标题+mtime)。
- resume flag 是 claude 专属:Config() 仅对 claude CLI 追加,别的 CLI(测试的 cat)不会被 --continue 搞挂。
- DeviceClaudeArgs 不再加 --continue(DeviceSession 接管 resume)。
- 云中继 proxy:agent.sessions(真列表+active 标记)、agent.sessions.create(New→重启)、agent.sessions.activate/select(Resume→重启)替掉空 stub;三入口共用 DeviceSession。
- session.Manager.Remove(id):公开 kill+remove。

**对真 claude 端到端验证**:一轮后 New() 重启=干净会话(turn2 不记得 turn1)。单测(resume 模式/持久化/claude 限定/.jsonl 列举)+ 全量 + race + e2e 绿。P2 剩余:固件会话菜单(新建/历史/选择)触发这些;P3(按会话隔离 agent.messages)随后。

Epic #192。ADR-032。

🤖 Generated with [Claude Code](https://claude.com/claude-code)