### PR TITLE
feat(adapter_v2): 设备线 tool_call 进度显示(ADR-030 移植,只显示不念)

### DIFF
--- a/adapter_v2/internal/cloudrelay/transcript.go
+++ b/adapter_v2/internal/cloudrelay/transcript.go
@@ -367,6 +367,26 @@ func (e *cloudEvents) forwardDelta(text string) {
 // ReplyDelta streams the growing reply as a monotonic voice.reply.delta.
 func (e *cloudEvents) ReplyDelta(text string) { e.forwardDelta(text) }
 
+// ToolStep forwards a DISPLAY-ONLY tool_call event to the cloud, which relays it to
+// the device as a dimmed progress chip (ADR-030) — never TTS'd. Discrete events:
+// no prefix-monotonic gate (unlike forwardDelta) and no dedup (the Bridge already
+// deduped per turn). The same active/write guard as forwardDelta drops a late step
+// after end().
+func (e *cloudEvents) ToolStep(name, hint string) {
+	e.mu.Lock()
+	if !e.active || e.write == nil {
+		e.mu.Unlock()
+		return
+	}
+	w, env, home := e.write, e.env, e.homeSite
+	e.mu.Unlock()
+	_ = w(Envelope{
+		Type: "event", MessageID: env.MessageID, DeviceID: env.DeviceID,
+		HomeSiteID: home, Kind: "tool_call",
+		Payload: map[string]any{"type": "tool_call", "name": name, "hint": hint},
+	})
+}
+
 // ReplyComplete records the authoritative final reply text and forwards the final
 // tail when it extends the last snapshot (covering the whole reply in the common
 // append-only case; see the `sent` field doc for the mid-string-divergence

--- a/adapter_v2/internal/deviceapi/deviceapi.go
+++ b/adapter_v2/internal/deviceapi/deviceapi.go
@@ -141,6 +141,11 @@ type Events interface {
 	// ReplyComplete reports the final reply text of a turn, before it is spoken.
 	// The transport emits its reply.end frame here.
 	ReplyComplete(text string)
+	// ToolStep reports a NEW tool invocation claude started mid-turn (Bash, Edit,
+	// …) for DISPLAY-ONLY device progress (ADR-030): a dimmed "Bash: …" chip. It is
+	// NEVER spoken — TTS is driven solely by the prose reply. Emitted at most once
+	// per distinct {name,hint} per turn (deduped in Run). nil Events: no-op.
+	ToolStep(name, hint string)
 	// TurnIdle reports the turn is fully done (spoken) and the device may PTT
 	// again. The transport emits its turn{idle} frame here.
 	TurnIdle()
@@ -451,6 +456,7 @@ func (b *Bridge) Run(ctx context.Context) error {
 			dismissSurvey()
 			reply, _ := ext.OnOutput()
 			det.Observe(time.Now(), b.screen, len(chunk) > 0)
+			b.emitToolSteps(ts) // display-only tool progress (ADR-030); only on a new paint
 			if err := b.onProgress(ctx, reply.Text, ts); err != nil {
 				return err
 			}
@@ -572,9 +578,31 @@ func isTrustPrompt(visible string) bool {
 // been pushed as a delta, and what text has already been spoken sentence-by-
 // sentence. Reset at the start of every turn.
 type turnStream struct {
-	seed      string // the prior turn's reply, still on screen until this turn paints; suppressed by onProgress
-	lastDelta string // last full reply text emitted via Events.ReplyDelta
-	spoken    string // reply prefix already synthesised by per-segment TTS
+	seed      string              // the prior turn's reply, still on screen until this turn paints; suppressed by onProgress
+	lastDelta string              // last full reply text emitted via Events.ReplyDelta
+	spoken    string              // reply prefix already synthesised by per-segment TTS
+	steps     map[string]struct{} // tool steps already emitted this turn (dedup); reset per turn via rebaseline
+}
+
+// emitToolSteps scans the screen for claude's tool-step bullets and emits a
+// DISPLAY-ONLY ToolStep for each NEW {name,hint} this turn (deduped via ts.steps).
+// No audio — progress only. Called per PTY paint; the dedup makes repeated repaints
+// of the same step emit once.
+func (b *Bridge) emitToolSteps(ts *turnStream) {
+	if b.events == nil {
+		return
+	}
+	for _, st := range extract.ScanToolSteps(b.screen.VisibleText()) {
+		key := st.Name + "\x00" + st.Hint
+		if ts.steps == nil {
+			ts.steps = map[string]struct{}{}
+		}
+		if _, seen := ts.steps[key]; seen {
+			continue
+		}
+		ts.steps[key] = struct{}{}
+		b.events.ToolStep(st.Name, st.Hint)
+	}
 }
 
 // onProgress runs the Phase B streaming side-effects on each extraction advance:

--- a/adapter_v2/internal/deviceapi/streaming_test.go
+++ b/adapter_v2/internal/deviceapi/streaming_test.go
@@ -4,7 +4,34 @@ import (
 	"context"
 	"sync"
 	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/vtscreen"
 )
+
+// TestEmitToolStepsDedupAndDisplayOnly: tool-step bullets on screen produce one
+// display-only ToolStep per distinct {name,hint} per turn (deduped across repaints),
+// and never enter the reply/audio path.
+func TestEmitToolStepsDedupAndDisplayOnly(t *testing.T) {
+	ev := &recordingEvents{}
+	b := &Bridge{screen: vtscreen.New(80, 24), events: ev}
+	ts := &turnStream{}
+
+	b.screen.Feed([]byte("\x1b[3;1H⏺ Bash(df -h)\r\n"))
+	b.emitToolSteps(ts)
+	b.emitToolSteps(ts) // same screen repaint → deduped, no second emit
+	if len(ev.tools) != 1 || ev.tools[0] != "Bash|df -h" {
+		t.Fatalf("want one ToolStep Bash|df -h, got %v", ev.tools)
+	}
+
+	b.screen.Feed([]byte("\x1b[4;1H⏺ Read(main.go)\r\n"))
+	b.emitToolSteps(ts)
+	if len(ev.tools) != 2 || ev.tools[1] != "Read|main.go" {
+		t.Fatalf("want second ToolStep Read|main.go, got %v", ev.tools)
+	}
+	if len(ev.deltas) != 0 || len(ev.complete) != 0 {
+		t.Errorf("tool steps must not touch the reply/audio path: deltas=%v complete=%v", ev.deltas, ev.complete)
+	}
+}
 
 func TestNextSentence(t *testing.T) {
 	cases := []struct {
@@ -33,12 +60,18 @@ type recordingEvents struct {
 	mu       sync.Mutex
 	deltas   []string
 	complete []string
+	tools    []string // "name|hint" per ToolStep
 	idles    int
 }
 
 func (e *recordingEvents) ReplyDelta(text string)    { e.mu.Lock(); e.deltas = append(e.deltas, text); e.mu.Unlock() }
 func (e *recordingEvents) ReplyComplete(text string) { e.mu.Lock(); e.complete = append(e.complete, text); e.mu.Unlock() }
-func (e *recordingEvents) TurnIdle()                 { e.mu.Lock(); e.idles++; e.mu.Unlock() }
+func (e *recordingEvents) ToolStep(name, hint string) {
+	e.mu.Lock()
+	e.tools = append(e.tools, name+"|"+hint)
+	e.mu.Unlock()
+}
+func (e *recordingEvents) TurnIdle() { e.mu.Lock(); e.idles++; e.mu.Unlock() }
 
 // TestOnProgressStreamsDeltas: with StreamReplyDelta on, each new reply snapshot
 // fires one ReplyDelta; unchanged text does not; blank text is suppressed.

--- a/adapter_v2/internal/devicews/frames.go
+++ b/adapter_v2/internal/devicews/frames.go
@@ -149,6 +149,17 @@ type replyDelta struct {
 	Text   string `json:"text"`
 }
 
+// toolStep is a DISPLAY-ONLY tool-progress frame (ADR-030): the device shows it as
+// a dimmed "name: hint" chip and never plays it as audio. Its own per-turn seq,
+// independent of reply.delta's.
+type toolStep struct {
+	T      string `json:"t"`
+	TurnID string `json:"turnId"`
+	Seq    uint16 `json:"seq"`
+	Name   string `json:"name"`
+	Hint   string `json:"hint,omitempty"`
+}
+
 type replyEnd struct {
 	T      string `json:"t"`
 	TurnID string `json:"turnId"`

--- a/adapter_v2/internal/devicews/server.go
+++ b/adapter_v2/internal/devicews/server.go
@@ -128,6 +128,7 @@ type deviceConn struct {
 	curU      uint16
 	dnSeq     uint16 // downlink TTS frame counter, reset per turn
 	deltaSeq  uint16 // reply.delta sequence counter, reset per turn
+	toolSeq   uint16 // tool.step sequence counter, reset per turn (independent of deltaSeq)
 }
 
 // tryBeginCapture opens a new turn iff the connection is idle, recording its
@@ -139,7 +140,7 @@ func (c *deviceConn) tryBeginCapture(turnID string, u uint16) bool {
 		return false
 	}
 	c.fsm = connCapturing
-	c.curTurnID, c.curU, c.dnSeq, c.deltaSeq = turnID, u, 0, 0
+	c.curTurnID, c.curU, c.dnSeq, c.deltaSeq, c.toolSeq = turnID, u, 0, 0, 0
 	return true
 }
 
@@ -230,6 +231,16 @@ func (c *deviceConn) ReplyDelta(text string) {
 func (c *deviceConn) ReplyComplete(text string) {
 	turnID, _ := c.turn()
 	_ = c.writeCtrl(replyEnd{T: "reply.end", TurnID: turnID, Text: text})
+}
+
+// ToolStep implements deviceapi.Events: a display-only tool-progress frame
+// (tool.step). Shown as a dimmed chip on the device; never spoken.
+func (c *deviceConn) ToolStep(name, hint string) {
+	c.mu.Lock()
+	turnID, seq := c.curTurnID, c.toolSeq
+	c.toolSeq++
+	c.mu.Unlock()
+	_ = c.writeCtrl(toolStep{T: "tool.step", TurnID: turnID, Seq: seq, Name: name, Hint: hint})
 }
 
 // TurnIdle implements deviceapi.Events: the turn is fully spoken → turn{idle},

--- a/adapter_v2/internal/extract/extract.go
+++ b/adapter_v2/internal/extract/extract.go
@@ -152,7 +152,9 @@ func extractMarkerBlock(visible string) (string, bool) {
 		// workspace", "⏺ ⏵⏵ bypass permissions on … ← for agents". Their content is
 		// noise (isStatusLine), so anchoring on them would speak the model/usage
 		// footer instead of the reply. Skip them; the last REAL reply marker wins.
-		if isNoiseLine(stripReplyMarker(strings.TrimRight(l, " \t"))) {
+		// Likewise a "⏺ Name(args)" TOOL step is not prose — anchoring on it would
+		// speak "Bash curl …" (it's surfaced separately as display-only progress).
+		if isNoiseLine(stripReplyMarker(strings.TrimRight(l, " \t"))) || isToolStep(l) {
 			continue
 		}
 		last = i

--- a/adapter_v2/internal/extract/toolstep.go
+++ b/adapter_v2/internal/extract/toolstep.go
@@ -1,0 +1,107 @@
+package extract
+
+import "strings"
+
+// toolstep.go scrapes claude's tool-invocation bullets ("⏺ Name(args)") from the
+// visible grid so the device can show DISPLAY-ONLY progress (ADR-030): a dimmed
+// "Bash: …" chip while a turn runs. Tool steps are NEVER spoken — TTS is driven
+// solely by the prose reply. The detection rule is deliberately strict so a normal
+// prose reply ("⏺ The answer is …", "⏺ 你好") is never mistaken for a tool step
+// (which would also wrongly drop it from the spoken reply — see extract.go's
+// extractMarkerBlock guard).
+
+// ToolStep is one claude tool invocation: Name is the tool ("Bash"/"Edit"/…),
+// Hint the short argument preview (the parenthesised content, truncated).
+type ToolStep struct {
+	Name string
+	Hint string
+}
+
+// toolHintMax bounds the parenthesised hint (rune-safe) so a long command can't
+// bloat the device chip or a cloud frame.
+const toolHintMax = 80
+
+// isToolStep reports whether a raw grid line is a tool-step bullet.
+func isToolStep(rawLine string) bool {
+	_, ok := parseToolStep(rawLine)
+	return ok
+}
+
+// parseToolStep extracts {Name, Hint} from a "⏺ Name(args)" line, or ok=false.
+// The discriminator is a TitleCase ASCII identifier IMMEDIATELY followed by "("
+// (no space): "⏺ Bash(curl …)" → {Bash, "curl …"}; "⏺ The capital is Paris."
+// fails (space after "The", and no "("); "⏺ 你好" fails (CJK, no "("); "⏺ [Opus
+// …]" fails ("[" not A-Z). Hint runs from the first "(" to the last ")", or to
+// end-of-line when the closing ")" scrolled off the 80-col grid (we do NOT require
+// it). A blank hint is rejected.
+func parseToolStep(rawLine string) (ToolStep, bool) {
+	t := strings.TrimLeft(rawLine, " ")
+	if !strings.HasPrefix(t, replyMarker) {
+		return ToolStep{}, false
+	}
+	body := stripReplyMarker(strings.TrimRight(t, " \t"))
+	open := strings.IndexByte(body, '(')
+	if open <= 0 { // no "(", or "(" at the very start (e.g. "(earlier) …")
+		return ToolStep{}, false
+	}
+	name := body[:open]
+	if !isToolName(name) {
+		return ToolStep{}, false
+	}
+	rest := body[open+1:]
+	hint := rest
+	if c := strings.LastIndexByte(rest, ')'); c >= 0 {
+		hint = rest[:c]
+	}
+	hint = strings.TrimSpace(hint)
+	if hint == "" {
+		return ToolStep{}, false
+	}
+	return ToolStep{Name: name, Hint: truncateRunes(hint, toolHintMax)}, true
+}
+
+// isToolName reports whether s is a TitleCase ASCII tool identifier: A-Z then
+// zero+ ASCII letters/digits, nothing else. Strict on purpose so prose openers
+// ("The", "I'll") and chrome never match. MCP tools (mcp__foo__bar) intentionally
+// don't match yet — they'd simply not show, never mis-speak.
+func isToolName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if r < 'A' || r > 'Z' {
+				return false
+			}
+			continue
+		}
+		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')) {
+			return false
+		}
+	}
+	return true
+}
+
+// ScanToolSteps returns every tool step on the visible grid, in screen order.
+func ScanToolSteps(visible string) []ToolStep {
+	if visible == "" {
+		return nil
+	}
+	var out []ToolStep
+	for _, line := range strings.Split(visible, "\n") {
+		if st, ok := parseToolStep(line); ok {
+			out = append(out, st)
+		}
+	}
+	return out
+}
+
+// truncateRunes caps s to n runes (rune-safe — never splits a multibyte rune),
+// appending an ellipsis when it truncates.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}

--- a/adapter_v2/internal/extract/toolstep_test.go
+++ b/adapter_v2/internal/extract/toolstep_test.go
@@ -1,0 +1,93 @@
+package extract
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/vtscreen"
+)
+
+func TestParseToolStep(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		wantOK   bool
+		wantName string
+		wantHint string
+	}{
+		{"bash", "⏺ Bash(curl -s https://api.ipify.org)", true, "Bash", "curl -s https://api.ipify.org"},
+		{"edit", "⏺ Edit(src/main.go)", true, "Edit", "src/main.go"},
+		{"indented continuation marker", "  ⏺ Read(main.go)", true, "Read", "main.go"},
+		{"truncated no close paren", "⏺ Bash(for d in ~/gitee ~/github ~/Gitee", true, "Bash", "for d in ~/gitee ~/github ~/Gitee"},
+
+		{"cjk prose", "⏺ 你好你好,我在呢!", false, "", ""},
+		{"english prose", "⏺ The capital of France is Paris.", false, "", ""},
+		{"prose no paren", "⏺ I'll run the command now", false, "", ""},
+		{"prose with spaced paren", "⏺ Paris (the capital) is lovely.", false, "", ""},
+		{"chrome model status", "⏺ [Opus 4.8 (1M context)] │ workspace", false, "", ""},
+		{"paren at start", "⏺ (earlier) 2 + 2 = 4.", false, "", ""},
+		{"result body line", "  ⎿  +7 lines (ctrl+o to expand)", false, "", ""},
+		{"blank hint", "⏺ Bash()", false, "", ""},
+		{"no marker", "Bash(ls)", false, "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st, ok := parseToolStep(tc.line)
+			if ok != tc.wantOK {
+				t.Fatalf("parseToolStep(%q) ok=%v, want %v (got %+v)", tc.line, ok, tc.wantOK, st)
+			}
+			if ok && (st.Name != tc.wantName || st.Hint != tc.wantHint) {
+				t.Errorf("parseToolStep(%q) = {%q,%q}, want {%q,%q}", tc.line, st.Name, st.Hint, tc.wantName, tc.wantHint)
+			}
+		})
+	}
+}
+
+func TestScanToolStepsPreservesOrder(t *testing.T) {
+	visible := "⏺ Read(a.go)\n  ⎿  120 lines\n⏺ Bash(go build ./...)\n⏺ 你好,做完了。\n❯ \n"
+	steps := ScanToolSteps(visible)
+	if len(steps) != 2 {
+		t.Fatalf("want 2 tool steps, got %d: %+v", len(steps), steps)
+	}
+	if steps[0].Name != "Read" || steps[1].Name != "Bash" {
+		t.Errorf("order/names wrong: %+v", steps)
+	}
+}
+
+func TestToolHintRuneSafeTruncation(t *testing.T) {
+	hint := strings.Repeat("字", 100) // 100 CJK runes (300 bytes)
+	st, ok := parseToolStep("⏺ Bash(" + hint + ")")
+	if !ok {
+		t.Fatal("expected a tool step")
+	}
+	r := []rune(st.Hint)
+	if len(r) > toolHintMax+1 { // +1 for the appended ellipsis
+		t.Errorf("hint not truncated: %d runes", len(r))
+	}
+	// Truncation must be rune-safe: every rune valid (no split multibyte).
+	for _, c := range st.Hint {
+		if c == '�' {
+			t.Fatalf("truncation split a multibyte rune: %q", st.Hint)
+		}
+	}
+}
+
+// Regression: when the LAST "⏺" on screen is a TOOL step, the spoken reply must be
+// the EARLIER prose block, not the tool text — otherwise the device would speak
+// "Bash df -h" instead of the answer.
+func TestExtractMarkerBlockSkipsTrailingToolStep(t *testing.T) {
+	s := vtscreen.New(80, 24)
+	ext := New(s)
+	s.Feed([]byte("\x1b[1;1H" +
+		"⏺ 好的,我帮你看磁盘。\r\n" + // prose reply (earlier)
+		"⏺ Bash(df -h)\r\n" + // tool step (later, last ⏺)
+		"  ⎿  Running…\r\n" +
+		"❯ \r\n"))
+	r, _ := ext.OnOutput()
+	if !strings.Contains(r.Text, "好的,我帮你看磁盘") {
+		t.Errorf("expected the prose reply, got %q", r.Text)
+	}
+	if strings.Contains(r.Text, "Bash") || strings.Contains(r.Text, "df -h") {
+		t.Errorf("tool step leaked into the spoken reply: %q", r.Text)
+	}
+}


### PR DESCRIPTION
设备线之前只有纯文本+语音,长工具轮期间用户什么都看不到、只能干等。本改动把 claude 的工具步骤作为**只显示不念**的进度 chip(\"Bash: df -h\")露出来:TTS 仍只由正文回复驱动(ADR-030,帧类型即\"念/显示\"标记)。

- **extract/toolstep.go(新)**:ScanToolSteps 识别 \"⏺ Name(args)\" 工具行——TitleCase 标识符**紧跟**\"(\"(无空格),取 {Name,Hint}。无空格规则是判别器,让正文(\"⏺ The capital…\"、\"⏺ 你好\")和 chrome(\"⏺ [Opus…]\")不误判。Hint 到最后一个 \")\" 或行尾(右括号可能被 80 列截断),rune 安全截断到 80。
- **extract.go**:extractMarkerBlock 选回复锚点时也跳过工具步骤 ⏺——顺手修个潜伏 bug:工具步骤若是屏上最后一个 ⏺ 会被当回复念成\"Bash df -h\"。
- **deviceapi**:Events 加 ToolStep;Bridge.emitToolSteps 每次 PTY 重绘扫描,每轮每个新 {name,hint} 发一次(turnStream.steps 去重)。cloudrelay 转 {type:tool_call,name,hint} 事件;devicews 发 tool.step 帧。
- **云端(另一 PR)**:透传 hint(原先丢)。固件已按 ADR-030 只显示不念渲染 tool_call{name,hint},**不用改**。

**范围**:捕获 80x24 可见网格上的工具步骤——即**慢工具**(\"⏺ Bash(…) ⎿ Running…\" 在等待期间留屏,正是设备线要的长轮进度场景)。瞬时工具(ls/echo)在重绘间滚走不显示——可接受:它们本就不造成等待。设计上只显示/尽力而为。

**真 claude 验证**:`sleep 4 && echo` 轮发出 ToolStep{Bash, sleep 4 && echo SLOWDONE},而念出的回复仍是正文。单测(判别规则含 CJK/正文/chrome/截断 + extractMarkerBlock 回归 + 去重)+ 全量 + race + e2e 绿。待办 #2。ADR-030。

🤖 Generated with [Claude Code](https://claude.com/claude-code)