### PR TITLE
feat(adapter_v2): agent.messages 返回真实对话历史(ADR-032 P3 adapter 半)

### DIFF
--- a/adapter_v2/internal/butler/session.go
+++ b/adapter_v2/internal/butler/session.go
@@ -136,6 +136,107 @@ func (d *DeviceSession) List() ([]ConversationInfo, error) {
 	return listConversations(d.cwd)
 }
 
+// ConversationMessage is one rendered turn for the device/web history view
+// (agent.messages). content is plain text — rows that carry only a tool_use /
+// tool_result / thinking block (no speakable text) are dropped.
+type ConversationMessage struct {
+	Role      string // "user" | "assistant"
+	Content   string // plain text
+	Timestamp string // RFC3339 if the .jsonl row has one
+	Seq       int    // chronological index (0-based) over the kept messages
+}
+
+// messageContentMax caps a single message's text (rune-safe) for the small device
+// screen / PSRAM.
+const messageContentMax = 4096
+
+// Messages parses a conversation's claude .jsonl into rendered messages, in
+// chronological order. A missing file (or unknown encoding) yields an empty slice,
+// not an error — the device shows a blank history rather than failing.
+func (d *DeviceSession) Messages(id string) ([]ConversationMessage, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, nil
+	}
+	dir := claudeProjectDir(d.cwd)
+	if dir == "" {
+		return nil, nil
+	}
+	f, err := os.Open(filepath.Join(dir, id+".jsonl"))
+	if err != nil {
+		return nil, nil // missing conversation => empty page
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024) // assistant turns can be large
+	var out []ConversationMessage
+	for sc.Scan() {
+		var rec struct {
+			Type      string `json:"type"`
+			Timestamp string `json:"timestamp"`
+			Message   struct {
+				Role    string          `json:"role"`
+				Content json.RawMessage `json:"content"`
+			} `json:"message"`
+		}
+		if json.Unmarshal(sc.Bytes(), &rec) != nil {
+			continue
+		}
+		role := rec.Message.Role
+		if role == "" {
+			role = rec.Type
+		}
+		if role != "user" && role != "assistant" {
+			continue
+		}
+		// firstText returns "" for tool_result / tool_use / thinking-only content,
+		// so reusing it drops exactly the non-speakable rows.
+		text := firstText(rec.Message.Content)
+		if text == "" {
+			continue
+		}
+		out = append(out, ConversationMessage{
+			Role:      role,
+			Content:   capRunes(text, messageContentMax),
+			Timestamp: rec.Timestamp,
+			Seq:       len(out),
+		})
+	}
+	return out, nil
+}
+
+// PageMessages returns a backward page of msgs (0-indexed chronological): before<=0
+// is the newest page (ending at total); else end=min(before,total), start=
+// max(0,end-limit). hasMore reports older messages remain. limit is clamped to
+// [1,200] (default 50).
+func PageMessages(all []ConversationMessage, before, limit int) (page []ConversationMessage, total int, hasMore bool) {
+	total = len(all)
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	end := total
+	if before > 0 && before < total {
+		end = before
+	}
+	start := end - limit
+	if start < 0 {
+		start = 0
+	}
+	return all[start:end], total, start > 0
+}
+
+// capRunes hard-caps s to n runes (rune-safe).
+func capRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
+}
+
 // ConversationInfo is one claude conversation for the device's history picker.
 type ConversationInfo struct {
 	ID         string // claude session uuid

--- a/adapter_v2/internal/butler/session_test.go
+++ b/adapter_v2/internal/butler/session_test.go
@@ -60,6 +60,76 @@ func TestDeviceSessionConfigResumeModes(t *testing.T) {
 	}
 }
 
