### PR TITLE
fix(adapter_v2/extract): 回复尾巴去掉换行的 token 计数器残片

### DIFF
--- a/adapter_v2/internal/extract/noise.go
+++ b/adapter_v2/internal/extract/noise.go
@@ -81,6 +81,11 @@ func isStatusLine(t string) bool {
 		return true // "[Opus 4.8 (1M context)] │ …" model status
 	case strings.Contains(t, "for agents"):
 		return true // "… ← for agents" footer hint
+	case strings.Contains(t, "tokens") && (strings.HasSuffix(t, "tokens)") ||
+		strings.ContainsRune(t, '↑') || strings.ContainsRune(t, '↓') || strings.Contains(t, "·")):
+		return true // token-counter fragment ("38 tokens)", "↑ 1.2k tokens · …") —
+		// the completion summary's counter wraps onto its own flush-left line and
+		// would otherwise leak onto the end of the spoken reply.
 	}
 	return false
 }

--- a/adapter_v2/internal/extract/noise_test.go
+++ b/adapter_v2/internal/extract/noise_test.go
@@ -25,6 +25,10 @@ func TestIsNoiseLine(t *testing.T) {
 		{"spinner glyph dropped by emulator", "Cogitating… (3s · esc to interrupt)", true},
 		{"api retry wait", "Waiting for API response · will retry in 2m 26s · check your network", true},
 		{"api retry short", "· will retry in 30s ·", true},
+		{"token counter tail", "38 tokens)", true},
+		{"token counter with arrow", "↑ 1.2k tokens", true},
+		{"token counter with sep", "38 tokens · esc to interrupt", true},
+		{"reply mentioning tokens (not chrome)", "你的余额还有 100 tokens 可用", false},
 
 		{"box top border", "╭──────────────╮", true},
 		{"box bottom border", "╰──────────────╯", true},


### PR DESCRIPTION
claude 完成摘要的 token 计数器(\"↑ 38 tokens · …\")换行到独立顶格行,被 extractMarkerBlock 当回复续行捕获——短回复尾巴被加上\"… 38 tokens)\"念出来。isStatusLine 现在把 token 计数器残片当噪声:含 \"tokens\" 且 以 \"tokens)\" 结尾 / 带 ↑↓ 计数符 / 带 \"·\" 分隔。正文里普通提到 \"tokens\" 不误判。测试已加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)