### PR TITLE
fix(adapter_v2): 自动关掉 claude 会话反馈弹窗(它把语音线卡死)

### DIFF
--- a/adapter_v2/internal/deviceapi/deviceapi.go
+++ b/adapter_v2/internal/deviceapi/deviceapi.go
@@ -394,6 +394,25 @@ func (b *Bridge) Run(ctx context.Context) error {
 	ticker := time.NewTicker(b.cfg.PollInterval)
 	defer ticker.Stop()
 
+	// dismissSurvey clears claude's input-blocking session-feedback overlay the
+	// moment it appears, pressing "0: Dismiss". Single-shot per appearance (armed
+	// again only after the overlay leaves the screen) so we never spam the key into
+	// the prompt if it's already gone.
+	surveyArmed := true
+	dismissSurvey := func() {
+		if strings.Contains(b.screen.VisibleText(), surveyMarker) {
+			if surveyArmed {
+				surveyArmed = false
+				if debugExtract {
+					log.Printf("deviceapi: dismissing claude session-feedback overlay")
+				}
+				_ = b.sess.Write([]byte(surveyDismissKey))
+			}
+			return
+		}
+		surveyArmed = true
+	}
+
 	// rebaseline starts a fresh turn: a new Extractor baselined on the current
 	// screen, a reset Detector, and cleared streaming state. It also captures the
 	// reply currently on screen as the turn's `seed`: claude's extractor surfaces
@@ -429,6 +448,7 @@ func (b *Bridge) Run(ctx context.Context) error {
 			}
 			b.reconcileMirrorSize()
 			b.screen.Feed(chunk)
+			dismissSurvey()
 			reply, _ := ext.OnOutput()
 			det.Observe(time.Now(), b.screen, len(chunk) > 0)
 			if err := b.onProgress(ctx, reply.Text, ts); err != nil {
@@ -444,6 +464,7 @@ func (b *Bridge) Run(ctx context.Context) error {
 			// No new bytes: re-check the boundary so a turn that ended on a quiet
 			// screen (the settle window elapsing after the last chunk) is still
 			// detected without waiting for the next unrelated chunk.
+			dismissSurvey()
 			det.Observe(time.Now(), b.screen, false)
 			reply, _ := ext.OnOutput()
 			if spoke, err := b.maybeSpeak(ctx, det, reply.Text, ts); err != nil {
@@ -454,6 +475,17 @@ func (b *Bridge) Run(ctx context.Context) error {
 		}
 	}
 }
+
+// surveyMarker is claude's periodic, input-BLOCKING session-feedback overlay
+// ("● How is Claude doing this session? (optional) / 1: Bad 2: Fine 3: Good
+// 0: Dismiss"). Left up it eats the next injected transcript, so the turn never
+// runs and the device gets no reply / no TTS (observed: it wedged the line for
+// minutes until every turn timed out). surveyDismissKey is its "0: Dismiss"
+// option; we press it whenever the overlay appears so the prompt stays clear.
+const (
+	surveyMarker     = "How is Claude doing this session"
+	surveyDismissKey = "0"
+)
 
 const (
 	// warmupTimeout bounds warmup so a CLI that never reaches an idle prompt can't


### PR DESCRIPTION
真机\"完全没有 TTS\":claude 周期性弹出**阻塞输入**的反馈弹窗——\"● How is Claude doing this session? (optional) / 1: Bad 2: Fine 3: Good 0: Dismiss\"。它在时,注入的转写落进弹窗而不是开新轮 → claude 不回复 → 设备没回复/没 TTS(真机被卡了好几分钟,一句\"你好\"都 90s 超时)。这跟 warmup 的信任弹窗一样,是 claude TUI 中断,adapter 必须清掉。

Bridge.Run 现在一检测到弹窗就按 \"0: Dismiss\"(每次出现只按一次,离屏后才重新武装,避免往 prompt 里狂塞键)。每次屏幕更新都查(PTY chunk + 轮询)。ADAPTER_V2_DEBUG_EXTRACT 打印每次关闭。

(与云端 barge-in 无关——那个是好的;是 claude 自己卡住了。)build + deviceapi 测试绿。Epic #192。

🤖 Generated with [Claude Code](https://claude.com/claude-code)