### PR TITLE
feat(adapter_v2): 云中继 barge-in——新 ASR 打断当前任务

### DIFF
--- a/adapter_v2/internal/cloudrelay/transcript.go
+++ b/adapter_v2/internal/cloudrelay/transcript.go
@@ -41,10 +41,22 @@ func (r *Relay) handleTranscript(ctx context.Context, write func(Envelope) error
 		return err
 	}
 
-	// One turn at a time per device: serialise, then arm the events observer with
-	// this request's write/env, inject, and wait for the turn to complete.
+	// Barge-in (ADR-028): a newer transcript preempts the in-flight turn. Cancel
+	// the running turn's wait BEFORE taking turnMu so its handler releases the lock;
+	// then SubmitVoiceTurn's ESC below aborts the CLI's now-stale generation. This
+	// is the natural turn-taking of voice — "stop, do THIS instead" — rather than
+	// queueing a now-stale answer ahead of what the user just said.
+	cb.preempt()
 	cb.turnMu.Lock()
 	defer cb.turnMu.Unlock()
+
+	// Register this turn so a later transcript can preempt it; turnCtx fires when
+	// that happens.
+	turnCtx, cancelTurn := context.WithCancel(ctx)
+	defer cancelTurn()
+	h := cb.arm(cancelTurn)
+	defer cb.disarm(h)
+
 	done := cb.ev.begin(write, env, r.cfg.HomeSiteID)
 	defer cb.ev.end()
 
