### PR TITLE
fix(adapter_v2/extract): claude API-重试等待 视为 BUSY(保住 barge-in 的 ESC)

### DIFF
--- a/adapter_v2/internal/extract/boundary_test.go
+++ b/adapter_v2/internal/extract/boundary_test.go
@@ -188,6 +188,40 @@ func TestMidReplyPauseDoesNotEnd(t *testing.T) {
 	}
 }
 
+// TestApiRetryWaitDoesNotEnd: claude's network/API retry state ("Waiting for API
+// response · will retry in Ns · check your network") drops the "esc to interrupt"
+// affordance, but the turn is NOT over — it will retry. Treating it as idle ended
+// the turn early and cleared the in-flight flag, so a barge-in typed into the box
+// (claude queued it) instead of ESC-aborting. The detector must keep it in flight.
+func TestApiRetryWaitDoesNotEnd(t *testing.T) {
+	s := vtscreen.New(fixtureCols, fixtureRows)
+	s.Feed([]byte("\x1b[2J\x1b[H"))
+
+	var d Detector
+	t0 := time.Unix(5_500_000, 0)
+
+	// A spinner appeared — the turn started working.
+	s.Feed([]byte("\x1b[3;1H⏺ working on it"))
+	s.Feed([]byte("\x1b[21;1H✶ Seasoning… (3s · ↑ 12 tokens · esc to interrupt)"))
+	d.Observe(t0, s, true)
+
+	// The API call fails; claude drops the "esc to interrupt" spinner and shows the
+	// retry wait instead.
+	t1 := t0.Add(time.Second)
+	s.Feed([]byte("\x1b[21;1H\x1b[2K")) // esc-to-interrupt spinner gone
+	s.Feed([]byte("\x1b[22;1HWaiting for API response · will retry in 2m 26s · check your network"))
+	d.Observe(t1, s, true)
+
+	// Output is settled well past Quiet, but the turn is NOT over (it will retry),
+	// so the detector must keep reporting in-flight — otherwise inFlight clears and
+	// the next barge-in can't ESC.
+	for _, gap := range []time.Duration{Quiet, 5 * time.Second, 30 * time.Second} {
+		if d.TurnEnded(t1.Add(gap)) {
+			t.Fatalf("API-retry wait falsely reported turn ended after %v", gap)
+		}
+	}
+}
+
 // TestNeverSpeakingGuard covers the false-negative end: a spinner-less / very
 // fast CLI whose reply finishes without ever painting a spinner must still end
 // on prompt-return + quiet, so the device is never stuck silent.

--- a/adapter_v2/internal/extract/noise.go
+++ b/adapter_v2/internal/extract/noise.go
@@ -27,6 +27,15 @@ import "strings"
 // all churn, but the "esc to interrupt" affordance is stable while busy.
 const promptInterruptHint = "esc to interrupt"
 
+// apiRetryHints mark claude's network/API retry wait — "Waiting for API response
+// · will retry in Ns · check your network". In this state claude drops the
+// "esc to interrupt" affordance, but the turn is NOT finished: it will retry.
+// The boundary detector must treat it as still-working, else it completes the
+// turn early and clears the in-flight flag — so a barge-in then TYPES into the
+// input box (claude queues it: "Press up to edit queued messages") instead of
+// ESC-aborting. These substrings are the stable markers of that state.
+var apiRetryHints = []string{"will retry", "Waiting for API response"}
+
 // isNoiseLine reports whether a visible line is UI chrome rather than reply
 // content. The input line is whitespace-insensitive: callers pass a raw grid
 // row (already plain text, no ANSI).
@@ -105,12 +114,21 @@ func isPromptLine(t string) bool {
 	return false
 }
 
-// isSpinnerLine matches the working/progress status line. The "esc to interrupt"
-// affordance is claude's stable marker; we also catch the rare frame where only
-// the elapsed-time / token counter is present by checking for the interrupt
-// hint, which is what makes spinner redraws collapse to nothing in the reply.
+// isSpinnerLine matches the working/progress status line — claude is busy and the
+// turn is in flight. The "esc to interrupt" affordance is the stable marker of the
+// normal working spinner; the API-retry wait (no "esc to interrupt" but still
+// working — see apiRetryHints) is the other busy state. Both keep the boundary
+// detector from ending the turn (and keep barge-in's in-flight ESC armed).
 func isSpinnerLine(t string) bool {
-	return strings.Contains(t, promptInterruptHint)
+	if strings.Contains(t, promptInterruptHint) {
+		return true
+	}
+	for _, h := range apiRetryHints {
+		if strings.Contains(t, h) {
+			return true
+		}
+	}
+	return false
 }
 
 // isBoxDrawingOnly reports whether a line consists solely of box-drawing /

--- a/adapter_v2/internal/extract/noise_test.go
+++ b/adapter_v2/internal/extract/noise_test.go
@@ -23,6 +23,8 @@ func TestIsNoiseLine(t *testing.T) {
 		{"spinner full", "✶ Cogitating… (3s · ↑ 240 tokens · esc to interrupt)", true},
 		{"spinner minimal", "  ✻ Working… (12s · esc to interrupt)", true},
 		{"spinner glyph dropped by emulator", "Cogitating… (3s · esc to interrupt)", true},
+		{"api retry wait", "Waiting for API response · will retry in 2m 26s · check your network", true},
+		{"api retry short", "· will retry in 30s ·", true},
 
 		{"box top border", "╭──────────────╮", true},
 		{"box bottom border", "╰──────────────╯", true},


### PR DESCRIPTION
真机 barge-in 在 claude 网络/API 重试态失效:新 transcript 被**打字进输入框排队**(\"Press up to edit queued messages\"),没 ESC 打断卡住的轮。

根因:claude 重试态 \"Waiting for API response · will retry in Ns · check your network\" 丢掉了边界检测器依赖的 \"esc to interrupt\"。spinner \"消失\"+输出静默 → 检测器判定轮结束 → Bridge 清掉 in-flight 标志。SubmitVoiceTurn 只在 in-flight 时发 ESC,标志没了就跳过 ESC、直接打字 → claude(其实还忙、要重试)把它当待发消息排队。

修:isSpinnerLine 也匹配重试态(apiRetryHints:\"will retry\"/\"Waiting for API response\")。该态=还在工作,非 idle,检测器保持轮 in-flight(不早结、不早抽回复),in-flight 标志保留 → barge-in 能 ESC 打断卡住的轮。重试行也归为 noise,不漏进回复。

测试:边界测试(spinner 后进重试态 → 永不报结束)+ noise 分类。全 extract + race 绿。

注:底层 \"check your network\" 是 claude 在本机连不上 API(网络/API 问题),非 adapter bug——本修复只让 adapter 优雅处理(保持 in-flight、允许打断)。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)