### PR TITLE
feat(adapter_v2): web 配置页(ADR-025 web-first,env-overlay 移植)

### DIFF
--- a/adapter_v2/cmd/bbclaw-adapter-v2/main.go
+++ b/adapter_v2/cmd/bbclaw-adapter-v2/main.go
@@ -20,17 +20,20 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
 	"nhooyr.io/websocket"
 
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/adminapi"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/buildinfo"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/butler"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/cloudrelay"
@@ -38,6 +41,7 @@ import (
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/devicews"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/ptyhost"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/settingsstore"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/termchan"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/voicekit"
 	"github.com/daboluocc/bbclaw/adapter_v2/web"
@@ -53,6 +57,25 @@ func main() {
 		log.Println(buildinfo.String("bbclaw-adapter-v2"))
 		return
 	}
+
+	// Web-first config (ADR-025, env-overlay variant). This MUST run before the
+	// config/voicekit/cloudrelay readers below: it seeds settings.json from the
+	// environment on first boot, then exports the file's values back into the
+	// process env so the EXISTING FromEnv/LoadFromEnv/LoadConfig readers see the
+	// file-sourced configuration with ZERO changes to those packages.
+	seed := settingsstore.FromEnv()
+	settingsPath := filepath.Join(settingsstore.DataDir(), "settings.json")
+	if err := settingsstore.Bootstrap(settingsPath, seed); err != nil {
+		log.Printf("bbclaw-adapter-v2: settings bootstrap failed (continuing on env): %v", err)
+	}
+	store, err := settingsstore.Open(settingsPath, seed)
+	if err != nil {
+		// Corrupt/unreadable file: Open still returns a usable store holding the
+		// env-derived base, so we log and continue rather than blocking startup.
+		log.Printf("bbclaw-adapter-v2: settings load error (using env defaults): %v", err)
+	}
+	store.ExportEnv() // env now reflects settings.json; the readers below pick it up
+	restartFlag := &adminapi.RestartFlag{}
 
 	cfg := config.LoadFromEnv()
 	mgr := session.NewManager()
@@ -75,10 +98,25 @@ func main() {
 	devSess := butler.NewDeviceSession(mgr, baseArgv, defaultCwd)
 	log.Printf("bbclaw-adapter-v2: butler workspace %s (active session %q)", defaultCwd, devSess.ActiveID())
 
+	// derive supplies the read-only block the admin page shows (build version,
+	// resolved home_site_id, workspace, settings file). homeSiteId is resolved the
+	// same way cloudrelay does: the HOME_SITE_ID env (now reflecting settings.json)
+	// or the persisted identity.json — computed per-request so a just-saved id shows.
+	derive := func() adminapi.Derived {
+		return adminapi.Derived{
+			Version:      buildinfo.Tag,
+			HomeSiteID:   resolveHomeSiteID(),
+			Workspace:    defaultCwd,
+			SettingsFile: store.Path(),
+		}
+	}
+
 	srv := &http.Server{
 		Addr:    cfg.Addr,
-		Handler: newRouter(mgr, cfg, devSess),
+		Handler: newRouter(mgr, cfg, devSess, store, restartFlag, derive),
 	}
+	log.Printf("bbclaw-adapter-v2: settings file %s", store.Path())
+	log.Printf("bbclaw-adapter-v2: admin at http://127.0.0.1%s/admin", cfg.Addr)
 
 	// Cloud relay (SaaS): when CLOUD_WS_URL is set, register with the BBClaw Cloud
 	// as a HomeAdapter so the device can pick adapter_v2 in its sites.list and have
@@ -133,10 +171,17 @@ func main() {
 // newRouter builds the Phase 1 HTTP mux: the terminal WebSocket endpoint and a
 // health probe. It is a separate constructor so tests can exercise routing
 // without binding a real listener.
-func newRouter(mgr *session.Manager, cfg config.Config, devSess *butler.DeviceSession) http.Handler {
+func newRouter(mgr *session.Manager, cfg config.Config, devSess *butler.DeviceSession, store *settingsstore.Store, restart *adminapi.RestartFlag, derive func() adminapi.Derived) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", wsHandler(mgr, cfg, devSess))
 	mux.HandleFunc("/healthz", healthzHandler)
+
+	// Web-first config admin surface (ADR-025), loopback-only. Registered before
+	// the "/" catch-all so ServeMux's longest-prefix match routes these first.
+	mux.HandleFunc("/admin", adminapi.LocalOnly(web.AdminHandler().ServeHTTP))
+	mux.HandleFunc("/admin/", adminapi.LocalOnly(web.AdminHandler().ServeHTTP))
+	mux.HandleFunc("/v1/settings", adminapi.LocalOnly(adminapi.Settings(store, restart, derive)))
+	mux.HandleFunc("/v1/settings/restart", adminapi.LocalOnly(adminapi.Restart()))
 
 	// bbwire/2 device protocol, Phase A (adapter_v2/docs/device-protocol.md).
 	// ASR/TTS come from the shared voice module via voicekit.FromEnv (same env var
@@ -174,6 +219,34 @@ func envBool(name string, def bool) bool {
 	default:
 		return def
 	}
+}
+
+// resolveHomeSiteID reports the home_site_id the cloud relay would use, for the
+// admin page's read-only block: the HOME_SITE_ID env (which now reflects
+// settings.json after ExportEnv), else the UUID persisted in
+// ~/.bbclaw-adapter-v2/identity.json. It only READS — never creates the file
+// (cloudrelay owns that on first cloud connect), so a LAN-only adapter shows the
+// env value or "(none)" without minting an identity it never uses.
+func resolveHomeSiteID() string {
+	if id := strings.TrimSpace(os.Getenv("HOME_SITE_ID")); id != "" {
+		return id
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "(none)"
+	}
+	path := filepath.Join(home, ".bbclaw-adapter-v2", "identity.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "(none)"
+	}
+	var f struct {
+		HomeSiteID string `json:"homeSiteId"`
+	}
+	if json.Unmarshal(raw, &f) == nil && strings.TrimSpace(f.HomeSiteID) != "" {
+		return strings.TrimSpace(f.HomeSiteID)
+	}
+	return "(none)"
 }
 
 // healthzHandler is the liveness probe.

--- a/adapter_v2/cmd/bbclaw-adapter-v2/main_test.go
+++ b/adapter_v2/cmd/bbclaw-adapter-v2/main_test.go
@@ -12,10 +12,22 @@ import (
 
 	"nhooyr.io/websocket"
 
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/adminapi"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/butler"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/config"
 	"github.com/daboluocc/bbclaw/adapter_v2/internal/session"
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/settingsstore"
 )
+
+// testRouter builds the router with the web-first config plumbing wired to an
+// in-memory store (no settings.json on disk), so the existing routing tests are
+// unaffected by the admin surface added in ADR-025.
+func testRouter(mgr *session.Manager) http.Handler {
+	cfg := testConfig()
+	store, _ := settingsstore.Open("", settingsstore.Settings{})
+	derive := func() adminapi.Derived { return adminapi.Derived{} }
+	return newRouter(mgr, cfg, butler.NewDeviceSession(mgr, cfg.Argv, cfg.Cwd), store, &adminapi.RestartFlag{}, derive)
+}
 
 // testConfig launches a trivial long-running CLI under the PTY so a created
 // session stays alive for the duration of a test. `cat` echoes stdin to stdout
@@ -64,7 +76,7 @@ func readReconnected(t *testing.T, conn *websocket.Conn) {
 // TestHealthz verifies the liveness probe returns 200 "ok".
 func TestHealthz(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
+	srv := httptest.NewServer(testRouter(mgr))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/healthz")
@@ -88,7 +100,7 @@ func TestHealthz(t *testing.T) {
 // share one PTY.
 func TestWSNoSessionJoinsDefault(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
+	srv := httptest.NewServer(testRouter(mgr))
 	t.Cleanup(srv.Close)
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
 
@@ -116,7 +128,7 @@ func TestWSNoSessionJoinsDefault(t *testing.T) {
 // longer an error: it resolves to the shared default session.)
 func TestWSNonWebSocketRejected(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
+	srv := httptest.NewServer(testRouter(mgr))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/ws")
@@ -138,7 +150,7 @@ func TestWSNonWebSocketRejected(t *testing.T) {
 // the existing session rather than spawning a second process.
 func TestWSCreatesSessionOnce(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
+	srv := httptest.NewServer(testRouter(mgr))
 	t.Cleanup(srv.Close)
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
 
@@ -177,7 +189,7 @@ func TestWSCreatesSessionOnce(t *testing.T) {
 // not swallow stray requests as the index page.
 func TestRouterUnknownPath(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
+	srv := httptest.NewServer(testRouter(mgr))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/nope")
@@ -197,7 +209,7 @@ func TestRouterUnknownPath(t *testing.T) {
 // index.html can't silently drop the contract the server depends on.
 func TestWebClientServed(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
+	srv := httptest.NewServer(testRouter(mgr))
 	t.Cleanup(srv.Close)
 
 	resp, err := http.Get(srv.URL + "/")
@@ -246,7 +258,7 @@ func TestWebClientServed(t *testing.T) {
 // must dispatch those to their own handlers, not to the static index page.
 func TestSpecificRoutesWinOverWebRoot(t *testing.T) {
 	mgr := session.NewManager()
-	srv := httptest.NewServer(newRouter(mgr, testConfig(), butler.NewDeviceSession(mgr, testConfig().Argv, testConfig().Cwd)))
+	srv := httptest.NewServer(testRouter(mgr))
 	t.Cleanup(srv.Close)
 
 	tests := []struct {

--- a/adapter_v2/internal/adminapi/adminapi.go
+++ b/adapter_v2/internal/adminapi/adminapi.go
@@ -1,0 +1,182 @@
+// Package adminapi is adapter_v2's slim, loopback-only web admin/config surface
+// (ADR-025). It is self-contained: it depends only on the settingsstore package
+// (and the standard library) — nothing from v1.
+//
+// Endpoints (all loopback-gated by LocalOnly at the mux layer):
+//
+//	GET    /v1/settings          → the full settings doc + derived read-only block
+//	PUT    /v1/settings          ← a full Settings doc; persists + flags restart
+//	POST   /v1/settings/restart  → re-exec the process in place (apply changes)
+//
+// Secrets (API keys/tokens) are returned/accepted in PLAINTEXT on purpose: the
+// route is loopback-only and the persisted file is plaintext too (ADR-025).
+package adminapi
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/settingsstore"
+)
+
+// response is the uniform JSON envelope: {ok, data?, error?, detail?}.
+type response struct {
+	OK     bool   `json:"ok"`
+	Data   any    `json:"data,omitempty"`
+	Error  string `json:"error,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, body response) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// RestartFlag is a tiny shared latch: PUT sets it, GET reads it. It is an atomic
+// bool so the HTTP handlers (which run concurrently) can touch it safely without
+// the caller wiring a mutex. Construct one in main and pass it to the handlers.
+type RestartFlag struct{ v atomic.Bool }
+
+// Set marks that a settings change is pending and needs a restart to apply.
+func (r *RestartFlag) Set() { r.v.Store(true) }
+
+// Load reports whether a restart is pending.
+func (r *RestartFlag) Load() bool { return r.v.Load() }
+
+// Derived carries the read-only, system-generated values the page displays but
+// never lets the user edit (build version, resolved device identity, workspace,
+// settings file path).
+type Derived struct {
+	Version      string `json:"version"`
+	HomeSiteID   string `json:"homeSiteId"`
+	Workspace    string `json:"workspace"`
+	SettingsFile string `json:"settingsFile"`
+}
+
+// LocalOnly restricts a handler to loopback callers. The admin surface mutates
+// runtime config (including secrets) and can re-exec the process, so it must
+// never be reachable from the LAN or the cloud relay — even though the adapter
+// itself may bind 0.0.0.0 for device traffic. The gate is per-request on the
+// peer address. A malformed/non-IP peer is treated as non-loopback (fail-closed).
+func LocalOnly(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !isLoopbackAddr(r.RemoteAddr) {
+			writeJSON(w, http.StatusForbidden, response{
+				OK:     false,
+				Error:  "ADMIN_LOCAL_ONLY",
+				Detail: "admin endpoints are restricted to localhost",
+			})
+			return
+		}
+		next(w, r)
+	}
+}
+
+// isLoopbackAddr reports whether addr (host:port, as in http.Request.RemoteAddr)
+// is a loopback peer (127.0.0.0/8 or ::1). A malformed or non-IP address is
+// treated as non-loopback — fail closed. Ported from v1 (module-agnostic).
+func isLoopbackAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(strings.TrimSpace(addr))
+	if err != nil {
+		host = strings.TrimSpace(addr) // some transports omit the port
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// SettingsGet returns the full settings document plus the restart-pending flag
+// and the derived read-only block. derive is called per-request so the resolved
+// homeSiteId/version/workspace reflect the live process.
+//
+//	GET /v1/settings
+//	→ {"ok":true,"data":{"settings":{...},"restartRequired":bool,"derived":{...}}}
+func SettingsGet(store *settingsstore.Store, restart *RestartFlag, derive func() Derived) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, response{OK: true, Data: map[string]any{
+			"settings":        store.Snapshot(),
+			"restartRequired": restart.Load(),
+			"derived":         derive(),
+		}})
+	}
+}
+
+// SettingsPut persists a new settings document. The page sends the FULL doc; it
+// is decoded over the current snapshot so a partial body still merges cleanly.
+// On success the restart flag is set (the change applies on the next boot) and
+// the page is told to surface the restart banner.
+//
+//	PUT /v1/settings   body = settingsstore.Settings
+func SettingsPut(store *settingsstore.Store, restart *RestartFlag) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		next := store.Snapshot()
+		dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10))
+		if err := dec.Decode(&next); err != nil {
+			writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "INVALID_REQUEST", Detail: err.Error()})
+			return
+		}
+		if err := store.Replace(next); err != nil {
+			writeJSON(w, http.StatusBadRequest, response{OK: false, Error: "SETTINGS_WRITE_FAILED", Detail: err.Error()})
+			return
+		}
+		restart.Set()
+		writeJSON(w, http.StatusOK, response{OK: true, Data: map[string]any{"restartRequired": true}})
+	}
+}
+
+// Settings dispatches GET/PUT on /v1/settings to one handler so the route can be
+// registered once and still split on method (the v2 mux pattern is path-only).
+func Settings(store *settingsstore.Store, restart *RestartFlag, derive func() Derived) http.HandlerFunc {
+	get := SettingsGet(store, restart, derive)
+	put := SettingsPut(store, restart)
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			get(w, r)
+		case http.MethodPut:
+			put(w, r)
+		default:
+			w.Header().Set("Allow", "GET, PUT")
+			writeJSON(w, http.StatusMethodNotAllowed, response{OK: false, Error: "METHOD_NOT_ALLOWED"})
+		}
+	}
+}
+
+// Restart re-executes the adapter in place so a settings change takes effect. It
+// replies 200 first, flushes, then (after a short delay so the response reaches
+// the socket) syscall.Exec replaces the process image with a fresh copy that
+// re-reads settings.json on boot. Ported from v1's handleAdminRestart — it is
+// module-agnostic. The page also polls /healthz to know when to reload.
+//
+//	POST /v1/settings/restart
+func Restart() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", "POST")
+			writeJSON(w, http.StatusMethodNotAllowed, response{OK: false, Error: "METHOD_NOT_ALLOWED"})
+			return
+		}
+		exe, err := os.Executable()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, response{OK: false, Error: "RESTART_FAILED", Detail: err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, response{OK: true, Data: map[string]any{"restarting": true}})
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		go func() {
+			// Give the HTTP response time to reach the socket before we replace the
+			// process image. Best-effort; the page also polls /healthz to reconnect.
+			time.Sleep(300 * time.Millisecond)
+			argv := append([]string{exe}, os.Args[1:]...)
+			_ = syscall.Exec(exe, argv, os.Environ())
+		}()
+	}
+}

--- a/adapter_v2/internal/adminapi/adminapi_test.go
+++ b/adapter_v2/internal/adminapi/adminapi_test.go
@@ -1,0 +1,126 @@
+package adminapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/daboluocc/bbclaw/adapter_v2/internal/settingsstore"
+)
+
+func newStore(t *testing.T) *settingsstore.Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.json")
+	st, err := settingsstore.Open(path, settingsstore.Settings{})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	return st
+}
+
+// TestLocalOnlyRejectsRemote verifies a non-loopback peer is 403'd (fail-closed).
+func TestLocalOnlyRejectsRemote(t *testing.T) {
+	h := LocalOnly(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	for _, addr := range []string{"203.0.113.7:44321", "not-an-ip", ""} {
+		req := httptest.NewRequest(http.MethodGet, "/v1/settings", nil)
+		req.RemoteAddr = addr
+		rec := httptest.NewRecorder()
+		h(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("RemoteAddr %q: status = %d, want 403", addr, rec.Code)
+		}
+	}
+}
+
+// TestLocalOnlyAllowsLoopback verifies loopback peers (v4 + v6) pass through.
+func TestLocalOnlyAllowsLoopback(t *testing.T) {
+	h := LocalOnly(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	for _, addr := range []string{"127.0.0.1:5050", "[::1]:5050", "127.5.6.7:9"} {
+		req := httptest.NewRequest(http.MethodGet, "/v1/settings", nil)
+		req.RemoteAddr = addr
+		rec := httptest.NewRecorder()
+		h(rec, req)
+		if rec.Code != http.StatusTeapot {
+			t.Errorf("RemoteAddr %q: status = %d, want pass-through 418", addr, rec.Code)
+		}
+	}
+}
+
+// TestSettingsGetPut verifies GET returns the snapshot + derived, and PUT
+// persists and sets the restart flag.
+func TestSettingsGetPut(t *testing.T) {
+	store := newStore(t)
+	restart := &RestartFlag{}
+	derive := func() Derived {
+		return Derived{Version: "test", HomeSiteID: "uuid-123", Workspace: "/ws", SettingsFile: store.Path()}
+	}
+	h := Settings(store, restart, derive)
+
+	// GET initial.
+	{
+		req := httptest.NewRequest(http.MethodGet, "/v1/settings", nil)
+		rec := httptest.NewRecorder()
+		h(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET status = %d", rec.Code)
+		}
+		var resp struct {
+			OK   bool `json:"ok"`
+			Data struct {
+				RestartRequired bool    `json:"restartRequired"`
+				Derived         Derived `json:"derived"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode GET: %v", err)
+		}
+		if !resp.OK || resp.Data.RestartRequired {
+			t.Fatalf("unexpected GET body: ok=%v restart=%v", resp.OK, resp.Data.RestartRequired)
+		}
+		if resp.Data.Derived.HomeSiteID != "uuid-123" {
+			t.Fatalf("derived homeSiteId = %q", resp.Data.Derived.HomeSiteID)
+		}
+	}
+
+	// PUT a new doc.
+	body := `{"voice":{"asr":{"provider":"doubao_native","apiKey":"k"}},"device":{"streamDelta":false}}`
+	{
+		req := httptest.NewRequest(http.MethodPut, "/v1/settings", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		h(rec, req)
+		if rec.Code != http.StatusOK {
+			b, _ := io.ReadAll(rec.Body)
+			t.Fatalf("PUT status = %d body=%s", rec.Code, b)
+		}
+	}
+	if !restart.Load() {
+		t.Fatalf("restart flag not set after PUT")
+	}
+	got := store.Snapshot()
+	if got.Voice.ASR.Provider != "doubao_native" || got.Voice.ASR.APIKey != "k" {
+		t.Fatalf("PUT did not persist: %+v", got.Voice.ASR)
+	}
+	if got.Device.StreamDelta {
+		t.Fatalf("PUT did not persist streamDelta=false")
+	}
+}
+
+// TestSettingsPutBadBody verifies a malformed body 400s.
+func TestSettingsPutBadBody(t *testing.T) {
+	store := newStore(t)
+	h := SettingsPut(store, &RestartFlag{})
+	req := httptest.NewRequest(http.MethodPut, "/v1/settings", strings.NewReader("{not json"))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad body status = %d, want 400", rec.Code)
+	}
+}

--- a/adapter_v2/internal/settingsstore/settingsstore.go
+++ b/adapter_v2/internal/settingsstore/settingsstore.go
@@ -1,0 +1,385 @@
+// Package settingsstore is adapter_v2's web-mutable runtime configuration store
+// (ADR-025 "web-first config", env-overlay variant). It is fully self-contained:
+// it imports nothing from the rest of adapter_v2 and nothing from v1.
+//
+// The design keeps voicekit/cloudrelay/butler/config UNCHANGED. They each read
+// their settings from os.Getenv at boot (FromEnv / LoadFromEnv / LoadConfig).
+// This store sits in front of them:
+//
+//  1. FromEnv() takes a snapshot of the SAME env vars the readers use — the seed.
+//  2. Bootstrap() writes that seed to settings.json on first boot only.
+//  3. Open() loads settings.json OVER the seed (file keys win, absent keep seed).
+//  4. ExportEnv() pushes every value back into os.Setenv BEFORE the existing
+//     readers run, so they transparently see the file-sourced configuration.
+//
+// The file is plaintext (it holds secrets such as API keys/tokens): it is the
+// loopback-only admin surface that mutates it, mirroring v1's choice. The file
+// is mode 0600 inside a 0700 dir.
+package settingsstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// currentVersion stamps the schema so a future migration can detect old files.
+const currentVersion = 1
+
+// Settings is the full web-editable configuration document, grouped to mirror
+// the admin page's sections. Every string field is serialized WITHOUT omitempty
+// so an explicitly-cleared field round-trips as "" (and ExportEnv can decide,
+// per leaf, whether an empty value should shadow the environment). Bools always
+// serialize (Go's default), so a page-set false persists and overrides a code
+// default of true.
+type Settings struct {
+	Version int            `json:"version"`
+	Voice   VoiceSettings  `json:"voice"`
+	Device  DeviceSettings `json:"device"`
+	CLI     CLISettings    `json:"cli"`
+	Cloud   CloudSettings  `json:"cloud"`
+}
+
+// VoiceSettings groups the ASR and TTS provider configuration. The env-var names
+// mirror the ones voicekit.FromEnv reads (ASR_* / TTS_*).
+type VoiceSettings struct {
+	ASR ASRSettings `json:"asr"`
+	TTS TTSSettings `json:"tts"`
+}
+
+// ASRSettings mirrors voicekit's ASR_* reads (see internal/voicekit/voicekit.go).
+type ASRSettings struct {
+	Provider      string `json:"provider"`      // ASR_PROVIDER
+	Hotwords      string `json:"hotwords"`      // ASR_HOTWORDS
+	BaseURL       string `json:"baseUrl"`       // ASR_BASE_URL
+	APIKey        string `json:"apiKey"`        // ASR_API_KEY
+	Model         string `json:"model"`         // ASR_MODEL
+	AppID         string `json:"appId"`         // ASR_APP_ID
+	ResourceID    string `json:"resourceId"`    // ASR_RESOURCE_ID
+	Language      string `json:"language"`      // ASR_LANGUAGE
+	LocalBin      string `json:"localBin"`      // ASR_LOCAL_BIN
+	LocalArgs     string `json:"localArgs"`     // ASR_LOCAL_ARGS
+	LocalTextPath string `json:"localTextPath"` // ASR_LOCAL_TEXT_PATH
+}
+
+// TTSSettings mirrors voicekit's TTS_* reads (see internal/voicekit/voicekit.go).
+type TTSSettings struct {
+	Provider          string `json:"provider"`          // TTS_PROVIDER
+	BaseURL           string `json:"baseUrl"`           // TTS_BASE_URL
+	AppID             string `json:"appId"`             // TTS_APP_ID
+	Token             string `json:"token"`             // TTS_TOKEN
+	Cluster           string `json:"cluster"`           // TTS_CLUSTER
+	Voice             string `json:"voice"`             // TTS_VOICE
+	LocalBin          string `json:"localBin"`          // TTS_LOCAL_BIN
+	LocalArgs         string `json:"localArgs"`         // TTS_LOCAL_ARGS
+	LocalOutputFormat string `json:"localOutputFormat"` // TTS_LOCAL_OUTPUT_FORMAT
+}
+
+// DeviceSettings groups the bbwire/2 device-line streaming knobs (main.go).
+type DeviceSettings struct {
+	StreamDelta bool `json:"streamDelta"` // ADAPTER_V2_STREAM_DELTA (default true)
+	SegmentTTS  bool `json:"segmentTts"`  // ADAPTER_V2_SEGMENT_TTS (default false)
+}
+
+// CLISettings groups the PTY/CLI and butler knobs (config.go + butler).
+type CLISettings struct {
+	Cli               string `json:"cli"`               // ADAPTER_V2_CLI (space-split argv; default "claude")
+	Cwd               string `json:"cwd"`               // ADAPTER_V2_CWD
+	SkipPermissions   bool   `json:"skipPermissions"`   // ADAPTER_V2_SKIP_PERMISSIONS (default true)
+	VoiceSystemPrompt string `json:"voiceSystemPrompt"` // ADAPTER_V2_VOICE_SYSTEM_PROMPT
+	Addr              string `json:"addr"`              // ADAPTER_V2_ADDR (default ":18090")
+}
+
+// CloudSettings groups the cloud-relay knobs (cloudrelay.go).
+type CloudSettings struct {
+	WsURL      string `json:"wsUrl"`      // CLOUD_WS_URL
+	AuthToken  string `json:"authToken"`  // CLOUD_AUTH_TOKEN
+	HomeSiteID string `json:"homeSiteId"` // HOME_SITE_ID (blank ⇒ persisted identity.json wins)
+}
+
+// envBool parses a boolean env var with the same 1/true/yes/on truthiness the
+// rest of adapter_v2 uses (config/main/butler all share this), returning def
+// when unset or unrecognised.
+func envBool(name string, def bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	}
+	return def
+}
+
+// envOr returns the trimmed env var value, or def when unset/blank.
+func envOr(name, def string) string {
+	if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+		return v
+	}
+	return def
+}
+
+// FromEnv reads the SAME env vars the rest of adapter_v2 reads, producing the
+// seed/base snapshot. Defaults match the code defaults exactly so a zero-config
+// boot persists what the readers would have computed anyway.
+func FromEnv() Settings {
+	return Settings{
+		Version: currentVersion,
+		Voice: VoiceSettings{
+			ASR: ASRSettings{
+				Provider:      strings.TrimSpace(os.Getenv("ASR_PROVIDER")),
+				Hotwords:      strings.TrimSpace(os.Getenv("ASR_HOTWORDS")),
+				BaseURL:       strings.TrimSpace(os.Getenv("ASR_BASE_URL")),
+				APIKey:        strings.TrimSpace(os.Getenv("ASR_API_KEY")),
+				Model:         strings.TrimSpace(os.Getenv("ASR_MODEL")),
+				AppID:         strings.TrimSpace(os.Getenv("ASR_APP_ID")),
+				ResourceID:    strings.TrimSpace(os.Getenv("ASR_RESOURCE_ID")),
+				Language:      envOr("ASR_LANGUAGE", "zh-CN"),
+				LocalBin:      strings.TrimSpace(os.Getenv("ASR_LOCAL_BIN")),
+				LocalArgs:     strings.TrimSpace(os.Getenv("ASR_LOCAL_ARGS")),
+				LocalTextPath: strings.TrimSpace(os.Getenv("ASR_LOCAL_TEXT_PATH")),
+			},
+			TTS: TTSSettings{
+				Provider:          strings.TrimSpace(os.Getenv("TTS_PROVIDER")),
+				BaseURL:           strings.TrimSpace(os.Getenv("TTS_BASE_URL")),
+				AppID:             strings.TrimSpace(os.Getenv("TTS_APP_ID")),
+				Token:             strings.TrimSpace(os.Getenv("TTS_TOKEN")),
+				Cluster:           strings.TrimSpace(os.Getenv("TTS_CLUSTER")),
+				Voice:             strings.TrimSpace(os.Getenv("TTS_VOICE")),
+				LocalBin:          strings.TrimSpace(os.Getenv("TTS_LOCAL_BIN")),
+				LocalArgs:         strings.TrimSpace(os.Getenv("TTS_LOCAL_ARGS")),
+				LocalOutputFormat: envOr("TTS_LOCAL_OUTPUT_FORMAT", "wav"),
+			},
+		},
+		Device: DeviceSettings{
+			StreamDelta: envBool("ADAPTER_V2_STREAM_DELTA", true),
+			SegmentTTS:  envBool("ADAPTER_V2_SEGMENT_TTS", false),
+		},
+		CLI: CLISettings{
+			Cli:               envOr("ADAPTER_V2_CLI", "claude"),
+			Cwd:               strings.TrimSpace(os.Getenv("ADAPTER_V2_CWD")),
+			SkipPermissions:   envBool("ADAPTER_V2_SKIP_PERMISSIONS", true),
+			VoiceSystemPrompt: os.Getenv("ADAPTER_V2_VOICE_SYSTEM_PROMPT"), // may be set-empty on purpose
+			Addr:              envOr("ADAPTER_V2_ADDR", ":18090"),
+		},
+		Cloud: CloudSettings{
+			WsURL:      strings.TrimSpace(os.Getenv("CLOUD_WS_URL")),
+			AuthToken:  strings.TrimSpace(os.Getenv("CLOUD_AUTH_TOKEN")),
+			HomeSiteID: strings.TrimSpace(os.Getenv("HOME_SITE_ID")),
+		},
+	}
+}
+
+// DataDir returns the directory holding settings.json: ~/.bbclaw-adapter-v2
+// (the same v2-specific dir cloudrelay uses for identity.json), overridable with
+// BBCLAW_ADAPTER_V2_DATA_DIR for tests/relocation.
+func DataDir() string {
+	if d := strings.TrimSpace(os.Getenv("BBCLAW_ADAPTER_V2_DATA_DIR")); d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Degrade to the current dir rather than failing startup; settings persist
+		// somewhere writable and the rest of the boot continues on env defaults.
+		return ".bbclaw-adapter-v2"
+	}
+	return filepath.Join(home, ".bbclaw-adapter-v2")
+}
+
+// writeAtomic writes data to path via a temp file + rename so a crash mid-write
+// never leaves a half-written (corrupt) settings.json. The dir is created 0700
+// and the file 0600 because it holds plaintext secrets.
+func writeAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create settings dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".settings-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp settings: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if anything below fails before the rename.
+	defer func() { _ = os.Remove(tmpName) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp settings: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp settings: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp settings: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename settings: %w", err)
+	}
+	return nil
+}
+
+func marshal(s Settings) ([]byte, error) {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+// Bootstrap writes seed to path on first boot only. If the file already exists it
+// is a no-op (the persisted file is the source of truth from then on). Idempotent.
+func Bootstrap(path string, seed Settings) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil // already initialised; leave the operator's file untouched
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat settings: %w", err)
+	}
+	if seed.Version == 0 {
+		seed.Version = currentVersion
+	}
+	data, err := marshal(seed)
+	if err != nil {
+		return fmt.Errorf("marshal seed: %w", err)
+	}
+	return writeAtomic(path, data)
+}
+
+// Store holds the live settings document behind an RWMutex.
+type Store struct {
+	mu   sync.RWMutex
+	path string
+	s    Settings
+}
+
+// Open loads the settings file at path OVER base: keys present in the file
+// override base, absent keys keep base. A missing file yields a Store holding
+// base. A CORRUPT file returns the parse error BUT also a usable Store holding
+// base — settings must never block startup.
+func Open(path string, base Settings) (*Store, error) {
+	st := &Store{path: path, s: base}
+	if st.s.Version == 0 {
+		st.s.Version = currentVersion
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return st, nil // first boot before Bootstrap, or no file: base is fine
+		}
+		return st, fmt.Errorf("read settings: %w", err) // usable Store + error
+	}
+	// Unmarshal OVER base: json.Unmarshal only sets the keys present in the file,
+	// so absent keys keep their base value and present keys (incl. explicit "") win.
+	merged := base
+	if err := json.Unmarshal(raw, &merged); err != nil {
+		// Corrupt file: keep base (already in st.s), surface the error so the caller
+		// can log it, but return a usable Store so the boot continues.
+		return st, fmt.Errorf("parse settings: %w", err)
+	}
+	if merged.Version == 0 {
+		merged.Version = currentVersion
+	}
+	st.s = merged
+	return st, nil
+}
+
+// Path returns the settings file path this store reads/writes.
+func (s *Store) Path() string { return s.path }
+
+// Snapshot returns a copy of the current settings under a read lock. Settings is
+// a value type with no reference fields, so the returned copy is independent.
+func (s *Store) Snapshot() Settings {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.s
+}
+
+// Replace atomically persists next (temp + rename) and updates the in-memory
+// copy under a write lock. The file write happens while holding the lock so a
+// concurrent Snapshot never observes a state that did not reach disk.
+func (s *Store) Replace(next Settings) error {
+	if next.Version == 0 {
+		next.Version = currentVersion
+	}
+	data, err := marshal(next)
+	if err != nil {
+		return fmt.Errorf("marshal settings: %w", err)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := writeAtomic(s.path, data); err != nil {
+		return err
+	}
+	s.s = next
+	return nil
+}
+
+// ExportEnv pushes the current settings into the process environment so the
+// existing FromEnv/LoadFromEnv/LoadConfig readers transparently see file-sourced
+// values. It MUST run before those readers.
+//
+// Rules (load-bearing):
+//   - Every bool leaf is ALWAYS exported as "1"/"0" — a page-set false must
+//     override a code default of true, so we can never skip a bool.
+//   - A NON-EMPTY string leaf is exported as-is.
+//   - An EMPTY string leaf is SKIPPED (os.Setenv is NOT called): a blank
+//     HOME_SITE_ID must not shadow the persisted identity.json UUID, and a blank
+//     field must not clobber a value the operator exported in the shell.
+//   - CLI.Cli is exported verbatim to ADAPTER_V2_CLI (main splits it on spaces).
+func (s *Store) ExportEnv() {
+	snap := s.Snapshot()
+
+	setStr := func(name, val string) {
+		if strings.TrimSpace(val) == "" {
+			return // skip empty: don't shadow identity.json / shell-exported values
+		}
+		_ = os.Setenv(name, val)
+	}
+	setBool := func(name string, val bool) {
+		if val {
+			_ = os.Setenv(name, "1")
+		} else {
+			_ = os.Setenv(name, "0")
+		}
+	}
+
+	a := snap.Voice.ASR
+	setStr("ASR_PROVIDER", a.Provider)
+	setStr("ASR_HOTWORDS", a.Hotwords)
+	setStr("ASR_BASE_URL", a.BaseURL)
+	setStr("ASR_API_KEY", a.APIKey)
+	setStr("ASR_MODEL", a.Model)
+	setStr("ASR_APP_ID", a.AppID)
+	setStr("ASR_RESOURCE_ID", a.ResourceID)
+	setStr("ASR_LANGUAGE", a.Language)
+	setStr("ASR_LOCAL_BIN", a.LocalBin)
+	setStr("ASR_LOCAL_ARGS", a.LocalArgs)
+	setStr("ASR_LOCAL_TEXT_PATH", a.LocalTextPath)
+
+	t := snap.Voice.TTS
+	setStr("TTS_PROVIDER", t.Provider)
+	setStr("TTS_BASE_URL", t.BaseURL)
+	setStr("TTS_APP_ID", t.AppID)
+	setStr("TTS_TOKEN", t.Token)
+	setStr("TTS_CLUSTER", t.Cluster)
+	setStr("TTS_VOICE", t.Voice)
+	setStr("TTS_LOCAL_BIN", t.LocalBin)
+	setStr("TTS_LOCAL_ARGS", t.LocalArgs)
+	setStr("TTS_LOCAL_OUTPUT_FORMAT", t.LocalOutputFormat)
+
+	setBool("ADAPTER_V2_STREAM_DELTA", snap.Device.StreamDelta)
+	setBool("ADAPTER_V2_SEGMENT_TTS", snap.Device.SegmentTTS)
+
+	c := snap.CLI
+	setStr("ADAPTER_V2_CLI", c.Cli) // verbatim; main splits on spaces
+	setStr("ADAPTER_V2_CWD", c.Cwd)
+	setBool("ADAPTER_V2_SKIP_PERMISSIONS", c.SkipPermissions)
+	setStr("ADAPTER_V2_VOICE_SYSTEM_PROMPT", c.VoiceSystemPrompt)
+	setStr("ADAPTER_V2_ADDR", c.Addr)
+
+	cl := snap.Cloud
+	setStr("CLOUD_WS_URL", cl.WsURL)
+	setStr("CLOUD_AUTH_TOKEN", cl.AuthToken)
+	setStr("HOME_SITE_ID", cl.HomeSiteID) // blank skipped ⇒ identity.json UUID wins
+}

--- a/adapter_v2/internal/settingsstore/settingsstore_test.go
+++ b/adapter_v2/internal/settingsstore/settingsstore_test.go
@@ -1,0 +1,273 @@
+package settingsstore
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// settingsPath returns a settings.json path inside a fresh temp HOME, with the
+// data-dir override cleared so DataDir() resolves under that HOME.
+func settingsPath(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("BBCLAW_ADAPTER_V2_DATA_DIR", "")
+	return filepath.Join(DataDir(), "settings.json")
+}
+
+// TestBootstrapWritesOnce verifies Bootstrap creates the file on first boot and
+// is a no-op (does not overwrite) if the file already exists.
+func TestBootstrapWritesOnce(t *testing.T) {
+	path := settingsPath(t)
+
+	seed := Settings{}
+	seed.Voice.ASR.Provider = "doubao_native"
+	if err := Bootstrap(path, seed); err != nil {
+		t.Fatalf("first Bootstrap: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("settings file missing after Bootstrap: %v", err)
+	}
+	// File must be 0600 (plaintext secrets).
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("settings perm = %o, want 600", perm)
+	}
+
+	// A second Bootstrap with a DIFFERENT seed must NOT overwrite the file.
+	other := Settings{}
+	other.Voice.ASR.Provider = "openai_compatible"
+	if err := Bootstrap(path, other); err != nil {
+		t.Fatalf("second Bootstrap: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	var got Settings
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal persisted: %v", err)
+	}
+	if got.Voice.ASR.Provider != "doubao_native" {
+		t.Fatalf("Bootstrap overwrote existing file: provider=%q, want doubao_native", got.Voice.ASR.Provider)
+	}
+	if got.Version != currentVersion {
+		t.Fatalf("seed version = %d, want %d", got.Version, currentVersion)
+	}
+}
+
+// TestOpenOverlaysFileOverBase verifies the file overlays base: present keys
+// (including an explicit empty) win, absent keys keep base.
+func TestOpenOverlaysFileOverBase(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	base := Settings{Version: currentVersion}
+	base.Voice.ASR.Provider = "BASE_PROVIDER"
+	base.Voice.ASR.Language = "BASE_LANG" // absent from file ⇒ kept
+	base.Voice.TTS.Voice = "BASE_VOICE"
+	base.Device.StreamDelta = true
+	base.CLI.Cli = "claude"
+
+	// File sets provider to a new value, clears the TTS voice explicitly (""),
+	// flips StreamDelta to false, and omits language entirely.
+	fileDoc := `{
+	  "voice": {
+	    "asr": {"provider": "FILE_PROVIDER"},
+	    "tts": {"voice": ""}
+	  },
+	  "device": {"streamDelta": false}
+	}`
+	if err := os.WriteFile(path, []byte(fileDoc), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	st, err := Open(path, base)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	got := st.Snapshot()
+
+	if got.Voice.ASR.Provider != "FILE_PROVIDER" {
+		t.Errorf("present key not applied: provider=%q, want FILE_PROVIDER", got.Voice.ASR.Provider)
+	}
+	if got.Voice.ASR.Language != "BASE_LANG" {
+		t.Errorf("absent key not kept from base: language=%q, want BASE_LANG", got.Voice.ASR.Language)
+	}
+	if got.Voice.TTS.Voice != "" {
+		t.Errorf("present-empty key did not override base: voice=%q, want empty", got.Voice.TTS.Voice)
+	}
+	if got.Device.StreamDelta != false {
+		t.Errorf("present false bool did not override base true: streamDelta=%v, want false", got.Device.StreamDelta)
+	}
+	if got.CLI.Cli != "claude" {
+		t.Errorf("absent CLI key not kept: cli=%q, want claude", got.CLI.Cli)
+	}
+}
+
+// TestOpenMissingFileKeepsBase verifies a missing file yields a usable Store
+// holding base with no error.
+func TestOpenMissingFileKeepsBase(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.json")
+
+	base := Settings{Version: currentVersion}
+	base.Cloud.WsURL = "wss://example/ws"
+	st, err := Open(path, base)
+	if err != nil {
+		t.Fatalf("Open missing file should not error: %v", err)
+	}
+	if got := st.Snapshot(); got.Cloud.WsURL != "wss://example/ws" {
+		t.Fatalf("base not retained: wsUrl=%q", got.Cloud.WsURL)
+	}
+}
+
+// TestOpenCorruptFileReturnsErrorButUsableStore verifies a corrupt file returns
+// the parse error AND a usable Store holding base (never blocks startup).
+func TestOpenCorruptFileReturnsErrorButUsableStore(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+
+	base := Settings{Version: currentVersion}
+	base.CLI.Addr = ":18090"
+	st, err := Open(path, base)
+	if err == nil {
+		t.Fatalf("Open corrupt file should return an error")
+	}
+	if st == nil {
+		t.Fatalf("Open corrupt file must still return a usable Store")
+	}
+	if got := st.Snapshot(); got.CLI.Addr != ":18090" {
+		t.Fatalf("corrupt-file Store should hold base: addr=%q", got.CLI.Addr)
+	}
+}
+
+// TestExportEnv verifies non-empty strings + both bools are exported, empty
+// strings are skipped (so a blank HOME_SITE_ID stays unset).
+func TestExportEnv(t *testing.T) {
+	// Pre-set the env vars we expect to be either overwritten or left alone.
+	t.Setenv("ASR_PROVIDER", "stale")
+	t.Setenv("HOME_SITE_ID", "")
+	if err := os.Unsetenv("HOME_SITE_ID"); err != nil {
+		t.Fatalf("unset HOME_SITE_ID: %v", err)
+	}
+	t.Setenv("ADAPTER_V2_STREAM_DELTA", "1")
+	t.Setenv("ADAPTER_V2_SKIP_PERMISSIONS", "1")
+
+	s := Settings{Version: currentVersion}
+	s.Voice.ASR.Provider = "doubao_native"
+	s.Voice.ASR.APIKey = "sekret"
+	s.Voice.ASR.Language = "" // empty ⇒ must NOT be exported
+	s.Device.StreamDelta = false
+	s.Device.SegmentTTS = true
+	s.CLI.SkipPermissions = false
+	s.Cloud.HomeSiteID = "" // empty ⇒ must NOT shadow identity.json
+
+	st := &Store{path: filepath.Join(t.TempDir(), "s.json"), s: s}
+	st.ExportEnv()
+
+	if got := os.Getenv("ASR_PROVIDER"); got != "doubao_native" {
+		t.Errorf("ASR_PROVIDER = %q, want doubao_native", got)
+	}
+	if got := os.Getenv("ASR_API_KEY"); got != "sekret" {
+		t.Errorf("ASR_API_KEY = %q, want sekret", got)
+	}
+	if _, ok := os.LookupEnv("ASR_LANGUAGE"); ok {
+		t.Errorf("empty ASR_LANGUAGE should not be exported, but it is set")
+	}
+	if _, ok := os.LookupEnv("HOME_SITE_ID"); ok {
+		t.Errorf("empty HOME_SITE_ID must stay unset (identity.json wins), but it is set")
+	}
+	// Both bools always exported, including page-set false overriding env "1".
+	if got := os.Getenv("ADAPTER_V2_STREAM_DELTA"); got != "0" {
+		t.Errorf("ADAPTER_V2_STREAM_DELTA = %q, want 0 (false must override env)", got)
+	}
+	if got := os.Getenv("ADAPTER_V2_SEGMENT_TTS"); got != "1" {
+		t.Errorf("ADAPTER_V2_SEGMENT_TTS = %q, want 1", got)
+	}
+	if got := os.Getenv("ADAPTER_V2_SKIP_PERMISSIONS"); got != "0" {
+		t.Errorf("ADAPTER_V2_SKIP_PERMISSIONS = %q, want 0 (false must override env)", got)
+	}
+}
+
+// TestReplaceRoundTrips verifies Replace persists to disk and updates memory,
+// and that a fresh Open reads back the replaced document.
+func TestReplaceRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	base := Settings{Version: currentVersion}
+	st, err := Open(path, base)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	next := base
+	next.Voice.TTS.Provider = "doubao_native"
+	next.Voice.TTS.Token = "tok"
+	next.Cloud.WsURL = "wss://cloud/ws"
+	next.Device.SegmentTTS = true
+	if err := st.Replace(next); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+
+	// In-memory updated.
+	if got := st.Snapshot(); got.Voice.TTS.Token != "tok" || !got.Device.SegmentTTS {
+		t.Fatalf("in-memory not updated after Replace: %+v", got.Voice.TTS)
+	}
+	// Persisted: a fresh Open over empty base reads the replaced doc.
+	st2, err := Open(path, Settings{})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	got := st2.Snapshot()
+	if got.Voice.TTS.Provider != "doubao_native" || got.Cloud.WsURL != "wss://cloud/ws" {
+		t.Fatalf("Replace did not round-trip on disk: %+v", got)
+	}
+	// File still 0600 after the atomic rewrite.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after replace: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("settings perm after Replace = %o, want 600", perm)
+	}
+}
+
+// TestFromEnvDefaults verifies the documented defaults are applied when the env
+// is empty, and the bool truthiness matches the rest of v2.
+func TestFromEnvDefaults(t *testing.T) {
+	for _, k := range []string{
+		"ASR_PROVIDER", "ASR_LANGUAGE", "TTS_LOCAL_OUTPUT_FORMAT",
+		"ADAPTER_V2_CLI", "ADAPTER_V2_ADDR", "ADAPTER_V2_STREAM_DELTA",
+		"ADAPTER_V2_SEGMENT_TTS", "ADAPTER_V2_SKIP_PERMISSIONS", "HOME_SITE_ID",
+	} {
+		if err := os.Unsetenv(k); err != nil {
+			t.Fatalf("unset %s: %v", k, err)
+		}
+	}
+	s := FromEnv()
+	if s.Voice.ASR.Language != "zh-CN" {
+		t.Errorf("ASR language default = %q, want zh-CN", s.Voice.ASR.Language)
+	}
+	if s.Voice.TTS.LocalOutputFormat != "wav" {
+		t.Errorf("TTS local output format default = %q, want wav", s.Voice.TTS.LocalOutputFormat)
+	}
+	if s.CLI.Cli != "claude" {
+		t.Errorf("CLI default = %q, want claude", s.CLI.Cli)
+	}
+	if s.CLI.Addr != ":18090" {
+		t.Errorf("Addr default = %q, want :18090", s.CLI.Addr)
+	}
+	if !s.Device.StreamDelta {
+		t.Errorf("StreamDelta default = false, want true")
+	}
+	if s.Device.SegmentTTS {
+		t.Errorf("SegmentTTS default = true, want false")
+	}
+	if !s.CLI.SkipPermissions {
+		t.Errorf("SkipPermissions default = false, want true")
+	}
+}

--- a/adapter_v2/web/admin.html
+++ b/adapter_v2/web/admin.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>bbclaw adapter v2 · 配置</title>
+  <!--
+    Slim, loopback-only web admin/config page for adapter_v2 (ADR-025 "web-first
+    config", env-overlay variant). ONE static HTML file: inline <style> + vanilla
+    JS, NO Vue/Vite/build step — it embeds cleanly alongside index.html so
+    `go build` stays toolchain-free.
+
+    On load: GET /v1/settings → render the grouped form from the JSON.
+    Save:    PUT /v1/settings with the WHOLE doc → show the restart banner.
+    Restart: POST /v1/settings/restart → poll /healthz until 200 → reload.
+  -->
+  <style>
+    /* dot-matrix / Nothing-style tokens (design/UI_DESIGN_LANGUAGE.md) */
+    :root{
+      --bg:#070b0e; --lit:#dfeaec; --ghost:#152128; --dim:#6e8a93;
+      --accent:#2ec4a0; --ok:#4cd964; --err:#e66f6f; --pitch:9px;
+    }
+    *{box-sizing:border-box}
+    html,body{margin:0;min-height:100vh}
+    body{
+      font:13px/1.55 ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+      color:var(--lit); background:var(--bg);
+      background-image:radial-gradient(var(--ghost) 1px, transparent 1px);
+      background-size:var(--pitch) var(--pitch);
+    }
+    a{color:var(--accent)}
+    .hdr{padding:16px 22px;border-bottom:1px solid var(--ghost);display:flex;align-items:baseline;gap:14px;
+      background:rgba(7,11,14,.85);backdrop-filter:blur(2px);position:sticky;top:0;z-index:3;flex-wrap:wrap}
+    .wordmark{font-weight:700;font-size:15px;letter-spacing:.42em;color:var(--lit);
+      border-bottom:2px dotted var(--accent);padding-bottom:3px}
+    .hdr .sub{font-size:11px;color:var(--dim);letter-spacing:.12em;text-transform:uppercase}
+    .hdr .actions{margin-left:auto;display:flex;gap:8px;align-items:center}
+    main{max-width:980px;margin:0 auto;padding:22px}
+    @media (max-width:720px){ .hdr{padding:14px;gap:10px} .hdr .sub{display:none} main{padding:14px} }
+
+    .card{background:rgba(13,18,22,.78);border:1px solid var(--ghost);border-radius:10px;padding:16px 18px;margin-bottom:18px}
+    .card h2{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--dim);margin:0 0 14px;display:flex;align-items:center}
+    .card h2::before{content:"";width:5px;height:5px;border-radius:50%;background:var(--accent);
+      box-shadow:9px 0 0 var(--ghost),18px 0 0 var(--ghost);margin-right:18px;display:inline-block}
+
+    .form{display:grid;gap:13px;grid-template-columns:repeat(2,minmax(0,1fr))}
+    .form.one{grid-template-columns:1fr}
+    @media (max-width:560px){ .form{grid-template-columns:1fr} }
+    .field{display:grid;gap:5px;min-width:0}
+    .field.wide{grid-column:1 / -1}
+    .field>label{font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--dim)}
+    .field input[type=text],.field input[type=password],.field select,.field textarea{
+      font:inherit;background:#05090c;color:var(--lit);border:1px solid var(--ghost);border-radius:7px;
+      padding:8px 10px;width:100%;min-width:0}
+    .field textarea{resize:vertical;min-height:64px}
+    .field input:focus,.field select:focus,.field textarea:focus{outline:none;border-color:var(--accent)}
+    .field .hint{font-size:10px;color:var(--dim)}
+    .switch{display:flex;align-items:center;gap:9px;cursor:pointer;user-select:none}
+    .switch input{accent-color:var(--accent);width:15px;height:15px}
+    .switch span{font-size:12px;color:var(--lit)}
+
+    .status-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:10px}
+    .status-grid .item{border:1px solid var(--ghost);border-radius:7px;padding:9px 11px;background:rgba(7,11,14,.5)}
+    .status-grid .k{font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--dim);margin-bottom:3px}
+    .status-grid .v{font-size:12px;color:var(--lit);word-break:break-all}
+
+    button{font:inherit;cursor:pointer;border-radius:7px;padding:8px 16px;border:1px solid var(--accent);
+      background:var(--accent);color:#04110f;font-weight:600;letter-spacing:.03em}
+    button:disabled{opacity:.45;cursor:default}
+    button.ghost{background:transparent;color:var(--dim);border-color:var(--ghost)}
+    button.ghost:hover:not(:disabled){color:var(--lit);border-color:var(--dim)}
+
+    .banner{position:sticky;bottom:0;z-index:4;margin:0 -22px -22px;padding:14px 22px;
+      border-top:1px solid var(--ghost);background:rgba(7,11,14,.94);backdrop-filter:blur(3px);
+      display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+    .banner .msg{flex:1;min-width:200px;font-size:12px;color:var(--lit)}
+    .banner.hide{display:none}
+    .toast{position:fixed;left:50%;bottom:84px;transform:translateX(-50%);z-index:9;
+      background:#05090c;border:1px solid var(--ghost);border-radius:8px;padding:9px 16px;font-size:12px;
+      color:var(--lit);box-shadow:0 6px 24px rgba(0,0,0,.5);opacity:0;transition:opacity .2s;pointer-events:none}
+    .toast.show{opacity:1}
+    .toast.ok{border-color:#1f4d47;color:var(--ok)}
+    .toast.err{border-color:#3a2422;color:var(--err)}
+    .loading,.error{padding:40px 0;text-align:center;color:var(--dim)}
+    .error{color:var(--err)}
+  </style>
+</head>
+<body>
+  <header class="hdr">
+    <span class="wordmark">BBCLAW</span>
+    <span class="sub">adapter v2 · config</span>
+    <div class="actions">
+      <button id="save" class="" disabled>保存</button>
+    </div>
+  </header>
+
+  <main>
+    <div id="root"><div class="loading">加载配置中…</div></div>
+  </main>
+
+  <div id="banner" class="banner hide">
+    <span class="msg">配置已保存。需要重启适配器使其生效。</span>
+    <button id="restart">重启并应用</button>
+  </div>
+  <div id="toast" class="toast"></div>
+
+  <script>
+  (function () {
+    "use strict";
+    const $ = (id) => document.getElementById(id);
+    let current = null;     // last-loaded full Settings doc
+    let restartPending = false;
+
+    function toast(msg, kind) {
+      const t = $("toast");
+      t.textContent = msg;
+      t.className = "toast show" + (kind ? " " + kind : "");
+      setTimeout(() => { t.className = "toast"; }, 2600);
+    }
+
+    function esc(s) { return String(s == null ? "" : s); }
+
+    // Build one text/password input field.
+    function inputField(label, path, value, opts) {
+      opts = opts || {};
+      const type = opts.password ? "password" : "text";
+      const wide = opts.wide ? " wide" : "";
+      const hint = opts.hint ? `<div class="hint">${esc(opts.hint)}</div>` : "";
+      const ph = opts.placeholder ? ` placeholder="${esc(opts.placeholder)}"` : "";
+      return `<div class="field${wide}">
+        <label>${esc(label)}</label>
+        <input type="${type}" data-path="${path}" value="${esc(value).replace(/"/g, "&quot;")}"${ph} autocomplete="off" spellcheck="false" />
+        ${hint}</div>`;
+    }
+
+    function areaField(label, path, value, hint) {
+      return `<div class="field wide">
+        <label>${esc(label)}</label>
+        <textarea data-path="${path}" spellcheck="false">${esc(value)}</textarea>
+        ${hint ? `<div class="hint">${esc(hint)}</div>` : ""}</div>`;
+    }
+
+    function boolField(label, path, value) {
+      return `<div class="field"><label class="switch">
+        <input type="checkbox" data-path="${path}" data-bool="1" ${value ? "checked" : ""} />
+        <span>${esc(label)}</span></label></div>`;
+    }
+
+    function card(title, bodyHTML, oneCol) {
+      return `<section class="card"><h2>${esc(title)}</h2>
+        <div class="form${oneCol ? " one" : ""}">${bodyHTML}</div></section>`;
+    }
+
+    function render(data) {
+      const s = data.settings || {};
+      const v = s.voice || {}, asr = v.asr || {}, tts = v.tts || {};
+      const dev = s.device || {}, cli = s.cli || {}, cloud = s.cloud || {};
+      const d = data.derived || {};
+
+      const derivedCard = `<section class="card"><h2>状态 / 只读</h2>
+        <div class="status-grid">
+          <div class="item"><div class="k">version</div><div class="v">${esc(d.version)}</div></div>
+          <div class="item"><div class="k">home site id</div><div class="v">${esc(d.homeSiteId)}</div></div>
+          <div class="item"><div class="k">workspace</div><div class="v">${esc(d.workspace)}</div></div>
+          <div class="item"><div class="k">settings file</div><div class="v">${esc(d.settingsFile)}</div></div>
+        </div></section>`;
+
+      const asrCard = card("语音 · ASR (识别)",
+        inputField("ASR_PROVIDER", "voice.asr.provider", asr.provider, {hint:"local / openai_compatible / doubao_native （留空用内置模拟）"}) +
+        inputField("ASR_LANGUAGE", "voice.asr.language", asr.language) +
+        inputField("ASR_BASE_URL", "voice.asr.baseUrl", asr.baseUrl) +
+        inputField("ASR_API_KEY", "voice.asr.apiKey", asr.apiKey, {password:true}) +
+        inputField("ASR_MODEL", "voice.asr.model", asr.model) +
+        inputField("ASR_APP_ID", "voice.asr.appId", asr.appId) +
+        inputField("ASR_RESOURCE_ID", "voice.asr.resourceId", asr.resourceId) +
+        inputField("ASR_HOTWORDS", "voice.asr.hotwords", asr.hotwords, {hint:"逗号/空格分隔"}) +
+        inputField("ASR_LOCAL_BIN", "voice.asr.localBin", asr.localBin) +
+        inputField("ASR_LOCAL_ARGS", "voice.asr.localArgs", asr.localArgs) +
+        inputField("ASR_LOCAL_TEXT_PATH", "voice.asr.localTextPath", asr.localTextPath, {wide:true})
+      );
+
+      const ttsCard = card("语音 · TTS (合成)",
+        inputField("TTS_PROVIDER", "voice.tts.provider", tts.provider, {hint:"local / doubao_native （留空用内置 say/silent）"}) +
+        inputField("TTS_VOICE", "voice.tts.voice", tts.voice) +
+        inputField("TTS_BASE_URL", "voice.tts.baseUrl", tts.baseUrl) +
+        inputField("TTS_APP_ID", "voice.tts.appId", tts.appId) +
+        inputField("TTS_TOKEN", "voice.tts.token", tts.token, {password:true}) +
+        inputField("TTS_CLUSTER", "voice.tts.cluster", tts.cluster) +
+        inputField("TTS_LOCAL_BIN", "voice.tts.localBin", tts.localBin) +
+        inputField("TTS_LOCAL_ARGS", "voice.tts.localArgs", tts.localArgs) +
+        inputField("TTS_LOCAL_OUTPUT_FORMAT", "voice.tts.localOutputFormat", tts.localOutputFormat)
+      );
+
+      const deviceCard = card("设备线 (bbwire/2)",
+        boolField("流式回复增量 (STREAM_DELTA)", "device.streamDelta", dev.streamDelta) +
+        boolField("分段 TTS (SEGMENT_TTS)", "device.segmentTts", dev.segmentTts)
+      );
+
+      const cliCard = card("CLI / 管家",
+        inputField("ADAPTER_V2_CLI", "cli.cli", cli.cli, {hint:"空格分隔 argv，如 claude"}) +
+        inputField("ADAPTER_V2_ADDR", "cli.addr", cli.addr, {hint:"监听地址，如 :18090"}) +
+        inputField("ADAPTER_V2_CWD", "cli.cwd", cli.cwd, {wide:true, hint:"留空则用共享 butler workspace"}) +
+        boolField("跳过权限确认 (SKIP_PERMISSIONS)", "cli.skipPermissions", cli.skipPermissions) +
+        areaField("ADAPTER_V2_VOICE_SYSTEM_PROMPT", "cli.voiceSystemPrompt", cli.voiceSystemPrompt, "覆盖设备人设；留空用默认人设")
+      );
+
+      const cloudCard = card("云 (Cloud Relay)",
+        inputField("CLOUD_WS_URL", "cloud.wsUrl", cloud.wsUrl, {wide:true, hint:"留空则不连云，仅 LAN"}) +
+        inputField("CLOUD_AUTH_TOKEN", "cloud.authToken", cloud.authToken, {password:true}) +
+        inputField("HOME_SITE_ID", "cloud.homeSiteId", cloud.homeSiteId, {hint:"留空用持久化身份 identity.json"})
+      );
+
+      $("root").innerHTML = derivedCard + asrCard + ttsCard + deviceCard + cliCard + cloudCard;
+      $("save").disabled = false;
+    }
+
+    // Set a nested value on an object by a dot path, creating objects as needed.
+    function setPath(obj, path, value) {
+      const parts = path.split(".");
+      let o = obj;
+      for (let i = 0; i < parts.length - 1; i++) {
+        if (o[parts[i]] == null || typeof o[parts[i]] !== "object") o[parts[i]] = {};
+        o = o[parts[i]];
+      }
+      o[parts[parts.length - 1]] = value;
+    }
+
+    // Collect the WHOLE doc: start from the last-loaded settings (preserves keys
+    // like version) and overlay every field's current value.
+    function collect() {
+      const doc = JSON.parse(JSON.stringify(current.settings || {}));
+      document.querySelectorAll("[data-path]").forEach((el) => {
+        const path = el.getAttribute("data-path");
+        const value = el.getAttribute("data-bool") ? !!el.checked : el.value;
+        setPath(doc, path, value);
+      });
+      return doc;
+    }
+
+    async function load() {
+      try {
+        const r = await fetch("/v1/settings", {headers: {Accept: "application/json"}});
+        const j = await r.json();
+        if (!r.ok || !j.ok) throw new Error((j && j.detail) || ("HTTP " + r.status));
+        current = j.data;
+        restartPending = !!j.data.restartRequired;
+        render(j.data);
+        if (restartPending) showBanner();
+      } catch (e) {
+        $("root").innerHTML = `<div class="error">加载配置失败：${esc(e.message)}</div>`;
+      }
+    }
+
+    function showBanner() { $("banner").classList.remove("hide"); }
+
+    async function save() {
+      const doc = collect();
+      $("save").disabled = true;
+      try {
+        const r = await fetch("/v1/settings", {
+          method: "PUT",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify(doc),
+        });
+        const j = await r.json();
+        if (!r.ok || !j.ok) throw new Error((j && j.detail) || ("HTTP " + r.status));
+        current.settings = doc;
+        restartPending = true;
+        toast("已保存", "ok");
+        showBanner();
+      } catch (e) {
+        toast("保存失败：" + e.message, "err");
+      } finally {
+        $("save").disabled = false;
+      }
+    }
+
+    async function pollHealth(then) {
+      // After re-exec the port is briefly down; poll until /healthz answers 200.
+      for (let i = 0; i < 60; i++) {
+        try {
+          const r = await fetch("/healthz", {cache: "no-store"});
+          if (r.ok) { then(); return; }
+        } catch (e) { /* server still restarting */ }
+        await new Promise((res) => setTimeout(res, 500));
+      }
+      toast("重启超时，请手动刷新", "err");
+    }
+
+    async function restart() {
+      $("restart").disabled = true;
+      $("restart").textContent = "重启中…";
+      try {
+        await fetch("/v1/settings/restart", {method: "POST"});
+      } catch (e) { /* the connection drops as the process re-execs — expected */ }
+      // Give the old process a moment to exec, then poll the new one.
+      setTimeout(() => pollHealth(() => location.reload()), 800);
+    }
+
+    $("save").addEventListener("click", save);
+    $("restart").addEventListener("click", restart);
+    load();
+  })();
+  </script>
+</body>
+</html>

--- a/adapter_v2/web/web.go
+++ b/adapter_v2/web/web.go
@@ -14,11 +14,11 @@ import (
 	"net/http"
 )
 
-// staticFS holds the embedded static client tree (currently just index.html).
+// staticFS holds the embedded static client tree (index.html + admin.html).
 // The embed pattern is relative to this file, so the assets live alongside it
 // under adapter_v2/web/.
 //
-//go:embed index.html
+//go:embed index.html admin.html
 var staticFS embed.FS
 
 // Handler returns an http.Handler that serves the embedded web client. Mount it
@@ -39,4 +39,21 @@ func Handler() http.Handler {
 		panic("web: sub embedded FS: " + err.Error())
 	}
 	return http.FileServer(http.FS(sub))
+}
+
+// AdminHandler returns an http.Handler that serves the embedded admin/config
+// page (admin.html) for /admin and /admin/. Unlike the static file server it
+// serves the single page regardless of the trailing slash and sends
+// Cache-Control: no-store so a settings change is never masked by a cached page.
+// The admin route is loopback-gated by the caller (see adminapi.LocalOnly).
+func AdminHandler() http.Handler {
+	page, err := staticFS.ReadFile("admin.html")
+	if err != nil {
+		panic("web: read embedded admin.html: " + err.Error())
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		_, _ = w.Write(page)
+	})
 }


### PR DESCRIPTION
adapter_v2 原来只能改 .env。本改动加了自包含 web 配置页(v1 对等,精简版),且**不动任何现有 config 读取**。

**做法——env 覆盖**:settings store 首启用 env 种 settings.json,之后每次启动把值 os.Setenv 回去,**在现有 voicekit.FromEnv/cloudrelay.LoadConfig/config.LoadFromEnv 之前** → 这些包零改动,env 现在来自文件。

- **settingsstore**:Settings(分组:语音 ASR/TTS、设备线、CLI/管家、云)+ FromEnv 种子 + Bootstrap(只写一次)+ Open(文件覆盖 base;损坏→用 base 不阻塞启动)+ Snapshot/Replace(原子 tmp+rename,0700/0600)+ ExportEnv(空串跳过 → 空 HOME_SITE_ID/CLOUD_WS_URL 回落 identity.json/禁用;bool 永设 1/0 → 页面设 false 能覆盖 true 默认)。文件在 ~/.bbclaw-adapter-v2/settings.json。
- **adminapi**:LocalOnly loopback 闸(fail-closed)包住每个 admin 路由;SettingsGet/Put(整文档)+ Restart(syscall.Exec)+ RestartFlag。
- **web**:嵌入 admin.html(单文件 dot-matrix teal,纯 JS,无构建)+ AdminHandler;路由 /admin、/v1/settings、/v1/settings/restart(全 loopback)注册在 \"/\" 终端 catch-all 之前。
- **main.go**:load-bearing 顺序——FromEnv→Bootstrap→Open→ExportEnv 在读取之前;日志打 settings 文件 + admin url。

全在 adapter_v2(独立 module,无 v1 import)。**不刷机、云端零改**。实测:/admin 200、GET /v1/settings 返回 schema+derived、settings.json 0600 种好。build+test+vet+gofmt 绿。ADR-025。

🤖 Generated with [Claude Code](https://claude.com/claude-code)