@@ -64,6 +76,18 @@ func (r *Relay) handleTranscript(ctx context.Context, write func(Envelope) error
 	timedOut := false
 	select {
 	case <-done:
+	case <-turnCtx.Done():
+		// Preempted by a newer transcript (barge-in). With final-only TTS nothing
+		// was spoken for this turn yet, so return a clean empty reply to complete
+		// the cloud's request for THIS messageID; the newer transcript carries its
+		// own reply (and its SubmitVoiceTurn ESC-aborted this turn's CLI work).
+		r.log("cloudrelay: ⊘ reply device=%s superseded by newer transcript (barge-in) after %s",
+			deviceID, time.Since(started).Round(time.Millisecond))
+		return write(Envelope{
+			Type: "reply", MessageID: env.MessageID, DeviceID: env.DeviceID,
+			HomeSiteID: r.cfg.HomeSiteID, Kind: "voice.reply",
+			Payload: map[string]any{"ok": true, "text": "", "superseded": true},
+		})
 	case <-time.After(r.cfg.ReplyWait):
 		timedOut = true
 	case <-ctx.Done():
@@ -117,11 +141,50 @@ type cloudBridge struct {
 	sess   *session.Session
 	bridge *deviceapi.Bridge
 	ev     *cloudEvents
-	// turnMu serialises turns for this device. The cloud already waits for each
-	// voice.reply before relaying the next transcript, so same-device turns don't
-	// overlap in practice — this guards against a future pipelining cloud and
-	// keeps the single-turn cloudEvents observer correct.
+	// turnMu serialises turns for this device so the single-turn cloudEvents
+	// observer stays correct. Barge-in does not skip it: a newer transcript first
+	// preempt()s the running turn (which then releases turnMu), then takes it.
 	turnMu sync.Mutex
+
+	// actMu guards active, the cancel handle of the turn currently holding turnMu.
+	// preempt() cancels it so a barging-in transcript doesn't block behind it.
+	actMu  sync.Mutex
+	active *turnHandle
+}
+
+// turnHandle identifies one in-flight turn for preemption. Pointer identity (not
+// the un-comparable CancelFunc) lets disarm clear only its own turn.
+type turnHandle struct{ cancel context.CancelFunc }
+
+// arm records h as the in-flight turn and returns it (for disarm).
+func (cb *cloudBridge) arm(cancel context.CancelFunc) *turnHandle {
+	h := &turnHandle{cancel: cancel}
+	cb.actMu.Lock()
+	cb.active = h
+	cb.actMu.Unlock()
+	return h
+}
+
+// disarm clears the active turn iff it is still h (a newer turn may have replaced
+// it via arm already).
+func (cb *cloudBridge) disarm(h *turnHandle) {
+	cb.actMu.Lock()
+	if cb.active == h {
+		cb.active = nil
+	}
+	cb.actMu.Unlock()
+}
+
+// preempt cancels the in-flight turn (if any) so its handler returns and releases
+// turnMu. No-op when nothing is in flight (the common sequential case).
+func (cb *cloudBridge) preempt() {
+	cb.actMu.Lock()
+	h := cb.active
+	cb.active = nil
+	cb.actMu.Unlock()
+	if h != nil {
+		h.cancel()
+	}
 }
 
 // bridgeManager lazily creates one cloudBridge per device id and keeps its

--- a/adapter_v2/internal/cloudrelay/transcript_test.go
+++ b/adapter_v2/internal/cloudrelay/transcript_test.go
@@ -1,0 +1,50 @@
+package cloudrelay
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCloudBridgePreempt covers the barge-in handle mechanism: preempt cancels the
+// in-flight turn, and disarm only clears its OWN turn (a stale handle must not
+// clear a newer turn that already replaced it). The end-to-end barge-in (a newer
+// transcript interrupting claude) is exercised against the real CLI; this pins the
+// pointer-identity bookkeeping that routes the cancel correctly.
+func TestCloudBridgePreempt(t *testing.T) {
+	cb := &cloudBridge{}
+
+	// preempt with nothing in flight is a no-op (the common sequential case).
+	cb.preempt()
+
+	// arm a turn; preempt cancels exactly it.
+	ctx1, c1 := context.WithCancel(context.Background())
+	h1 := cb.arm(c1)
+	cb.preempt()
+	select {
+	case <-ctx1.Done():
+	default:
+		t.Fatal("preempt did not cancel the in-flight turn")
+	}
+
+	// A stale disarm (h1) after a newer arm (h2) must NOT clear h2 — else a
+	// finishing superseded turn would unregister the live one and the next barge-in
+	// couldn't preempt it.
+	_, c2 := context.WithCancel(context.Background())
+	h2 := cb.arm(c2)
+	cb.disarm(h1)
+	cb.actMu.Lock()
+	active := cb.active
+	cb.actMu.Unlock()
+	if active != h2 {
+		t.Fatal("stale disarm cleared the active (newer) turn")
+	}
+
+	// disarm of the active handle clears it.
+	cb.disarm(h2)
+	cb.actMu.Lock()
+	active = cb.active
+	cb.actMu.Unlock()
+	if active != nil {
+		t.Fatal("disarm of the active handle should clear it")
+	}
+}


### PR DESCRIPTION
补全 SaaS 语音链路的打断能力。固件早已 barge-in(ADR-028 §2.5.1:任何状态按 PTT 都停 TTS+起新录音),云端把每次 PTT 当独立 voice.transcript 转发,所以中途第二句早就到了 adapter——但 handleTranscript **在 turnMu 上串行**,把新轮排在旧轮后面而不是打断。语音上很别扭:设备会先把过时回复念完才轮到你刚说的。

现在新 transcript 抢占在飞的那轮:
- 取 turnMu 前先 preempt() 取消在飞轮的 context → 它返回并释放锁,而不是把新轮堵在多秒回复后面。
- 被抢占的轮回一个干净的空 voice.reply{superseded:true},让云端那个 messageID 的请求完成(final-only TTS 下还没念任何东西,无需撤回)。
- 新轮拿到 turnMu,SubmitVoiceTurn 已有的 ESC 中止 CLI 的过时生成 + 重设抽取基线(被打断的残片不外泄)。**最新者胜**:连续多条各自抢占前一条。

cloudBridge 加了个小的 turn-handle 注册表(arm/disarm/preempt),按指针标识(CancelFunc 不可比),避免收尾的被抢占轮误注销在飞的那轮。

**对真 claude 端到端验证**:m1 \"数到40\" 被中途打断(回 superseded/空),m2 \"1加1等于几\" 被回答(\"1加1等于2。\")。单测固定 arm/disarm/preempt 记账;全量+race+e2e 绿。Epic #192。ADR-028。

🤖 Generated with [Claude Code](https://claude.com/claude-code)