### PR TITLE
fix(adapter_v2/extract): --resume 后不再把 claude 状态 chrome 当回复念

### DIFF
--- a/adapter_v2/internal/extract/extract.go
+++ b/adapter_v2/internal/extract/extract.go
@@ -144,9 +144,18 @@ func extractMarkerBlock(visible string) (string, bool) {
 	raw := strings.Split(visible, "\n")
 	last := -1
 	for i, l := range raw {
-		if strings.HasPrefix(strings.TrimLeft(l, " "), replyMarker) {
-			last = i
+		if !strings.HasPrefix(strings.TrimLeft(l, " "), replyMarker) {
+			continue
 		}
+		// A "⏺ <chrome>" line is NOT a reply marker: claude re-renders status
+		// blocks with a leading bullet on --resume — "⏺ [Opus 4.8 (1M context)] │
+		// workspace", "⏺ ⏵⏵ bypass permissions on … ← for agents". Their content is
+		// noise (isStatusLine), so anchoring on them would speak the model/usage
+		// footer instead of the reply. Skip them; the last REAL reply marker wins.
+		if isNoiseLine(stripReplyMarker(strings.TrimRight(l, " \t"))) {
+			continue
+		}
+		last = i
 	}
 	if last < 0 {
 		return "", false
@@ -155,6 +164,13 @@ func extractMarkerBlock(visible string) (string, bool) {
 	block := []string{stripReplyMarker(strings.TrimRight(raw[last], " \t"))}
 	for k := last + 1; k < len(raw); k++ {
 		l := strings.TrimRight(raw[k], " \t")
+		// A later "⏺" line starts a NEW assistant block (a following segment, or a
+		// resume status/chrome block) — the current reply ends here. Without this
+		// the block would absorb a trailing "⏺ [Opus …] │ workspace" status line,
+		// whose "⏺" prefix hides it from the isNoiseLine check below.
+		if strings.HasPrefix(strings.TrimLeft(l, " "), replyMarker) {
+			break
+		}
 		if l == "" {
 			block = append(block, "") // keep interior blanks (paragraph breaks)
 			continue

--- a/adapter_v2/internal/extract/extract_test.go
+++ b/adapter_v2/internal/extract/extract_test.go
@@ -256,6 +256,45 @@ func TestExtractSuppressesClaudeChromeUntilMarker(t *testing.T) {
 	}
 }
 
+// Regression for the on-device SaaS bug (TTS spoke "[Opus 4.8 (1M context)] │
+// workspace" / "⏵⏵ bypass permissions on …"): on --resume claude re-renders its
+// model/usage status as "⏺ <chrome>" blocks AFTER the real reply. The last-"⏺"
+// scan anchored on those, so the device spoke claude's status footer. The marker
+// scan must skip "⏺ <noise>" lines and anchor on the last REAL reply.
+func TestExtractSkipsResumeStatusMarkerBlocks(t *testing.T) {
+	s := vtscreen.New(80, 24)
+	ext := New(s)
+	s.Feed([]byte("\x1b[1;1H" +
+		"⏺ 好的,我在。\r\n" + // the REAL reply
+		"\r\n" +
+		"⏺ [Opus 4.8 (1M context)] │ workspace\r\n" + // resume status chrome (a later "⏺")
+		"  Context ░░░░░░░░░░ 3% │ Usage █░░░░░░░░░ 9% (resets in 4h 20m)\r\n" +
+		"⏺ ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents\r\n" + // bypass footer as "⏺"
+		"❯ \r\n"))
+	r, _ := ext.OnOutput()
+	if !strings.Contains(r.Text, "好的,我在。") {
+		t.Errorf("real reply not extracted: %q", r.Text)
+	}
+	if strings.Contains(r.Text, "Opus 4.8") || strings.Contains(r.Text, "bypass permissions") || strings.Contains(r.Text, "context)") {
+		t.Errorf("resume status chrome leaked into reply: %q", r.Text)
+	}
+}
+
+// And when the ONLY "⏺" lines are status chrome (no real reply on screen yet —
+// e.g. right after --resume, before the new turn's reply renders), nothing is
+// extracted, rather than speaking the chrome.
+func TestExtractStatusOnlyMarkersYieldNothing(t *testing.T) {
+	s := vtscreen.New(80, 24)
+	ext := New(s)
+	s.Feed([]byte("\x1b[1;1H" +
+		"⏺ [Opus 4.8 (1M context)] │ workspace\r\n" +
+		"  Context ░░░░░░░░░░ 3% │ Usage █░░░░░░░░░ 9%\r\n" +
+		"❯ \r\n"))
+	if r, _ := ext.OnOutput(); strings.TrimSpace(r.Text) != "" {
+		t.Errorf("status-only chrome leaked as reply: %q", r.Text)
+	}
+}
+
 func TestExtractFallbackStillWorksForMarkerlessCLI(t *testing.T) {
 	s := vtscreen.New(80, 24)
 	ext := New(s)


### PR DESCRIPTION
真机 SaaS bug(P2 把 boot 改成 --resume 上次对话后复现):TTS 念出 \"[Opus 4.8 (1M context)] │ workspace\" 和 \"⏵⏵ bypass permissions on … ← for agents\",而不是回复。

根因:--resume 时 claude 把模型/用量状态 + bypass 页脚重渲染成 \"⏺ <chrome>\" 块,排在真回复后面。抽取器锚定最后一个 ⏺ 且**无条件**加该行(没过噪声),于是念了状态页脚。seed-guard 也压不住——用量 % 实时跳动(extract != seed)。

修(extractMarkerBlock):找锚点时**跳过内容是噪声的 ⏺ 行**(isStatusLine 已能识别模型/用量/\"for agents\" chrome)→ 锚到最后一个**真**回复;continuation **遇到下一个 ⏺ 就停**(后续 ⏺ 是新块,其 ⏺ 前缀会让逐行噪声检查漏掉)。

两个回归测试复刻真机屏(真回复 + resume 状态/bypass ⏺ 块 → 只抽到回复;纯状态 ⏺ → 空)。全 extract + 全量绿。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)