+func TestDeviceSessionMessages(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := "/Users/x/.bbclaw-adapter/workspace"
+	dir := claudeProjectDir(cwd)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Mixed rows: a plain user turn, a user tool_result (no text → dropped), an
+	// assistant text turn, and an assistant thinking-only turn (dropped).
+	lines := []string{
+		`{"type":"user","timestamp":"2026-06-23T00:00:01Z","message":{"role":"user","content":"问题一"}}`,
+		`{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"junk"}]}}`,
+		`{"type":"assistant","timestamp":"2026-06-23T00:00:02Z","message":{"role":"assistant","content":[{"type":"text","text":"回答一"}]}}`,
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"hmm"}]}}`,
+	}
+	body := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "conv-1.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewDeviceSession(session.NewManager(), []string{"claude"}, cwd)
+	msgs, err := d.Messages("conv-1")
+	if err != nil {
+		t.Fatalf("Messages: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("want 2 speakable messages (tool_result + thinking dropped), got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != "user" || msgs[0].Content != "问题一" || msgs[0].Seq != 0 {
+		t.Errorf("msg0 wrong: %+v", msgs[0])
+	}
+	if msgs[1].Role != "assistant" || msgs[1].Content != "回答一" || msgs[1].Seq != 1 {
+		t.Errorf("msg1 wrong: %+v", msgs[1])
+	}
+	if msgs[1].Timestamp != "2026-06-23T00:00:02Z" {
+		t.Errorf("timestamp not parsed: %q", msgs[1].Timestamp)
+	}
+	// Missing conversation → empty page, not an error.
+	if m, err := d.Messages("nope"); err != nil || len(m) != 0 {
+		t.Errorf("missing conversation should be empty: %v %v", m, err)
+	}
+}
+
+func TestPageMessages(t *testing.T) {
+	mk := func(n int) []ConversationMessage {
+		out := make([]ConversationMessage, n)
+		for i := range out {
+			out[i] = ConversationMessage{Seq: i}
+		}
+		return out
+	}
+	all := mk(10)
+	// Newest page (before<=0): last `limit`.
+	page, total, more := PageMessages(all, 0, 4)
+	if total != 10 || len(page) != 4 || page[0].Seq != 6 || !more {
+		t.Errorf("newest page wrong: total=%d len=%d first=%d more=%v", total, len(page), page[0].Seq, more)
+	}
+	// Backward page ending before seq 6 → seqs 2..5.
+	page, _, more = PageMessages(all, 6, 4)
+	if len(page) != 4 || page[0].Seq != 2 || page[3].Seq != 5 || !more {
+		t.Errorf("backward page wrong: %+v more=%v", page, more)
+	}
+	// Reaching the start → no more.
+	page, _, more = PageMessages(all, 3, 10)
+	if len(page) != 3 || page[0].Seq != 0 || more {
+		t.Errorf("start page wrong: %+v more=%v", page, more)
+	}
+}
+
 func TestDeviceSessionList(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/adapter_v2/internal/cloudrelay/proxy.go
+++ b/adapter_v2/internal/cloudrelay/proxy.go
@@ -43,9 +43,33 @@ func (r *Relay) handleAgentProxy(write func(Envelope) error, env Envelope) bool 
 			"drivers": []map[string]any{{"name": proxyDriver, "capabilities": driverCaps()}},
 		})
 	case "agent.messages":
-		// Empty history — the PTY is the source of truth, not a message store.
+		// Real conversation history (ADR-032 P3): parse the requested session's
+		// claude .jsonl. Empty sessionId defaults to the active conversation. The
+		// firmware/web reads content as a STRING under key "content".
+		var p struct {
+			SessionID string `json:"sessionId"`
+			Before    int    `json:"before"`
+			Limit     int    `json:"limit"`
+		}
+		raw, _ := json.Marshal(env.Payload)
+		_ = json.Unmarshal(raw, &p)
+		sid := strings.TrimSpace(p.SessionID)
+		if sid == "" {
+			sid = r.devActiveID()
+		}
+		var all []butler.ConversationMessage
+		if r.dev != nil && sid != "" {
+			all, _ = r.dev.Messages(sid)
+		}
+		page, total, hasMore := butler.PageMessages(all, p.Before, p.Limit)
+		msgs := make([]map[string]any, 0, len(page))
+		for _, m := range page {
+			msgs = append(msgs, map[string]any{
+				"role": m.Role, "content": m.Content, "timestamp": m.Timestamp, "seq": m.Seq,
+			})
+		}
 		return reply("agent.messages.reply", map[string]any{
-			"messages": []any{}, "total": 0, "hasMore": false,
+			"messages": msgs, "total": total, "hasMore": hasMore,
 		})
 	case "agent.sessions", "agent.sessions.list.logical":
 		// Real conversation history (ADR-032): the workspace's claude .jsonl files,


### PR DESCRIPTION
agent.messages 原是空 stub,设备/web 历史视图永远空白。现在解析对应会话的 claude .jsonl 成渲染消息。

- DeviceSession.Messages(id):开 <workspace>/<id>.jsonl,保留有可读文本的 user/assistant 行(复用 firstText——它对 tool_result/tool_use/thinking-only 返回空,正好丢掉这些行),每条 cap 4096 runes,4MB scanner 容纳长回复。
- PageMessages:向后分页(before/limit,clamp [1,200],hasMore)。
- proxy.go agent.messages:解析 {sessionId,before,limit};空 sessionId 默认 active 会话;回 {messages:[{role,content,timestamp,seq}],total,hasMore}——content 是 \"content\" 键的字符串(固件丢非字符串)。

**可直接部署,不刷机、云端零改**(云端已转发 agent.messages,固件客户端已会读这个形状)。P2 设备会话菜单 + P3 chat-cache NVS key 隔离是固件,下次刷机。

单测(混合行过滤/分页/缺文件→空)+ 全量 + race 绿。待办 #4(adapter 半)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)