### PR TITLE
fix(adapter_v2): 会话列表/active 选取跳过 v1 pool noop 探针

### DIFF
--- a/adapter_v2/internal/butler/session.go
+++ b/adapter_v2/internal/butler/session.go
@@ -276,29 +276,43 @@ func listConversations(cwd string) ([]ConversationInfo, error) {
 			continue
 		}
 		id := strings.TrimSuffix(name, ".jsonl")
+		// Skip the v1 claude-code pool's warm-up probe conversations. v1 and v2
+		// SHARE this workspace (#231), so the pool's noop ("respond with the single
+		// word: ready", adapter/internal/agent/claudecode/pool.go) litters the dir
+		// with thousands of throwaway .jsonl — they are NOT real sessions, and the
+		// most-recent one would otherwise be picked as the active conversation,
+		// shadowing the user's real butler memory.
+		first := firstUserText(filepath.Join(dir, name))
+		if strings.HasPrefix(strings.TrimSpace(first), v1PoolNoopProbe) {
+			continue
+		}
 		info, err := e.Info()
 		var mod int64
 		if err == nil {
 			mod = info.ModTime().Unix()
 		}
-		out = append(out, ConversationInfo{
-			ID:         id,
-			Title:      conversationTitle(filepath.Join(dir, name), id),
-			ModUnixSec: mod,
-		})
+		title := truncateTitle(first)
+		if title == "" {
+			title = shortID(id)
+		}
+		out = append(out, ConversationInfo{ID: id, Title: title, ModUnixSec: mod})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ModUnixSec > out[j].ModUnixSec })
 	return out, nil
 }
 
-// conversationTitle reads the first user message from a conversation .jsonl as a
-// human label, falling back to the id. claude writes one JSON object per line;
-// a user turn is {"type":"user","message":{"role":"user","content":...}} where
-// content is a string or an array of {type:"text",text:...} blocks.
-func conversationTitle(path, id string) string {
+// v1PoolNoopProbe is v1's claude-code pool warm-up prompt; conversations that start
+// with it are throwaway health probes, not real sessions (see listConversations).
+const v1PoolNoopProbe = "respond with the single word: ready"
+
+// firstUserText returns the first user message of a conversation .jsonl (full, not
+// truncated), or "" if none. claude writes one JSON object per line; a user turn is
+// {"type":"user","message":{"role":"user","content":...}} where content is a string
+// or an array of {type:"text",text:...} blocks.
+func firstUserText(path string) string {
 	f, err := os.Open(path)
 	if err != nil {
-		return shortID(id)
+		return ""
 	}
 	defer f.Close()
 	sc := bufio.NewScanner(f)
@@ -318,10 +332,10 @@ func conversationTitle(path, id string) string {
 			continue
 		}
 		if t := firstText(rec.Message.Content); t != "" {
-			return truncateTitle(t)
+			return t
 		}
 	}
-	return shortID(id)
+	return ""
 }
 
 // firstText extracts text from a claude content field (string, or []{type,text}).

--- a/adapter_v2/internal/butler/session_test.go
+++ b/adapter_v2/internal/butler/session_test.go
@@ -130,6 +130,37 @@ func TestPageMessages(t *testing.T) {
 	}
 }
 
+func TestListSkipsV1PoolNoopProbes(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := "/Users/x/.bbclaw-adapter/workspace"
+	dir := claudeProjectDir(cwd)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	noop := `{"type":"user","message":{"role":"user","content":"respond with the single word: ready"}}` + "\n" +
+		`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"ready"}]}}` + "\n"
+	real := `{"type":"user","message":{"role":"user","content":"记住我叫周老板,我做硬件"}}` + "\n"
+	for _, n := range []string{"noop-aaaa", "noop-bbbb", "noop-cccc"} {
+		if err := os.WriteFile(filepath.Join(dir, n+".jsonl"), []byte(noop), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "real-1.jsonl"), []byte(real), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewDeviceSession(session.NewManager(), []string{"claude"}, cwd)
+	list, _ := d.List()
+	if len(list) != 1 || list[0].ID != "real-1" {
+		t.Fatalf("List must drop v1 pool noop probes, keep only the real conversation; got %+v", list)
+	}
+	// The active-pick must land on the real conversation, not a noop probe.
+	if d.ActiveID() != "real-1" {
+		t.Errorf("active session should be the real conversation, got %q", d.ActiveID())
+	}
+}
+
 func TestDeviceSessionList(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
web 会话列表出现约 1300 个全是 \"respond with the single word: ready\" 的垃圾会话。根因:v1 claude-code pool 的预热探针(就是那句,adapter/internal/agent/claudecode/pool.go)在**共享 workspace**(#231)里跑 claude,每次探针都留一个一次性 .jsonl。listConversations 把它们全枚举了。

更糟:NewDeviceSession 取**最近**的 .jsonl 当 active 会话——而最近的总是新探针——所以 adapter 一直把 v1 垃圾当会话 resume,盖住了用户真实的管家记忆对话。

listConversations 现在跳过首条用户消息是 v1 pool noop 探针的会话(conversationTitle 重构为 firstUserText,检查+标题共用一次读取)。结果:列表只显示真实会话,active 落到真实对话(或新建)。

(主机侧一次性清理另做:把约 1303 个历史 noop .jsonl 移出 workspace + 清掉指向它的 active 指针,adapter 现在 resume 真实对话。)

测试:noop+真实混合 workspace → List 只返回真实、ActiveID 是真实。butler 套件绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)