### PR TITLE
fix(adapter_v2): 处理 turn.cancel——设备真正的 barge-in 信号

### DIFF
--- a/adapter_v2/internal/cloudrelay/cloudrelay.go
+++ b/adapter_v2/internal/cloudrelay/cloudrelay.go
@@ -264,6 +264,15 @@ func (r *Relay) handleRequest(ctx context.Context, write func(Envelope) error, e
 		}
 		return
 	}
+	// turn.cancel is the device's barge-in/abort signal (PTT pressed during a
+	// reply). Interrupt the in-flight turn so a stuck/slow turn (e.g. a long tool
+	// call, or claude stuck on an API retry) doesn't run until ReplyWait — before
+	// this the cancel was ignored ("no handler") and the device sat in "waiting"
+	// until the turn timed out.
+	if strings.EqualFold(strings.TrimSpace(env.Kind), "turn.cancel") {
+		r.handleTurnCancel(write, env)
+		return
+	}
 	// Settings/UI proxy kinds (agent.drivers, agent.messages, agent.menu, …) get a
 	// minimal static reply; unknown kinds fall through to a silent no-op. Log either
 	// way so the device's settings-page traffic is visible while debugging.

--- a/adapter_v2/internal/cloudrelay/transcript.go
+++ b/adapter_v2/internal/cloudrelay/transcript.go
@@ -107,6 +107,33 @@ func (r *Relay) handleTranscript(ctx context.Context, write func(Envelope) error
 	})
 }
 
+// handleTurnCancel aborts the in-flight turn on the device's barge-in/abort
+// (turn.cancel). It preempts the waiting handleTranscript (so it returns and frees
+// turnMu, completing its own request) and sends the CLI an ESC to drop the running
+// generation. No-op when nothing is in flight. Always acks so the cloud's
+// turn.cancel request completes.
+func (r *Relay) handleTurnCancel(write func(Envelope) error, env Envelope) {
+	deviceID := strings.TrimSpace(env.DeviceID)
+	if deviceID == "" {
+		deviceID = "cloud-anon"
+	}
+	if cb := r.bridges.peek(); cb != nil {
+		cb.preempt() // the in-flight handleTranscript returns superseded, frees turnMu
+		if err := cb.bridge.Interrupt(); err != nil {
+			r.log("cloudrelay: turn.cancel device=%s interrupt error: %v", deviceID, err)
+		} else {
+			r.log("cloudrelay: ⊘ turn.cancel device=%s — interrupted in-flight turn", deviceID)
+		}
+	} else {
+		r.log("cloudrelay: turn.cancel device=%s — nothing in flight", deviceID)
+	}
+	_ = write(Envelope{
+		Type: "reply", MessageID: env.MessageID, DeviceID: env.DeviceID,
+		HomeSiteID: r.cfg.HomeSiteID, Kind: "turn.cancel",
+		Payload: map[string]any{"ok": true},
+	})
+}
+
 // heartbeatInterval is well under the cloud's ReplyIdleWait (default 120s) so a
 // silent turn never trips HOME_ADAPTER_TIMEOUT.
 const heartbeatInterval = 15 * time.Second
@@ -199,6 +226,18 @@ type bridgeManager struct {
 
 func newBridgeManager(mgr *session.Manager, dev *butler.DeviceSession) *bridgeManager {
 	return &bridgeManager{mgr: mgr, dev: dev, bridges: map[string]*cloudBridge{}}
+}
+
+// peek returns the live default bridge without creating one — for turn.cancel,
+// which must abort an EXISTING turn, never spawn a CLI. nil when no live bridge
+// (nothing to cancel).
+func (m *bridgeManager) peek() *cloudBridge {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if cb, ok := m.bridges[session.DefaultID]; ok && m.mgr.Get(session.DefaultID) == cb.sess {
+		return cb
+	}
+	return nil
 }
 
 // get returns the cloud relay's bridge onto the shared DEFAULT session. The

--- a/adapter_v2/internal/deviceapi/deviceapi.go
+++ b/adapter_v2/internal/deviceapi/deviceapi.go
@@ -315,6 +315,27 @@ func (b *Bridge) SubmitVoiceTurn(transcript string) error {
 	return nil
 }
 
+// Interrupt aborts the in-flight turn without starting a new one — the explicit
+// barge-in/cancel path (the device's turn.cancel), as opposed to SubmitVoiceTurn's
+// interrupt-then-inject. It sends claude's ESC ("esc to interrupt") so the CLI
+// drops the current turn and returns to its idle prompt, clears the in-flight flag
+// (so a following SubmitVoiceTurn injects cleanly with no gratuitous second ESC),
+// and re-baselines so the interrupted partial never leaks into the next turn.
+// No-op when nothing is in flight (a cancel at an idle prompt must NOT emit a
+// stray ESC — it would corrupt the next keystroke; see SubmitVoiceTurn).
+func (b *Bridge) Interrupt() error {
+	if !b.inFlight.Load() {
+		return nil
+	}
+	if err := b.sess.Write([]byte(interruptKey)); err != nil {
+		return mapErr(err)
+	}
+	time.Sleep(interruptSettle)
+	b.inFlight.Store(false)
+	b.signalRearm()
+	return nil
+}
+
 // signalRearm performs a non-blocking poke of the rearm channel: if Run has not
 // yet consumed a prior signal, the buffer is already full and we drop this one
 // (coalescing), since one re-baseline against the latest screen covers any burst

--- a/adapter_v2/internal/deviceapi/deviceapi_test.go
+++ b/adapter_v2/internal/deviceapi/deviceapi_test.go
@@ -455,6 +455,59 @@ func TestSubmitVoiceTurnInterruptsInFlight(t *testing.T) {
 	}
 }
 
