### PR TITLE
feat(firmware): 设备会话菜单 + WS 切换/新建传输 + 按会话缓存隔离(ADR-032 P2/P3)

### DIFF
--- a/firmware/include/bb_adapter_client.h
+++ b/firmware/include/bb_adapter_client.h
@@ -136,6 +136,19 @@ esp_err_t bb_adapter_client_send_text(const char* payload);
  * Duplicate requests while one is still in flight are coalesced. */
 esp_err_t bb_adapter_request_turn_cancel(const char* played_text);
 
+/* adapter_v2 P2 — device-driven session switch / create (cloud_saas only).
+ *
+ * Voice always routes to the adapter's DEFAULT session. When the device
+ * selects or creates a conversation it must tell the adapter to respawn to
+ * that session via a WS request (kinds agent.sessions.activate /
+ * agent.sessions.create, relayed pass-through by the cloud; the adapter does
+ * Resume(id)/New() = respawn). Both are fire-and-forget: the WS send runs on a
+ * short-lived PSRAM-stack task so these are safe to call from the LVGL thread
+ * and never block. Duplicate requests while one is in flight are coalesced.
+ * No-op (returns ESP_OK) when not in cloud_saas mode. */
+esp_err_t bb_adapter_request_session_activate(const char* session_id);
+esp_err_t bb_adapter_request_session_new(void);
+
 /* ADR-028 §2.5.1 barge-in — abort the local finish-stream wait immediately.
  *
  * bb_adapter_stream_finish_stream() blocks up to BBCLAW_HTTP_STREAM_FINISH_TIMEOUT_MS

--- a/firmware/include/bb_ui_agent_chat.h
+++ b/firmware/include/bb_ui_agent_chat.h
@@ -255,6 +255,34 @@ void bb_ui_agent_chat_post_session(const char* sid, const char* driver);
 const char* bb_ui_agent_chat_get_current_driver(void);
 
 /**
+ * adapter_v2 P2 — current session id (or "" when none).
+ * Used by the Sessions picker to mark the active conversation.
+ */
+const char* bb_ui_agent_chat_get_current_session(void);
+
+/**
+ * adapter_v2 P2 — start a brand-new conversation from the Sessions picker.
+ *
+ * Fires the WS agent.sessions.create request (adapter respawns to a fresh
+ * session so voice routes there), drops the local session id, and clears the
+ * transcript cache. The adapter mints the new id; the next turn's SESSION
+ * frame persists it. Caller must hold the LVGL lock.
+ */
+esp_err_t bb_ui_agent_chat_start_new_session(void);
+
+/**
+ * adapter_v2 P2 — switch the active conversation from the Sessions picker.
+ *
+ * Fires the WS agent.sessions.activate request (adapter Resume(id) → voice
+ * routes to this session), adopts the id locally, clears the transcript cache,
+ * and loads + displays this session's history. `title` is the picker's display
+ * title (may be NULL). Does NOT write NVS (handle_click runs on a PSRAM stack
+ * where that panics); persistence happens on the next SESSION frame. Caller
+ * must hold the LVGL lock. Returns ESP_ERR_INVALID_ARG on a null/empty id.
+ */
+esp_err_t bb_ui_agent_chat_switch_session(const char* id, const char* title);
+
+/**
  * Phase 4.9 — scroll the agent chat transcript by `lines`.
  * lines < 0 scrolls up, lines > 0 scrolls down.
  * Must be called inside the LVGL lock.

--- a/firmware/src/bb_adapter_client.c
+++ b/firmware/src/bb_adapter_client.c
@@ -825,6 +825,98 @@ esp_err_t bb_adapter_request_turn_cancel(const char* played_text) {
   return ESP_OK;
 }
 
+/* ── adapter_v2 P2: device-driven session switch / create (cloud_saas only) ──
+ * Voice always runs the adapter's DEFAULT session, so when the device selects
+ * or creates a conversation it must tell the adapter to respawn to that session
+ * via a WS request (the adapter handles agent.sessions.activate / .create and
+ * the cloud relays them pass-through). Same fire-and-forget pattern as
+ * turn.cancel: build the JSON, ws_send on a one-shot PSRAM-stack task, one
+ * in-flight at a time per kind. */
+
+static volatile int s_session_activate_inflight;
+static volatile int s_session_new_inflight;
+
+static void session_activate_task(void* arg) {
+  char* session_id = (char*)arg; /* heap copy, non-NULL */
+  char* escaped = json_escape_alloc(session_id != NULL ? session_id : "");
+  char body[256];
+  snprintf(body, sizeof(body),
+           "{\"type\":\"request\",\"kind\":\"agent.sessions.activate\",\"messageId\":\"sact-%lld\","
+           "\"deviceId\":\"%s\",\"payload\":{\"sessionId\":\"%s\"}}",
+           (long long)bb_now_ms(), BBCLAW_DEVICE_ID, escaped != NULL ? escaped : "");
+  esp_err_t err = ws_client_ensure_connected();
+  if (err == ESP_OK) {
+    err = ws_send_text_message(body);
+  }
+  ESP_LOGI(TAG, "phase=session_activate_sent err=%s sid='%s'", esp_err_to_name(err),
+           session_id != NULL ? session_id : "");
+  free(escaped);
+  free(session_id);
+  s_session_activate_inflight = 0;
+  vTaskDeleteWithCaps(NULL);
+}
+
+esp_err_t bb_adapter_request_session_activate(const char* session_id) {
+  if (!bb_transport_is_cloud_saas()) {
+    return ESP_OK; /* HTTP path switches sessions per-turn, not via WS */
+  }
+  if (session_id == NULL || session_id[0] == '\0') {
+    return ESP_ERR_INVALID_ARG;
+  }
+  if (s_session_activate_inflight) {
+    return ESP_OK; /* one in-flight activate is enough */
+  }
+  s_session_activate_inflight = 1;
+  char* copy = strdup(session_id);
+  if (copy == NULL) {
+    s_session_activate_inflight = 0;
+    return ESP_ERR_NO_MEM;
+  }
+  /* PSRAM stack — internal DRAM is fragmented in Settings/chat; network IO
+   * runs fine on a PSRAM stack (same rationale as turn_cancel). */
+  if (xTaskCreateWithCaps(session_activate_task, "bb_sess_act", 8192, copy, 5, NULL,
+                          BBCLAW_MALLOC_CAP_PREFER_PSRAM) != pdPASS) {
+    ESP_LOGE(TAG, "session_activate: task spawn failed (no mem) — not sent");
+    free(copy);
+    s_session_activate_inflight = 0;
+    return ESP_ERR_NO_MEM;
+  }
+  return ESP_OK;
+}
+
+static void session_new_task(void* arg) {
+  (void)arg;
+  char body[192];
+  snprintf(body, sizeof(body),
+           "{\"type\":\"request\",\"kind\":\"agent.sessions.create\",\"messageId\":\"snew-%lld\","
+           "\"deviceId\":\"%s\",\"payload\":{}}",
+           (long long)bb_now_ms(), BBCLAW_DEVICE_ID);
+  esp_err_t err = ws_client_ensure_connected();
+  if (err == ESP_OK) {
+    err = ws_send_text_message(body);
+  }
+  ESP_LOGI(TAG, "phase=session_new_sent err=%s", esp_err_to_name(err));
+  s_session_new_inflight = 0;
+  vTaskDeleteWithCaps(NULL);
+}
+
+esp_err_t bb_adapter_request_session_new(void) {
+  if (!bb_transport_is_cloud_saas()) {
+    return ESP_OK;
+  }
+  if (s_session_new_inflight) {
+    return ESP_OK;
+  }
+  s_session_new_inflight = 1;
+  if (xTaskCreateWithCaps(session_new_task, "bb_sess_new", 8192, NULL, 5, NULL,
+                          BBCLAW_MALLOC_CAP_PREFER_PSRAM) != pdPASS) {
+    ESP_LOGE(TAG, "session_new: task spawn failed (no mem) — not sent");
+    s_session_new_inflight = 0;
+    return ESP_ERR_NO_MEM;
+  }
+  return ESP_OK;
+}
+
 static esp_err_t ws_send_binary_message(const uint8_t* data, size_t len) {
   if (data == NULL || len == 0U) {
     return ESP_ERR_INVALID_ARG;

--- a/firmware/src/bb_chat_cache.c
+++ b/firmware/src/bb_chat_cache.c
@@ -62,6 +62,45 @@ static const char* driver_to_key(const char* driver_name) {
   return NULL;
 }
 
+/* P3 (adapter_v2): the persisted NVS key must be sid-aware. With only a
+ * per-driver key ("cc/cc"), two same-driver conversations collide in NVS (last
+ * persisted wins; the other sid-mismatches on hydrate → boots blank). We append
+ * a 6-hex FNV-1a hash of the sid: "cc/cc/<6hex>".
+ *
+ * NVS key length budget (hard limit 15 incl. NUL → 15 usable chars): the
+ * per-driver prefix is 5 chars ("cc/cc") + "/" (1) + 6 hex = 12 chars. Fits.
+ * If a longer per-driver prefix is ever added, the hash width must shrink to
+ * stay <= 15 (asserted at runtime below). A hash (vs the raw sid tail) keeps
+ * the key NVS-char-safe regardless of the sid charset and works for short sids. */
+#define BB_CACHE_SID_HASH_HEX  6
+#define BB_CACHE_KEY_MAX       16  /* 15 usable + NUL */
+
+static uint32_t sid_fnv1a(const char* s) {
+  uint32_t h = 2166136261u;
+  for (; s != NULL && *s != '\0'; ++s) {
+    h ^= (uint8_t)(*s);
+    h *= 16777619u;
+  }
+  return h;
+}
+
+/* Build the sid-aware NVS key into out (>= BB_CACHE_KEY_MAX). Returns 0 on
+ * success, -1 when the driver is unknown or the key would overflow the NVS
+ * 15-char limit. */
+static int build_cache_key(const char* driver_name, const char* sid,
+                           char* out, size_t out_cap) {
+  const char* prefix = driver_to_key(driver_name);
+  if (prefix == NULL || out == NULL || out_cap < BB_CACHE_KEY_MAX) return -1;
+  uint32_t h = sid_fnv1a(sid != NULL ? sid : "");
+  /* "<prefix>/<6 hex of low 24 bits>" */
+  int n = snprintf(out, out_cap, "%s/%06x", prefix, (unsigned)(h & 0xFFFFFFu));
+  if (n < 0 || n > 15) {
+    /* Over the NVS 15-char limit — would be silently rejected by nvs_set_blob. */
+    return -1;
+  }
+  return 0;
+}
+
 /* Bound state. Mutated only on the LVGL task (transcript callbacks). */
 static char s_driver[24];
 static char s_sid[64];
@@ -205,7 +244,10 @@ static void persist_task(void* arg) {
   for (;;) {
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
     persist_payload_t* p = &s_persist_buf;
-    const char* key = driver_to_key(p->driver);
+    /* P3: sid-aware key so two same-driver conversations don't collide. */
+    char keybuf[BB_CACHE_KEY_MAX];
+    const char* key = (build_cache_key(p->driver, p->sid, keybuf, sizeof(keybuf)) == 0)
+                          ? keybuf : NULL;
     if (key != NULL) {
       nvs_handle_t h;
       esp_err_t err = nvs_open(BB_CACHE_NVS_NS, NVS_READWRITE, &h);
@@ -246,8 +288,14 @@ static void schedule_persist(void) {
 /* Read NVS blob for `driver` into s_buf. On success, sets sid_out to the
  * cached sid. */
 static int load_blob(const char* driver, char* sid_out, size_t sid_cap) {
-  const char* key = driver_to_key(driver);
-  if (key == NULL) return -1;
+  /* P3: load the blob for the currently-bound (driver, sid). The bound sid is
+   * s_sid (set by bb_chat_cache_bind before hydrate). Keying by sid means a
+   * different conversation on the same driver lands on a different NVS slot
+   * instead of colliding. The in-blob sid is still checked by the caller's
+   * exact-match hydrate guard. */
+  char keybuf[BB_CACHE_KEY_MAX];
+  if (build_cache_key(driver, s_sid, keybuf, sizeof(keybuf)) != 0) return -1;
+  const char* key = keybuf;
   nvs_handle_t h;
   esp_err_t err = nvs_open(BB_CACHE_NVS_NS, NVS_READONLY, &h);
   if (err != ESP_OK) return -1;

--- a/firmware/src/bb_ui_agent_chat.c
+++ b/firmware/src/bb_ui_agent_chat.c
@@ -2766,3 +2766,53 @@ esp_err_t bb_ui_agent_chat_resync_after_adapter_switch(const char* name) {
            s_chat.driver_name);
   return ESP_OK;
 }
+
+/* ── adapter_v2 P2: device-driven session select / create ──
+ *
+ * The device-side Sessions picker (bb_ui_settings) calls these to point the
+ * adapter (and thus voice, which always runs the adapter's DEFAULT session) at
+ * a specific conversation. The flow:
+ *   1. Fire the WS request → cloud relays pass-through → adapter respawns
+ *      (Resume(id) / New()) so voice now goes to that session.
+ *   2. Locally swap s_chat.session_id, clear the transcript cache, and (for a
+ *      switch) load + display that session's history.
+ *
+ * Both run under the LVGL lock (the caller — handle_click — already holds it).
+ * We must NOT write NVS here: handle_click runs on the stream_task PSRAM stack,
+ * where an NVS write panics (cache freeze). Persistence happens on the next
+ * SESSION frame (on_agent_event's bb_session_store_save path). */
+
+const char* bb_ui_agent_chat_get_current_session(void) {
+  return s_chat.session_id;
+}
+
+esp_err_t bb_ui_agent_chat_start_new_session(void) {
+  /* Tell the adapter to mint + activate a fresh session (New() = respawn). */
+  (void)bb_adapter_request_session_new();
+  /* Local: drop the current session id; the adapter mints the new id and the
+   * next turn's SESSION frame persists it. Clear the transcript cache via the
+   * shared UI-switch helper (apply_session_switch_ui rebinds the chat cache,
+   * which clears the ring). */
+  s_chat.session_id[0] = '\0';
+  history_state_reset();
+  apply_session_switch_ui("", NULL);
+  ESP_LOGI(TAG, "start_new_session: requested adapter.create, local transcript cleared");
+  return ESP_OK;
+}
+
+esp_err_t bb_ui_agent_chat_switch_session(const char* id, const char* title) {
+  if (id == NULL || id[0] == '\0') return ESP_ERR_INVALID_ARG;
+  /* Tell the adapter to Resume(id) → voice now routes to this session. */
+  (void)bb_adapter_request_session_activate(id);
+  /* Local: adopt the new session id, clear stale transcript, then load + show
+   * this session's history. apply_session_switch_ui rebinds the chat cache
+   * (clears the ring) for a clean swap. */
+  strncpy(s_chat.session_id, id, sizeof(s_chat.session_id) - 1);
+  s_chat.session_id[sizeof(s_chat.session_id) - 1] = '\0';
+  history_state_reset();
+  apply_session_switch_ui(id, title);
+  spawn_history_fetch_task(-1, /*is_initial=*/1);
+  ESP_LOGI(TAG, "switch_session: '%s' (title='%s') requested adapter.activate + history fetch",
+           id, title != NULL ? title : "");
+  return ESP_OK;
+}

--- a/firmware/src/bb_ui_settings.c
+++ b/firmware/src/bb_ui_settings.c
@@ -102,6 +102,7 @@ typedef enum {
   LEVEL_DRIVER_PICKER,
   LEVEL_MODEL_PICKER,
   LEVEL_ADAPTER_PICKER,
+  LEVEL_SESSION_PICKER,
   LEVEL_VOLUME_ADJUST,
 } settings_level_t;
 
@@ -113,6 +114,7 @@ typedef enum {
   MAIN_ROW_DRIVER = 0,
   MAIN_ROW_MODEL,
   MAIN_ROW_ADAPTER,
+  MAIN_ROW_SESSIONS,
   MAIN_ROW_VOLUME,
   MAIN_ROW_TTS,
   MAIN_ROW_BACK,
@@ -156,6 +158,13 @@ typedef struct {
   volatile uint32_t site_fetch_generation;
   char active_site_id[40]; /* optimistic active selection for snappy UI */
   int pending_chat_sync;   /* 1 = re-sync chat driver/session after site switch */
+
+  /* adapter_v2 P2: Sessions picker catalog. Populated async (HTTP list-sessions
+   * for the chat's current driver) when the Sessions picker is entered. */
+  bb_agent_session_info_t session_cache[16];
+  int session_cache_count;
+  volatile int session_fetch_pending;
+  volatile uint32_t session_fetch_generation;
 
   int tts_enabled;
 
@@ -314,6 +323,7 @@ static int main_visible_rows(main_row_t* out) {
    * chat re-sync) but is simply unreachable from the menu. */
   if (bb_transport_is_cloud_saas()) {
     out[n++] = MAIN_ROW_ADAPTER;
+    out[n++] = MAIN_ROW_SESSIONS;
   }
   out[n++] = MAIN_ROW_VOLUME;
   out[n++] = MAIN_ROW_TTS;
@@ -384,6 +394,11 @@ static void render_main(void) {
         break;
       case MAIN_ROW_ADAPTER:
         snprintf(buf, sizeof(buf), "Adapter: %s", current_site_label());
+        break;
+      case MAIN_ROW_SESSIONS:
+        /* Static label — the live list lives in the picker. CJK matches the
+         * chat labels (which already render CJK), so it's font-safe. */
+        snprintf(buf, sizeof(buf), "对话");
         break;
       case MAIN_ROW_VOLUME: {
         int pct = s_st.volume_pct;
@@ -487,6 +502,49 @@ static void render_adapter_picker(void) {
              is_active ? "  *" : "",
              s_st.site_cache[i].online ? "[on]" : "[offline]");
     lv_label_set_text(s_st.rows[i], buf);
+  }
+  highlight_selected();
+}
+
+/* ── Render: Sessions picker (adapter_v2 P2 — HTTP list-sessions, async) ──
+ *
+ * Row 0 is a synthetic "+ 新对话" (new conversation). Rows 1..N are the cached
+ * sessions; the one whose id matches the chat's current session is marked "*".
+ * Mirrors render_adapter_picker's loading/empty handling. */
+
+static void render_session_picker(void) {
+  if (s_st.root == NULL) return;
+  lv_label_set_text(s_st.header_lbl, "对话");
+
+  if (s_st.session_fetch_pending && s_st.session_cache_count == 0) {
+    /* Still loading the first page — show the New row + a Loading hint. */
+    build_rows_box(2);
+    lv_label_set_text(s_st.rows[0], "+ 新对话");
+    lv_label_set_text(s_st.rows[1], "Loading...");
+    highlight_selected();
+    return;
+  }
+
+  const char* cur = bb_ui_agent_chat_get_current_session();
+  int rows = s_st.session_cache_count + 1; /* +1 synthetic New row */
+  build_rows_box(rows);
+  lv_label_set_text(s_st.rows[0], "+ 新对话");
+  for (int i = 0; i < s_st.session_cache_count && s_st.rows[i + 1] != NULL; ++i) {
+    char buf[80];
+    const bb_agent_session_info_t* s = &s_st.session_cache[i];
+    char shortid[9];
+    const char* label;
+    if (s->title[0] != '\0') {
+      label = s->title;
+    } else {
+      /* No title — use the first 8 chars of the id. */
+      strncpy(shortid, s->id, sizeof(shortid) - 1);
+      shortid[sizeof(shortid) - 1] = '\0';
+      label = shortid;
+    }
+    int is_active = (cur != NULL && cur[0] != '\0' && strcmp(s->id, cur) == 0);
+    snprintf(buf, sizeof(buf), "%s%s", label, is_active ? "  *" : "");
+    lv_label_set_text(s_st.rows[i + 1], buf);
   }
   highlight_selected();
 }
@@ -625,6 +683,7 @@ static void rerender(void) {
     case LEVEL_DRIVER_PICKER:  render_driver_picker(); break;
     case LEVEL_MODEL_PICKER:   render_model_picker(); break;
     case LEVEL_ADAPTER_PICKER: render_adapter_picker(); break;
+    case LEVEL_SESSION_PICKER: render_session_picker(); break;
     case LEVEL_VOLUME_ADJUST:  render_volume_adjust(); break;
   }
 }
@@ -829,6 +888,95 @@ static void spawn_site_fetch_task(void) {
   if (ok != pdPASS) {
     ESP_LOGE(TAG, "spawn_site_fetch_task: xTaskCreateWithCaps failed");
     s_st.site_fetch_pending = 0;
+    free(r);
+  }
+}
+
+/* ── Session fetch (adapter_v2 P2 — HTTP list-sessions, async) ── */
+
+typedef struct {
+  uint32_t gen;
+  esp_err_t err;
+  int count;
+  bb_agent_session_info_t sessions[16];
+} session_fetch_result_t;
+
+static void on_session_fetch_done(void* user_data) {
+  session_fetch_result_t* r = (session_fetch_result_t*)user_data;
+  if (r == NULL) return;
+  s_st.session_fetch_pending = 0;
+  if (!s_st.active || r->gen != s_st.session_fetch_generation) {
+    free(r);
+    return;
+  }
+  if (r->err != ESP_OK || r->count <= 0) {
+    ESP_LOGW(TAG, "session fetch failed (%s) count=%d", esp_err_to_name(r->err), r->count);
+    s_st.session_cache_count = 0;
+  } else {
+    /* Cap to 15 so the synthetic "+ 新对话" row + sessions fit the 16-slot
+     * rows[] LVGL label array (rows[16] would be NULL → crash). */
+    int total = r->count > 15 ? 15 : r->count;
+    memcpy(s_st.session_cache, r->sessions, sizeof(r->sessions[0]) * (size_t)total);
+    s_st.session_cache_count = total;
+    ESP_LOGI(TAG, "session fetch ok: %d sessions (capped from %d)", total, r->count);
+  }
+  if (s_st.level == LEVEL_SESSION_PICKER) {
+    rerender();
+  }
+  free(r);
+}
+
+static void session_fetch_task(void* arg) {
+  session_fetch_result_t* r = (session_fetch_result_t*)arg;
+  if (r == NULL) {
+    s_st.session_fetch_pending = 0;
+    vTaskDeleteWithCaps(NULL); /* stack is PSRAM-allocated (xTaskCreateWithCaps) */
+    return;
+  }
+  r->err = bb_agent_list_sessions(bb_ui_agent_chat_get_current_driver(), r->sessions, 16, &r->count);
+  /* Hand the result back on the LVGL thread. Retry the lock a few times; if we
+   * still can't get it, clear the pending flag directly so the picker is never
+   * wedged on "Loading..." forever (a stuck pending flag would also block every
+   * future refresh — spawn early-returns while pending). */
+  int delivered = 0;
+  for (int attempt = 0; attempt < 3 && !delivered; ++attempt) {
+    if (lvgl_port_lock(200)) {
+      lv_async_call(on_session_fetch_done, r);
+      lvgl_port_unlock();
+      delivered = 1;
+    }
+  }
+  if (!delivered) {
+    ESP_LOGW(TAG, "session fetch: lvgl lock unavailable, clearing pending");
+    s_st.session_fetch_pending = 0;
+    free(r);
+  }
+  vTaskDeleteWithCaps(NULL);
+}
+
+static void spawn_session_fetch_task(void) {
+  if (!bb_transport_is_cloud_saas()) return;
+  if (s_st.session_fetch_pending) return;
+  s_st.session_fetch_pending = 1;
+  uint32_t gen = ++s_st.session_fetch_generation;
+
+  session_fetch_result_t* r = (session_fetch_result_t*)calloc(1, sizeof(*r));
+  if (r == NULL) {
+    ESP_LOGE(TAG, "spawn_session_fetch_task: calloc failed");
+    s_st.session_fetch_pending = 0;
+    return;
+  }
+  r->gen = gen;
+  TaskHandle_t t = NULL;
+  /* PSRAM stack — internal DRAM is too fragmented in Settings to spare 8KB,
+   * and list-sessions is network I/O only (HTTPS, no NVS) so PSRAM is safe. */
+  BaseType_t ok = xTaskCreateWithCaps(session_fetch_task, "sess_fetch",
+                                      BB_SETTINGS_FETCH_TASK_STACK, r,
+                                      BB_SETTINGS_FETCH_TASK_PRIO, &t,
+                                      BBCLAW_MALLOC_CAP_PREFER_PSRAM);
+  if (ok != pdPASS) {
+    ESP_LOGE(TAG, "spawn_session_fetch_task: xTaskCreateWithCaps failed");
+    s_st.session_fetch_pending = 0;
     free(r);
   }
 }
@@ -1121,6 +1269,16 @@ static void enter_adapter_picker(void) {
   rerender();
 }
 
+/* adapter_v2 P2: open the Sessions picker. Cursor lands on the synthetic New
+ * row; the list arrives async (HTTP list-sessions for the chat's current
+ * driver). */
+static void enter_session_picker(void) {
+  s_st.level = LEVEL_SESSION_PICKER;
+  s_st.sel = 0;
+  spawn_session_fetch_task();
+  rerender();
+}
+
 static void return_to_main(main_row_t row) {
   s_st.level = LEVEL_MAIN;
   s_st.sel = main_row_to_index(row);
@@ -1199,6 +1357,7 @@ void bb_ui_settings_hide(void) {
   s_st.active = 0;
   s_st.driver_fetch_generation++;
   s_st.site_fetch_generation++;
+  s_st.session_fetch_generation++;
   destroy_rows();
   if (s_st.root != NULL) {
     lv_obj_del(s_st.root);
@@ -1241,6 +1400,10 @@ void bb_ui_settings_handle_rotate(int delta) {
     case LEVEL_ADAPTER_PICKER:
       row_count = (s_st.site_cache_count > 0) ? s_st.site_cache_count : 1;
       break;
+    case LEVEL_SESSION_PICKER:
+      /* +1 for the synthetic "+ 新对话" row at index 0. */
+      row_count = s_st.session_cache_count + 1;
+      break;
     case LEVEL_MODEL_PICKER: {
       const bb_agent_driver_info_t* d = active_driver_entry();
       row_count = (d != NULL && d->model_count > 0) ? d->model_count : 1;
@@ -1280,6 +1443,9 @@ int bb_ui_settings_handle_click(void) {
         }
         case MAIN_ROW_ADAPTER:
           enter_adapter_picker();
+          break;
+        case MAIN_ROW_SESSIONS:
+          enter_session_picker();
           break;
         case MAIN_ROW_VOLUME:
           /* Enter volume adjust sub-level */
@@ -1351,6 +1517,29 @@ int bb_ui_settings_handle_click(void) {
       return_to_main(MAIN_ROW_ADAPTER);
       return 0;
 
+    case LEVEL_SESSION_PICKER: {
+      /* Row 0 = synthetic "+ 新对话"; rows 1..N = session_cache[sel-1].
+       * Both bb_ui_agent_chat_* do LVGL work; handle_click already runs under
+       * the LVGL context (other cases call rerender directly), so direct calls
+       * are fine. We return 1 so bb_radio_app tears down Settings → shows chat
+       * (the user just selected/created the conversation they want to be in). */
+      if (s_st.sel == 0) {
+        bb_ui_agent_chat_start_new_session();
+        ESP_LOGI(TAG, "session picker -> new chat");
+        return 1;
+      }
+      int idx = s_st.sel - 1;
+      if (idx >= 0 && idx < s_st.session_cache_count) {
+        bb_ui_agent_chat_switch_session(s_st.session_cache[idx].id,
+                                        s_st.session_cache[idx].title);
+        ESP_LOGI(TAG, "session picker -> '%s'", s_st.session_cache[idx].id);
+        return 1;
+      }
+      /* Out-of-range (e.g. list emptied under us) — just go back to main. */
+      return_to_main(MAIN_ROW_SESSIONS);
+      return 0;
+    }
+
     case LEVEL_MODEL_PICKER: {
       const bb_agent_driver_info_t* d = active_driver_entry();
       if (d == NULL || d->model_count <= 0) {
@@ -1406,6 +1595,9 @@ int bb_ui_settings_handle_back(void) {
       return 0;
     case LEVEL_ADAPTER_PICKER:
       return_to_main(MAIN_ROW_ADAPTER);
+      return 0;
+    case LEVEL_SESSION_PICKER:
+      return_to_main(MAIN_ROW_SESSIONS);
       return 0;
     case LEVEL_MODEL_PICKER:
       return_to_main(MAIN_ROW_MODEL);


### PR DESCRIPTION
设备端对话控制(adapter_v2 cloud_saas):设置页"对话"菜单——新建/列表/切换,且切换**真的移动 adapter 的语音会话**(不只本地显示),+ 按会话的 transcript 缓存隔离。

关键:adapter_v2 语音永走默认会话,所以设备切换**必须**让 adapter 重启那个会话。设备通过 cloud_saas WS 发 agent.sessions.activate{sessionId} / agent.sessions.create(云端透传 → adapter Resume/New,#236),语音随选择走。纯本地切换会显示对历史但语音仍发旧会话。

- **bb_adapter_client**:request_session_activate(id) + request_session_new()——克隆 turn.cancel 的 fire-and-forget WS 发送(PSRAM 栈 + WithCaps + inflight 守卫,仅 cloud_saas)。
- **bb_ui_settings**:LEVEL_SESSION_PICKER + MAIN_ROW_SESSIONS("对话")。克隆 Adapter picker:异步拉 bb_agent_list_sessions,渲染合成"+ 新对话"行 + 会话(标题/短 id,active *),nav,选中 return 1 落到 chat。列表上限 15(16 槽 rows[] 含 New 行)。
- **bb_ui_agent_chat**:get_current_session / start_new_session(发 create)/ switch_session(发 activate + 加历史)。**无直接 NVS 写**——持久化随下条 SESSION 帧(stream_task 在 PSRAM 栈,NVS 写会 panic)。apply_session_switch_ui 的 bind 清环(干净切)。
- **bb_chat_cache**:NVS key 带 sid("cc/<drv>/<6hex FNV>",≤15 字),同 driver 多会话不再互相覆盖。

**仅编译验证**(idf build 通过,8% free)——**未真机刷测**。adapter_v2/cloud 不动(handler 早已发)。待办 #3+#4。

🤖 Generated with [Claude Code](https://claude.com/claude-code)