+// TestInterruptEscOnlyWhenInFlight covers Bridge.Interrupt (the turn.cancel /
+// barge-in abort path): a no-op at an idle prompt (no stray ESC to corrupt the
+// next keystroke), and an ESC + in-flight clear when a turn IS running — so the
+// CLI drops the current turn and the next submitted line carries no second ESC.
+func TestInterruptEscOnlyWhenInFlight(t *testing.T) {
+	m := session.NewManager()
+	s, err := m.Create("probe-int", ptyhost.Config{
+		Argv:        []string{"bash", "-c", interruptProbeCLI},
+		InitialSize: ptyhost.Size{Cols: 80, Rows: 24},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	client, _, _ := s.Attach()
+	defer s.Detach(client)
+	br := b(s)
+
+	// (a) Idle: Interrupt is a no-op — nothing in flight, no ESC emitted.
+	if err := br.Interrupt(); err != nil {
+		t.Fatalf("Interrupt(idle): %v", err)
+	}
+	if br.inFlight.Load() {
+		t.Fatal("Interrupt at idle must not set inFlight")
+	}
+	// (b) Idle submit confirms no ESC is pending ahead of it.
+	if err := br.SubmitVoiceTurn("first"); err != nil {
+		t.Fatalf("SubmitVoiceTurn: %v", err)
+	}
+	if !drainContains(client.Out, "NO_ESC:first", 3*time.Second) {
+		t.Fatal("no ESC should precede the first (idle) turn")
+	}
+
+	// (c) A turn is now in flight (SubmitVoiceTurn set it). Interrupt emits ESC and
+	// clears the flag.
+	if !br.inFlight.Load() {
+		t.Fatal("SubmitVoiceTurn should have set inFlight")
+	}
+	if err := br.Interrupt(); err != nil {
+		t.Fatalf("Interrupt(in-flight): %v", err)
+	}
+	if br.inFlight.Load() {
+		t.Fatal("Interrupt must clear inFlight")
+	}
+	// (d) The next submit adds no ESC of its own (inFlight now false), so the ESC the
+	// probe sees ahead of this line came from Interrupt.
+	if err := br.SubmitVoiceTurn("second"); err != nil {
+		t.Fatalf("SubmitVoiceTurn: %v", err)
+	}
+	if !drainContains(client.Out, "SAW_ESC:second", 3*time.Second) {
+		t.Fatal("Interrupt's ESC must land ahead of the next submitted line")
+	}
+}
+
 // TestSayTTSSynthesizesWav exercises the real macOS `say` Synthesizer end to end:
 // it must produce a non-empty RIFF/WAVE buffer. Skipped where `say` is absent
 // (non-macOS CI), since SayTTS is the documented local-only stopgap.


### PR DESCRIPTION
真机 barge-in 还是不打断:新话被打字进 claude 输入框排队。日志说明原因——设备发的是 **turn.cancel**(回复中按 PTT),但 relay **没 handler**(\"ignored ... kind=turn.cancel (no handler)\"),于是卡住/慢的轮(磁盘工具调用、或 claude 在 API 重试)一直跑到 1m30s ReplyWait,设备全程卡在\"等待\"。之前的\"新 transcript 抢占\"是错的机制——设备靠 turn.cancel 打断,不是抢第二条 transcript。

- **deviceapi.Bridge.Interrupt()**:显式中止——发 claude 的 ESC 丢掉在飞轮回到 idle,清 in-flight 标志(下条 SubmitVoiceTurn 干净注入、不双 ESC),重设基线(残片不漏)。idle 时 no-op(乱发 ESC 会吃掉下个键)。
- **cloudrelay**:handleRequest 现在把 turn.cancel 派给 handleTurnCancel:preempt 等待中的 handleTranscript(回 superseded、放 turnMu)+ Bridge.Interrupt() + ack。bridgeManager.peek() 取在用 bridge **不新建**(cancel 绝不该 spawn CLI)。

**真 claude 验过**:m1 \"sleep 30\" 被 turn.cancel 打断(回 superseded),后续 m2 \"1+1\" 被答(\"二。\")。单测固定 Interrupt 的\"仅 in-flight 才发 ESC\";全量+race 绿。

注:长轮期间设备仍只显示\"等待\"无转写/步骤反馈(另一块进度展示,主要在 cloud+firmware);磁盘慢本身是 claude(工具/API 重试)——本修复让它\"可中止\",速度是环境问题。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)